### PR TITLE
Add Thread Export Feature to Dashboard

### DIFF
--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -1,7 +1,8 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, Response
 from flask_login import login_required, current_user
 from backend.models import Node, NodeVersion
 from backend.extensions import db
+from datetime import datetime
 
 export_bp = Blueprint("export_bp", __name__)
 
@@ -42,7 +43,143 @@ def export_data():
         })
     return jsonify(user_data), 200
 
-# Delete all of the current user’s data from our app.
+def format_node_tree(node, prefix="", index_path="1", is_last=True, processed_nodes=None):
+    """
+    Recursively format a node and its descendants into a human-readable tree structure.
+
+    Args:
+        node: The Node object to format
+        prefix: The indentation prefix for the current node
+        index_path: The hierarchical index (e.g., "1.1.2")
+        is_last: Whether this is the last child of its parent
+        processed_nodes: Set of node IDs already processed (to avoid infinite loops)
+
+    Returns:
+        str: Formatted text representation of the node tree
+    """
+    if processed_nodes is None:
+        processed_nodes = set()
+
+    # Avoid infinite loops from circular references
+    if node.id in processed_nodes:
+        return ""
+    processed_nodes.add(node.id)
+
+    # Format the node header
+    author = node.user.username if node.user else "Unknown"
+    node_type_display = "AI" if node.node_type == "llm" else "User"
+    if node.node_type == "llm" and node.llm_model:
+        node_type_display = f"AI ({node.llm_model})"
+
+    timestamp = node.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    # Build the node text
+    indent = "  " * (len(index_path.split('.')) - 1)
+    separator = "─" * 79
+
+    result = f"{indent}[{index_path}] {node_type_display} ({author}) - {timestamp}\n"
+    result += f"{indent}{separator}\n"
+
+    # Add the content with proper indentation
+    content_lines = node.content.split('\n')
+    for line in content_lines:
+        result += f"{indent}{line}\n"
+    result += "\n"
+
+    # Process children
+    children = sorted(node.children, key=lambda c: c.created_at)
+    for i, child in enumerate(children):
+        is_last_child = (i == len(children) - 1)
+        child_index = f"{index_path}.{i+1}"
+
+        # Mark branches (when there are multiple children)
+        if len(children) > 1 and i > 0:
+            result += f"{indent}  *** BRANCH ***\n\n"
+
+        result += format_node_tree(
+            child,
+            prefix=prefix,
+            index_path=child_index,
+            is_last=is_last_child,
+            processed_nodes=processed_nodes
+        )
+
+    return result
+
+@export_bp.route("/export/threads", methods=["GET"])
+@login_required
+def export_threads():
+    """
+    Export all threads originated by the current user in a human-readable text format.
+
+    This includes:
+    - All top-level nodes created by the user
+    - All descendants of those nodes (including AI replies)
+    - Properly formatted with hierarchical structure showing branches
+    """
+    # Get all top-level nodes (threads) created by the user
+    top_level_nodes = Node.query.filter_by(
+        user_id=current_user.id,
+        parent_id=None
+    ).order_by(Node.created_at).all()
+
+    if not top_level_nodes:
+        return Response(
+            "No threads found to export.",
+            mimetype="text/plain",
+            headers={
+                "Content-Disposition": f'attachment; filename="write-or-perish-export-{datetime.utcnow().strftime("%Y%m%d-%H%M%S")}.txt"'
+            }
+        )
+
+    # Build the export content
+    export_lines = []
+    export_lines.append("=" * 80)
+    export_lines.append("Write or Perish - Thread Export")
+    export_lines.append(f"User: {current_user.username}")
+    export_lines.append(f"Export Date: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    export_lines.append(f"Total Threads: {len(top_level_nodes)}")
+    export_lines.append("=" * 80)
+    export_lines.append("")
+
+    # Process each thread
+    for thread_num, node in enumerate(top_level_nodes, 1):
+        # Thread header
+        preview = node.content[:60].replace('\n', ' ')
+        if len(node.content) > 60:
+            preview += "..."
+
+        export_lines.append("")
+        export_lines.append("=" * 80)
+        export_lines.append(f"THREAD {thread_num}: \"{preview}\"")
+        export_lines.append(f"Started: {node.created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+        export_lines.append("=" * 80)
+        export_lines.append("")
+
+        # Format the entire thread tree
+        thread_text = format_node_tree(node, index_path=str(thread_num))
+        export_lines.append(thread_text)
+
+        export_lines.append("")
+
+    # Add footer
+    export_lines.append("=" * 80)
+    export_lines.append("End of Export")
+    export_lines.append("=" * 80)
+
+    export_content = "\n".join(export_lines)
+
+    # Return as downloadable text file
+    filename = f"write-or-perish-export-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.txt"
+    return Response(
+        export_content,
+        mimetype="text/plain",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"'
+        }
+    )
+
+# Delete all of the current user's data from our app.
 @export_bp.route("/delete_my_data", methods=["DELETE"])
 @login_required
 def delete_my_data():


### PR DESCRIPTION
## Summary
- Added a new "Export Data" button to the Dashboard that allows users to export all their threads in a human-readable text format
- The export includes all top-level nodes originated by the user and all descendants (including AI replies from the LLM)
- Data is formatted hierarchically with clear numbering (1, 1.1, 1.1.2, etc.) to show thread structure and branches
- Export file is downloaded as a .txt file with timestamp in filename

## Backend Changes
- Created new endpoint `GET /api/export/threads` in `backend/routes/export_data.py`
- Implemented `format_node_tree()` function to recursively format threads with hierarchical numbering
- Branches are clearly marked with "*** BRANCH ***" indicators
- Export includes metadata: username, export date, and thread count
- Handles edge case when user has no threads to export

## Frontend Changes
- Added "Export Data" button next to "Edit Profile" button on Dashboard (`frontend/src/components/Dashboard.js`)
- Button styled with green background (#2a5f2a) for visual distinction
- Implemented `handleExportData()` function using Blob API to trigger file download
- Extracts filename from Content-Disposition header or generates default
- Error handling for failed export requests

## Data Format
The export format is designed to be:
- **Human-readable**: Clear headers, separators, and indentation
- **Hierarchical**: Numbered indexing shows thread structure (1 → 1.1 → 1.1.1)
- **Branch-aware**: Multiple replies are marked as branches without duplicating ancestors
- **Comprehensive**: Includes author, timestamp, node type, and full content
- **Metadata-rich**: Export includes user info, date, and thread count

Example format:
```
================================================================================
Write or Perish - Thread Export
User: username
Export Date: 2025-11-16 12:34:56 UTC
Total Threads: 3
================================================================================

================================================================================
THREAD 1: "First 60 characters of content..."
Started: 2025-11-16 10:00:00 UTC
================================================================================

[1] User (username) - 2025-11-16 10:00:00 UTC
───────────────────────────────────────────────────────────────────────────────
This is the root content of the thread.

  [1.1] AI (claude-sonnet-4) - 2025-11-16 10:01:30 UTC
  ─────────────────────────────────────────────────────────────────────────────
  This is the AI's response to the root node.

    [1.1.1] User (username) - 2025-11-16 10:05:00 UTC
    ───────────────────────────────────────────────────────────────────────────
    User's follow-up question.

    *** BRANCH ***

    [1.1.2] BRANCH: User (username) - 2025-11-16 10:06:00 UTC
    ───────────────────────────────────────────────────────────────────────────
    Alternative response branching from the same AI reply.
```

## Test Plan
- [ ] User can click "Export Data" button on their own dashboard
- [ ] Export button is not shown on other users' public dashboards
- [ ] Clicking the button triggers a file download
- [ ] Downloaded file has proper filename with timestamp
- [ ] File contains all user-originated threads with complete conversation trees
- [ ] File format is human-readable and properly formatted
- [ ] Branches are clearly marked
- [ ] AI replies are included under user's threads
- [ ] Error message is shown if export fails
- [ ] Works correctly when user has no threads (shows appropriate message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)