### PR TITLE
Fix voice transcription for large audio files (>25MB)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           cache: 'pip'
           cache-dependency-path: backend/requirements.txt
 
+      - name: Install system dependencies (ffmpeg for audio processing)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Fixes the bug where audio files larger than 25 MB fail to transcribe, leaving nodes stuck with the "[Voice note – transcription pending]" placeholder.

This PR implements:
- **Automatic audio compression** for uncompressed formats (WAV/FLAC) and oversized files
- **Audio chunking** for files exceeding OpenAI's 25 MB or 25-minute limits
- **Comprehensive logging** for debugging transcription issues
- **CI/CD updates** to install ffmpeg (required by pydub)

## Problem

OpenAI's `gpt-4o-transcribe` API has two hard limits:
- **File size**: 25 MB maximum
- **Duration**: 1500 seconds (25 minutes) maximum

The backend previously accepted files up to 100 MB but didn't handle cases where files exceeded OpenAI's limits, causing silent failures with placeholder text never being replaced.

## Solution

### 1. Audio Compression (`_compress_audio_if_needed`)
- Detects uncompressed formats (WAV, FLAC)
- Converts to MP3 at 128kbps (good quality, ~5-10x smaller)
- Automatically compresses any file >25 MB

### 2. Duration Checking (`_get_audio_duration`)
- Uses pydub to determine audio length
- Validates against 25-minute limit

### 3. Audio Chunking (`_chunk_audio`)
- Splits audio into 20-minute segments (buffer below 25 min limit)
- Creates temporary MP3 files for each chunk
- Enables transcription of files of any length

### 4. Orchestration (`_transcribe_audio_file`)
- Compresses if needed
- Checks size and duration
- Decides between direct transcription or chunking
- Concatenates chunk transcripts with paragraph breaks
- Cleans up temporary files

### 5. Enhanced Logging
- Logs file sizes before/after compression
- Shows chunk boundaries and progress
- Includes full stack traces for errors

## Technical Details

**Modified Files:**
- `backend/routes/nodes.py`: Added helper functions and updated transcription logic
- `.github/workflows/ci.yml`: Added ffmpeg installation

**Dependencies:**
- `pydub>=0.25.1` (already in requirements.txt)
- `ffmpeg` (added to CI, should already be in production)

**Constants Added:**
```python
OPENAI_MAX_AUDIO_BYTES = 25 * 1024 * 1024  # 25 MB
OPENAI_MAX_DURATION_SEC = 1500  # 25 minutes
CHUNK_DURATION_SEC = 20 * 60  # 20 minutes per chunk
```

## Test Plan

- [ ] Deploy to staging/production
- [ ] Upload the problematic 28 MB file
- [ ] Verify transcription completes successfully
- [ ] Check logs show compression/chunking details
- [ ] Test with various file types:
  - [ ] Small MP3 (<25 MB) - should work as before
  - [ ] Large WAV file - should compress then transcribe
  - [ ] Very long audio (>25 min) - should chunk and transcribe
  - [ ] 28 MB file from bug report

## Expected Behavior

### For small files (≤25 MB, ≤25 min):
```
Transcribing audio: 12.3 MB, 600 seconds
Transcription successful for node 1234
```

### For large files:
```
Compressing audio file original.wav (size: 45.0 MB)
Compressed original.wav: 45.0 MB -> 15.2 MB
Transcribing audio: 15.2 MB, 900 seconds
Transcription successful for node 1234
```

### For very long files:
```
Compressing audio file original.wav (size: 80.0 MB)
Compressed original.wav: 80.0 MB -> 28.5 MB
Transcribing audio: 28.5 MB, 1800 seconds
File exceeds OpenAI limits (size: 28.5 MB, duration: 1800s), using chunked transcription
Created chunk 1: 0s - 1200s
Created chunk 2: 1200s - 1800s
Transcribing chunk 1/2
Transcribing chunk 2/2
Chunked transcription complete: 2 chunks, 15234 characters
Transcription successful for node 1234
```

## Deployment Notes

**Production server should have:**
- ✅ ffmpeg installed (likely already present)
- ✅ pydub in requirements.txt (already there)

**No breaking changes** - small files work exactly as before, large files now work instead of failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)