### PR TITLE
Fix timeout for large audio uploads with chunked upload

### DIFF
--- a/frontend/src/utils/chunkedUpload.js
+++ b/frontend/src/utils/chunkedUpload.js
@@ -1,0 +1,114 @@
+import api from "../api";
+
+/**
+ * Uploads a file in chunks with progress tracking
+ * @param {File} file - The file to upload
+ * @param {Object} metadata - Additional metadata to send with the upload
+ * @param {Function} onProgress - Callback for progress updates (0-100)
+ * @param {number} chunkSize - Size of each chunk in bytes (default 5MB)
+ * @returns {Promise<Object>} - Server response with node info
+ */
+export async function uploadFileInChunks(
+  file,
+  metadata = {},
+  onProgress = null,
+  chunkSize = 5 * 1024 * 1024 // 5MB chunks
+) {
+  const totalChunks = Math.ceil(file.size / chunkSize);
+  const uploadId = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  console.log(
+    `Starting chunked upload: ${file.name}, Size: ${(file.size / (1024 * 1024)).toFixed(2)}MB, Chunks: ${totalChunks}`
+  );
+
+  try {
+    // Step 1: Initialize upload session
+    const initResponse = await api.post("/nodes/upload/init", {
+      filename: file.name,
+      filesize: file.size,
+      total_chunks: totalChunks,
+      upload_id: uploadId,
+      ...metadata,
+    });
+
+    const { node_id } = initResponse.data;
+
+    // Step 2: Upload chunks
+    for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+      const start = chunkIndex * chunkSize;
+      const end = Math.min(start + chunkSize, file.size);
+      const chunk = file.slice(start, end);
+
+      const formData = new FormData();
+      formData.append("chunk", chunk);
+      formData.append("chunk_index", chunkIndex);
+      formData.append("upload_id", uploadId);
+      formData.append("node_id", node_id);
+
+      // Upload chunk with retry logic
+      await uploadChunkWithRetry(formData, chunkIndex, 3);
+
+      // Calculate and report progress
+      const progress = Math.round(((chunkIndex + 1) / totalChunks) * 100);
+      if (onProgress) {
+        onProgress(progress);
+      }
+
+      console.log(
+        `Uploaded chunk ${chunkIndex + 1}/${totalChunks} (${progress}%)`
+      );
+    }
+
+    // Step 3: Finalize upload
+    console.log("Finalizing upload...");
+    const finalizeResponse = await api.post("/nodes/upload/finalize", {
+      upload_id: uploadId,
+      node_id: node_id,
+    });
+
+    console.log("Upload completed successfully");
+    return finalizeResponse.data;
+  } catch (error) {
+    console.error("Chunked upload failed:", error);
+    // Attempt cleanup on error
+    try {
+      await api.post("/nodes/upload/cleanup", { upload_id: uploadId });
+    } catch (cleanupError) {
+      console.error("Cleanup failed:", cleanupError);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Uploads a single chunk with retry logic
+ */
+async function uploadChunkWithRetry(formData, chunkIndex, maxRetries = 3) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await api.post("/nodes/upload/chunk", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+        timeout: 120000, // 2 minutes per chunk (generous for 5MB)
+      });
+      return; // Success
+    } catch (error) {
+      lastError = error;
+      console.warn(
+        `Chunk ${chunkIndex} upload failed (attempt ${attempt}/${maxRetries}):`,
+        error.message
+      );
+
+      if (attempt < maxRetries) {
+        // Exponential backoff: 1s, 2s, 4s
+        const delay = Math.pow(2, attempt - 1) * 1000;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw new Error(
+    `Failed to upload chunk ${chunkIndex} after ${maxRetries} attempts: ${lastError.message}`
+  );
+}


### PR DESCRIPTION
## Summary
- Implements chunked file upload to fix timeout errors when uploading large audio files (~190MB)
- Files > 10MB are automatically split into 5MB chunks and uploaded with progress tracking
- Adds retry logic with exponential backoff for reliable uploads
- Separates upload progress from transcription progress in the UI

## Changes

### Backend (`backend/routes/nodes.py`)
- **POST `/nodes/upload/init`** - Initialize chunked upload session
- **POST `/nodes/upload/chunk`** - Receive individual chunks with metadata tracking
- **POST `/nodes/upload/finalize`** - Reassemble chunks into final audio file
- **POST `/nodes/upload/cleanup`** - Clean up failed/cancelled uploads

### Frontend (`frontend/src/utils/chunkedUpload.js`) - New file
- `uploadFileInChunks()` - Main upload function with progress callbacks
- Automatic chunk size: 5MB per chunk
- Retry logic: 3 attempts with exponential backoff (1s, 2s, 4s)
- 2-minute timeout per chunk (generous for 5MB)

### Frontend (`frontend/src/components/NodeForm.js`)
- Smart upload detection: files > 10MB use chunked upload, smaller files use traditional upload
- Real-time upload progress bar (blue, 0-100%)
- Separate transcription progress bar (green, shown after upload)
- Better error messages with server error details

## Test plan
- [ ] Upload small audio file (< 10MB) - should use traditional upload
- [ ] Upload large audio file (~190MB) - should use chunked upload with progress
- [ ] Verify upload progress bar appears and updates correctly
- [ ] Verify transcription starts after upload completes
- [ ] Test with slow/unstable connection to verify retry logic
- [ ] Verify chunks are cleaned up after successful upload
- [ ] Test error handling for failed uploads

## Technical details
- Chunk size: 5MB (configurable)
- Timeout per chunk: 2 minutes
- Overall timeout for 190MB file: ~76 minutes (38 chunks × 2 min max)
- Storage: Temporary chunks stored in `data/audio/chunks/{user_id}/{upload_id}/`
- Cleanup: Automatic cleanup after finalization or on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)