### PR TITLE
ADD: Global audio player with play/pause/stop/skip controls

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,9 @@ import NodeForm from "./components/NodeForm";
 import TermsModal from "./components/TermsModal";
 import AdminPanel from "./components/AdminPanel";
 import AlphaModal from "./components/AlphaModal";
+import GlobalAudioPlayer from "./components/GlobalAudioPlayer";
 import { useUser } from "./contexts/UserContext";
+import { AudioProvider } from "./contexts/AudioContext";
 
 function App() {
   const [showNewEntry, setShowNewEntry] = useState(false);
@@ -63,9 +65,11 @@ function App() {
   }, [showNewEntry]);
 
   return (
-    <div>
-      <NavBar onNewEntryClick={() => setShowNewEntry(true)} />
-      {showNewEntry && (
+    <AudioProvider>
+      <GlobalAudioPlayer />
+      <div style={{ paddingTop: '0px' }}>
+        <NavBar onNewEntryClick={() => setShowNewEntry(true)} />
+        {showNewEntry && (
         <div
           onClick={handleCloseModal}
           style={{
@@ -135,16 +139,17 @@ function App() {
         />
       )}
 
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/dashboard/:username" element={<Dashboard />} />
-        <Route path="/feed" element={<Feed />} />
-        <Route path="/node/:id" element={<NodeDetail />} />
-        <Route path="/admin" element={<AdminPanel />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </div>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard/:username" element={<Dashboard />} />
+          <Route path="/feed" element={<Feed />} />
+          <Route path="/node/:id" element={<NodeDetail />} />
+          <Route path="/admin" element={<AdminPanel />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </div>
+    </AudioProvider>
   );
 }
 

--- a/frontend/src/components/GlobalAudioPlayer.js
+++ b/frontend/src/components/GlobalAudioPlayer.js
@@ -1,0 +1,199 @@
+import React from 'react';
+import { FaPlay, FaPause, FaStop, FaStepBackward, FaStepForward } from 'react-icons/fa';
+import { useAudio } from '../contexts/AudioContext';
+
+const GlobalAudioPlayer = () => {
+  const {
+    currentAudio,
+    isPlaying,
+    currentTime,
+    duration,
+    loading,
+    play,
+    pause,
+    stop,
+    skipBackward,
+    skipForward,
+    seek,
+  } = useAudio();
+
+  // Don't show the player if there's no audio loaded
+  if (!currentAudio) {
+    return null;
+  }
+
+  const formatTime = (seconds) => {
+    if (isNaN(seconds) || !isFinite(seconds)) return '0:00';
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const handleSeek = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const percentage = x / rect.width;
+    const newTime = percentage * duration;
+    seek(newTime);
+  };
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: '#2a2a2a',
+      borderBottom: '1px solid #444',
+      padding: '8px 16px',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '12px',
+      zIndex: 999,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+    }}>
+      {/* Title */}
+      <div style={{
+        color: '#e0e0e0',
+        fontSize: '14px',
+        fontWeight: '500',
+        minWidth: '150px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}>
+        {currentAudio.title || 'Audio Player'}
+      </div>
+
+      {/* Controls */}
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <button
+          onClick={skipBackward}
+          disabled={loading}
+          title="Skip back 10 seconds"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: loading ? '#666' : '#e0e0e0',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            fontSize: '16px',
+            padding: '4px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <FaStepBackward />
+        </button>
+
+        {isPlaying ? (
+          <button
+            onClick={pause}
+            disabled={loading}
+            title="Pause"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: loading ? '#666' : '#61dafb',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              fontSize: '18px',
+              padding: '4px',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <FaPause />
+          </button>
+        ) : (
+          <button
+            onClick={play}
+            disabled={loading}
+            title="Play"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: loading ? '#666' : '#61dafb',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              fontSize: '18px',
+              padding: '4px',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <FaPlay />
+          </button>
+        )}
+
+        <button
+          onClick={stop}
+          disabled={loading}
+          title="Stop"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: loading ? '#666' : '#e0e0e0',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            fontSize: '16px',
+            padding: '4px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <FaStop />
+        </button>
+
+        <button
+          onClick={skipForward}
+          disabled={loading}
+          title="Skip forward 10 seconds"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: loading ? '#666' : '#e0e0e0',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            fontSize: '16px',
+            padding: '4px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <FaStepForward />
+        </button>
+      </div>
+
+      {/* Time display */}
+      <div style={{
+        color: '#b0b0b0',
+        fontSize: '12px',
+        minWidth: '80px',
+      }}>
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </div>
+
+      {/* Progress bar */}
+      <div
+        onClick={handleSeek}
+        style={{
+          flex: 1,
+          height: '6px',
+          backgroundColor: '#444',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            height: '100%',
+            width: `${duration > 0 ? (currentTime / duration) * 100 : 0}%`,
+            backgroundColor: '#61dafb',
+            borderRadius: '3px',
+            transition: 'width 0.1s linear',
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GlobalAudioPlayer;

--- a/frontend/src/contexts/AudioContext.js
+++ b/frontend/src/contexts/AudioContext.js
@@ -1,0 +1,164 @@
+import React, { createContext, useContext, useState, useRef, useCallback } from 'react';
+
+const AudioContext = createContext();
+
+export const useAudio = () => {
+  const context = useContext(AudioContext);
+  if (!context) {
+    throw new Error('useAudio must be used within an AudioProvider');
+  }
+  return context;
+};
+
+export const AudioProvider = ({ children }) => {
+  const [currentAudio, setCurrentAudio] = useState(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const audioRef = useRef(null);
+  const intervalRef = useRef(null);
+
+  // Update current time periodically
+  const startTimeTracking = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = setInterval(() => {
+      if (audioRef.current) {
+        setCurrentTime(audioRef.current.currentTime);
+      }
+    }, 100);
+  }, []);
+
+  const stopTimeTracking = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const loadAudio = useCallback(async (audioData) => {
+    // If there's already audio playing, pause it first
+    if (audioRef.current) {
+      audioRef.current.pause();
+      stopTimeTracking();
+    }
+
+    setLoading(true);
+    setCurrentAudio(audioData);
+
+    // Create new audio element
+    const audio = new Audio(audioData.url);
+    audioRef.current = audio;
+
+    // Set up event listeners
+    audio.onloadedmetadata = () => {
+      setDuration(audio.duration);
+      setLoading(false);
+    };
+
+    audio.ontimeupdate = () => {
+      setCurrentTime(audio.currentTime);
+    };
+
+    audio.onended = () => {
+      setIsPlaying(false);
+      stopTimeTracking();
+      setCurrentTime(0);
+    };
+
+    audio.onpause = () => {
+      setIsPlaying(false);
+      stopTimeTracking();
+    };
+
+    audio.onplay = () => {
+      setIsPlaying(true);
+      startTimeTracking();
+    };
+
+    audio.onerror = (e) => {
+      console.error('Error loading audio:', e);
+      setLoading(false);
+      setIsPlaying(false);
+      stopTimeTracking();
+    };
+
+    // Auto-play the audio
+    try {
+      await audio.play();
+    } catch (err) {
+      console.error('Error playing audio:', err);
+      setLoading(false);
+    }
+  }, [startTimeTracking, stopTimeTracking]);
+
+  const play = useCallback(async () => {
+    if (audioRef.current && !isPlaying) {
+      try {
+        await audioRef.current.play();
+      } catch (err) {
+        console.error('Error playing audio:', err);
+      }
+    }
+  }, [isPlaying]);
+
+  const pause = useCallback(() => {
+    if (audioRef.current && isPlaying) {
+      audioRef.current.pause();
+    }
+  }, [isPlaying]);
+
+  const stop = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      setCurrentTime(0);
+      setIsPlaying(false);
+      stopTimeTracking();
+    }
+  }, [stopTimeTracking]);
+
+  const skipForward = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = Math.min(
+        audioRef.current.currentTime + 10,
+        audioRef.current.duration
+      );
+    }
+  }, []);
+
+  const skipBackward = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = Math.max(
+        audioRef.current.currentTime - 10,
+        0
+      );
+    }
+  }, []);
+
+  const seek = useCallback((time) => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = time;
+      setCurrentTime(time);
+    }
+  }, []);
+
+  const value = {
+    currentAudio,
+    isPlaying,
+    currentTime,
+    duration,
+    loading,
+    loadAudio,
+    play,
+    pause,
+    stop,
+    skipForward,
+    skipBackward,
+    seek,
+  };
+
+  return <AudioContext.Provider value={value}>{children}</AudioContext.Provider>;
+};


### PR DESCRIPTION
## Summary
- Implemented a global audio player that appears at the top of the page
- Added play, pause, stop, skip back 10s, and skip forward 10s controls
- Created shared audio state between nodes and dashboard profile pages
- Automatically pauses previous audio when new audio starts playing
- Added progress bar with time display and seek functionality
- Visual feedback shows which audio is currently playing (speaker icon turns blue)

## Implementation Details
### New Files
- `frontend/src/contexts/AudioContext.js` - Global audio state management context
- `frontend/src/components/GlobalAudioPlayer.js` - Fixed-position audio player UI component

### Modified Files
- `frontend/src/App.js` - Wrapped app with AudioProvider and added GlobalAudioPlayer
- `frontend/src/components/SpeakerIcon.js` - Updated to use global audio context instead of managing individual audio instances

## How It Works
1. When a user clicks a speaker icon on any node or profile, the audio loads into the global player
2. The global player appears at the top of the page with full playback controls
3. If audio is already playing and user clicks a different speaker icon, the previous audio automatically pauses and the new audio starts playing
4. The speaker icon turns blue to indicate which audio is currently playing
5. Users can control playback from the global player without needing to find the original speaker icon

## Test Plan
- [ ] Click speaker icon on a node to start TTS playback
- [ ] Verify global player appears at top of page
- [ ] Test play/pause button in global player
- [ ] Test stop button (should reset to beginning)
- [ ] Test skip back 10s button
- [ ] Test skip forward 10s button
- [ ] Test progress bar seeking by clicking on it
- [ ] Navigate to dashboard and click profile speaker icon
- [ ] Verify previous audio pauses and new audio starts
- [ ] Verify speaker icon turns blue for currently playing audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)