### PR TITLE
Bugfix: Node selection

### DIFF
--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -118,16 +118,20 @@ function NodeDetail() {
     }
   };
 
-  // Define handleLLMResponse: send request and set task ID (polling starts via useEffect)
   const handleLLMResponse = () => {
     setError(""); // Clear previous errors
     api
       .post(`/nodes/${id}/llm`, { model: selectedModel })
       .then((response) => {
-        // Response now contains: { task_id, status: "pending", parent_node_id }
-        const parentNodeId = response.data.parent_node_id || id;
-        setLlmTaskNodeId(parentNodeId);
-        // Polling will start automatically via useEffect
+        // The backend now creates a placeholder and returns its ID.
+        // We use this ID for polling.
+        const newNodeId = response.data.node_id;
+        if (newNodeId) {
+          setLlmTaskNodeId(newNodeId);
+        } else {
+          // Fallback or error for safety, though the backend should always return it
+          setError("Failed to get a task ID for the new LLM node.");
+        }
       })
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
There is something fishy going on with node selection. When I create a text node, then add a LLM response, and want to go back to the text node and generate another LLM response, it sometimes tries to generate another response to the already generated LLM generated response, instead of the selected text node. Could you help me debug it?  

CHG: llm response now uses voice transcript async polling pattern