### PR TITLE
Fix: Reduce Sonnet 4.5 context window to 200k (API tier limit)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -23,7 +23,7 @@ class Config:
         "gpt-5": 128000,
         "gpt-5.1": 272000,
         "gpt-5.2": 272000,  # Temporarily 272k until OpenAI fixes their API limit (should be 400k)
-        "claude-sonnet-4.5": 1000000,
+        "claude-sonnet-4.5": 200000,  # Temporarily 200k due to API tier limit (should be 1M with higher tier)
         "claude-opus-4.5": 200000,
         "claude-opus-3": 200000,
     }


### PR DESCRIPTION
## Summary
- Temporarily reduce `claude-sonnet-4.5` context window from 1M to 200k
- Current Anthropic API tier enforces 200k limit regardless of model capability

## Root cause
The Anthropic API returns `prompt is too long: 203503 tokens > 200000 maximum` because our tier doesn't have access to the full 1M context window for Sonnet 4.5.

## Future action
Update to 1M when higher API tier becomes available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)