### PR TITLE
ADD: {quote:ID} placeholder for inline node quoting

### DIFF
--- a/backend/utils/quotes.py
+++ b/backend/utils/quotes.py
@@ -1,0 +1,129 @@
+"""
+Quote resolution utilities for {quote:ID} placeholders.
+
+This module provides functionality to detect and resolve inline node quotes,
+similar to how {user_profile} and {user_export} placeholders work.
+"""
+import re
+from typing import Tuple, List, Dict, Optional
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
+
+# Pattern to match {quote:123} where 123 is a node ID
+QUOTE_PLACEHOLDER_PATTERN = r'\{quote:(\d+)\}'
+
+
+def find_quote_ids(content: str) -> List[int]:
+    """
+    Find all node IDs referenced in {quote:ID} placeholders.
+
+    Args:
+        content: Text that may contain {quote:ID} placeholders
+
+    Returns:
+        List of node IDs found in the content
+    """
+    if not content:
+        return []
+    matches = re.findall(QUOTE_PLACEHOLDER_PATTERN, content)
+    return [int(node_id) for node_id in matches]
+
+
+def get_quote_data(node_ids: List[int], user_id: int) -> Dict[int, Optional[dict]]:
+    """
+    Fetch node data for the given IDs, checking access permissions.
+
+    Args:
+        node_ids: List of node IDs to fetch
+        user_id: ID of the user requesting access (for permission checks)
+
+    Returns:
+        Dict mapping node_id to node data dict (or None if not accessible)
+    """
+    from backend.models import Node, User
+    from backend.utils.privacy import can_user_access_node
+
+    result = {}
+    user = User.query.get(user_id) if user_id else None
+
+    for node_id in node_ids:
+        node = Node.query.get(node_id)
+        if node and can_user_access_node(user, node):
+            result[node_id] = {
+                "id": node.id,
+                "content": node.content,
+                "username": node.user.username if node.user else "Unknown",
+                "user_id": node.user_id,
+                "created_at": node.created_at.isoformat() if node.created_at else None,
+                "node_type": node.node_type,
+            }
+        else:
+            result[node_id] = None
+
+    return result
+
+
+def resolve_quotes(content: str, user_id: int, for_llm: bool = False) -> Tuple[str, List[int]]:
+    """
+    Replace {quote:ID} placeholders with quoted node content.
+
+    Args:
+        content: Text containing {quote:ID} placeholders
+        user_id: ID of requesting user (for access checks)
+        for_llm: If True, wrap content in XML tags for LLM context;
+                 if False, use human-readable format
+
+    Returns:
+        Tuple of (resolved_content, list_of_quoted_node_ids)
+    """
+    if not content:
+        return content, []
+
+    quote_ids = find_quote_ids(content)
+    if not quote_ids:
+        return content, []
+
+    # Fetch all quoted nodes
+    quote_data = get_quote_data(quote_ids, user_id)
+    resolved_ids = []
+
+    def replace_quote(match):
+        node_id = int(match.group(1))
+        data = quote_data.get(node_id)
+
+        if data is None:
+            # Node not found or not accessible
+            if for_llm:
+                return f"[Quote #{node_id}: not accessible]"
+            else:
+                return f"[Quote not accessible: node {node_id}]"
+
+        resolved_ids.append(node_id)
+        node_content = data["content"] or ""
+        username = data["username"]
+
+        if for_llm:
+            # XML format for clear LLM context
+            return f'<quoted_node id="{node_id}" author="{username}">\n{node_content}\n</quoted_node>'
+        else:
+            # Human-readable format for exports
+            return f'\n--- Quoted from @{username} (node #{node_id}) ---\n{node_content}\n--- End quote ---\n'
+
+    resolved_content = re.sub(QUOTE_PLACEHOLDER_PATTERN, replace_quote, content)
+    return resolved_content, resolved_ids
+
+
+def has_quotes(content: str) -> bool:
+    """
+    Check if content contains any {quote:ID} placeholders.
+
+    Args:
+        content: Text to check
+
+    Returns:
+        True if content contains quote placeholders
+    """
+    if not content:
+        return False
+    return bool(re.search(QUOTE_PLACEHOLDER_PATTERN, content))

--- a/frontend/src/components/InlineQuoteBubble.js
+++ b/frontend/src/components/InlineQuoteBubble.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import NodeFooter from './NodeFooter';
+
+/**
+ * InlineQuoteBubble - A compact version of Bubble for displaying inline quotes.
+ * Designed to fit within text flow while still being clickable.
+ */
+const InlineQuoteBubble = ({ quote, onClick }) => {
+  if (!quote) {
+    // Quote not accessible or not found
+    return (
+      <div style={notAccessibleStyle}>
+        [Quote not accessible]
+      </div>
+    );
+  }
+
+  const text = quote.content || "";
+  const truncatedText = text.length > 150 ? text.substring(0, 150) + "..." : text;
+
+  return (
+    <div style={bubbleStyle} onClick={() => onClick(quote.id)}>
+      <div style={quoteHeaderStyle}>
+        Quoted from @{quote.username}
+      </div>
+      <div style={contentStyle}>
+        {truncatedText}
+      </div>
+      <NodeFooter
+        username={quote.username}
+        createdAt={quote.created_at}
+        childrenCount={0}
+      />
+    </div>
+  );
+};
+
+const bubbleStyle = {
+  display: 'block',
+  padding: '12px',
+  margin: '10px 0',
+  background: '#252525',
+  border: '1px solid #444',
+  borderLeft: '3px solid #61dafb',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  whiteSpace: 'pre-wrap',
+  maxWidth: '100%',
+  transition: 'background 0.2s ease',
+};
+
+const quoteHeaderStyle = {
+  fontSize: '0.85em',
+  color: '#888',
+  marginBottom: '6px',
+  fontStyle: 'italic',
+};
+
+const contentStyle = {
+  fontSize: '0.95em',
+  lineHeight: '1.4',
+  marginBottom: '8px',
+};
+
+const notAccessibleStyle = {
+  display: 'inline-block',
+  padding: '4px 8px',
+  margin: '4px 0',
+  background: '#333',
+  border: '1px solid #555',
+  borderRadius: '4px',
+  color: '#888',
+  fontStyle: 'italic',
+  fontSize: '0.9em',
+};
+
+export default InlineQuoteBubble;

--- a/frontend/src/components/QuotedContent.js
+++ b/frontend/src/components/QuotedContent.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import InlineQuoteBubble from './InlineQuoteBubble';
+
+// Pattern to match {quote:123} placeholders
+const QUOTE_PATTERN = /\{quote:(\d+)\}/g;
+
+/**
+ * QuotedContent - Renders content with inline quote previews.
+ *
+ * Parses the content for {quote:ID} placeholders and renders them
+ * as clickable InlineQuoteBubble components.
+ *
+ * Props:
+ *   content: The raw text content that may contain {quote:ID} placeholders
+ *   quotes: Object mapping quote IDs to quote data (or null if not accessible)
+ *   onQuoteClick: Callback when a quote is clicked (receives quote ID)
+ */
+const QuotedContent = ({ content, quotes, onQuoteClick }) => {
+  if (!content) {
+    return null;
+  }
+
+  // If no quotes data provided, just render the content as-is with markdown
+  if (!quotes || Object.keys(quotes).length === 0) {
+    return (
+      <ReactMarkdown components={markdownComponents}>
+        {content}
+      </ReactMarkdown>
+    );
+  }
+
+  // Parse content into segments: text and quote placeholders
+  const segments = [];
+  let lastIndex = 0;
+  let match;
+
+  // Reset the regex lastIndex for fresh matching
+  QUOTE_PATTERN.lastIndex = 0;
+
+  while ((match = QUOTE_PATTERN.exec(content)) !== null) {
+    // Add text before this match
+    if (match.index > lastIndex) {
+      segments.push({
+        type: 'text',
+        content: content.substring(lastIndex, match.index),
+      });
+    }
+
+    // Add the quote placeholder
+    const quoteId = match[1];
+    segments.push({
+      type: 'quote',
+      quoteId: quoteId,
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text after last match
+  if (lastIndex < content.length) {
+    segments.push({
+      type: 'text',
+      content: content.substring(lastIndex),
+    });
+  }
+
+  // Render segments
+  return (
+    <div>
+      {segments.map((segment, index) => {
+        if (segment.type === 'text') {
+          return (
+            <ReactMarkdown key={index} components={markdownComponents}>
+              {segment.content}
+            </ReactMarkdown>
+          );
+        } else if (segment.type === 'quote') {
+          const quoteData = quotes[segment.quoteId];
+          return (
+            <InlineQuoteBubble
+              key={index}
+              quote={quoteData}
+              onClick={onQuoteClick}
+            />
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+};
+
+// Markdown component overrides for consistent styling
+const markdownComponents = {
+  p: ({ node, ...props }) => (
+    <p style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }} {...props} />
+  ),
+  code: ({ node, inline, className, children, ...props }) =>
+    inline ? (
+      <code style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }} {...props}>
+        {children}
+      </code>
+    ) : (
+      <pre style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }} {...props}>
+        <code>{children}</code>
+      </pre>
+    ),
+  li: ({ node, ...props }) => (
+    <li style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }} {...props} />
+  ),
+};
+
+export default QuotedContent;


### PR DESCRIPTION
## Summary
- Users can now include `{quote:123}` in their text to reference another node inline
- Quoted nodes display as clickable previews in the UI and expand in LLM context
- Supports privacy-aware access checks for cross-user quoting

## Changes

**Backend:**
- New `backend/utils/quotes.py` module with quote resolution logic
- Updated `llm_completion.py` to resolve quotes in LLM context (XML-wrapped)
- Updated `export_data.py` to expand quotes in exports/profile generation
- New `GET /nodes/<id>/resolve-quotes` endpoint for frontend

**Frontend:**
- New `InlineQuoteBubble` component for compact quote preview
- New `QuotedContent` component to parse and render `{quote:ID}` patterns
- Updated `NodeDetail` to fetch and display inline quotes

## Test plan
- [ ] Create a node with content containing `{quote:ID}` referencing an existing node
- [ ] Verify inline preview appears in NodeDetail and is clickable
- [ ] Request LLM response to a node chain containing quotes - verify quoted content is included
- [ ] Generate user profile - verify quotes in source nodes are expanded
- [ ] Test privacy: Try quoting a private node from another user - should show "not accessible"

🤖 Generated with [Claude Code](https://claude.com/claude-code)