### PR TITLE
Add streaming TTS playback

### DIFF
--- a/frontend/src/components/GlobalAudioPlayer.js
+++ b/frontend/src/components/GlobalAudioPlayer.js
@@ -11,6 +11,7 @@ const GlobalAudioPlayer = () => {
     // Use cumulative values for display (falls back gracefully for single audio)
     cumulativeTime,
     totalDuration,
+    generatingTTS,
     play,
     pause,
     stop,
@@ -189,8 +190,23 @@ const GlobalAudioPlayer = () => {
         color: '#b0b0b0',
         fontSize: '11px',
         minWidth: '70px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
       }}>
         {formatTime(displayTime)} / {formatTime(displayDuration)}
+        {generatingTTS && (
+          <span
+            style={{
+              fontSize: '9px',
+              color: '#61dafb',
+              animation: 'pulse 1.5s ease-in-out infinite',
+            }}
+            title="Generating more audio..."
+          >
+            ●
+          </span>
+        )}
       </div>
 
       {/* Progress bar */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,10 @@ html, body, #root {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
 
 a:link {
   color: #61dafb;   /* Unvisited */


### PR DESCRIPTION
## Summary
- Wire existing SSE infrastructure (`useTTSStreamSSE`) into `SpeakerIcon` so TTS audio chunks play as they arrive, instead of waiting for full generation to complete
- Add `appendChunkToQueue` method to `AudioContext` that extends the active audio queue with new chunks, with auto-resume when playback catches up to generation
- Show a pulsing indicator in `GlobalAudioPlayer` while TTS is still generating, with duration growing dynamically

## Test plan
- [ ] Trigger TTS for a long text node — audio should start playing after first chunk (~10-15s), not after all chunks complete
- [ ] Total duration in the player should grow as new chunks arrive
- [ ] Pulsing blue dot appears next to duration while generating, disappears when done
- [ ] Player controls (pause, skip, seek) work during generation
- [ ] Profile TTS still works via polling fallback
- [ ] Cached audio replays correctly after generation completes
- [x] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)