### PR TITLE
feat: add magic link email authentication

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -71,6 +71,15 @@ class Config:
         },
     }
 
+    # Magic link email authentication (SMTP)
+    MAIL_SERVER = os.environ.get("MAIL_SERVER", "localhost")
+    MAIL_PORT = int(os.environ.get("MAIL_PORT", "587"))
+    MAIL_USE_TLS = os.environ.get("MAIL_USE_TLS", "true").lower() in ("true", "1", "yes")
+    MAIL_USERNAME = os.environ.get("MAIL_USERNAME")
+    MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD")
+    MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", "login@loore.org")
+    MAGIC_LINK_EXPIRY_SECONDS = int(os.environ.get("MAGIC_LINK_EXPIRY_SECONDS", "900"))
+
     FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")
 
     # Celery configuration for async task queue

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,7 +5,7 @@ from backend.utils.encryption import encrypt_content, decrypt_content
 
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
-    twitter_id = db.Column(db.String(64), unique=True, nullable=False)
+    twitter_id = db.Column(db.String(64), unique=True, nullable=True)
     username = db.Column(db.String(64), unique=True, nullable=False)
     # A short description that the user may set (max 128 characters)
     description = db.Column(db.String(128), nullable=True, default="")
@@ -13,7 +13,9 @@ class User(db.Model, UserMixin):
     accepted_terms_at = db.Column(db.DateTime, nullable=True)
     # NEW: Approval status for our alpha (whitelisting) and optional email.
     approved = db.Column(db.Boolean, default=False, nullable=False)
-    email = db.Column(db.String(128), nullable=True)
+    email = db.Column(db.String(128), nullable=True, unique=True)
+    magic_link_token_hash = db.Column(db.String(128), nullable=True)
+    magic_link_expires_at = db.Column(db.DateTime, nullable=True)
     
     # Relationship to text nodes
     nodes = db.relationship("Node", backref="user", lazy=True)

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -71,7 +71,7 @@ def whitelist_user():
         return jsonify({"error": "User with that handle already exists."}), 400
 
     # Create a new user with the handle
-    user = User(twitter_id=handle, username=handle, approved=True)
+    user = User(twitter_id=None, username=handle, approved=True)
     db.session.add(user)
     try:
         db.session.commit()

--- a/backend/tests/test_magic_link.py
+++ b/backend/tests/test_magic_link.py
@@ -1,0 +1,145 @@
+"""Tests for magic link utilities."""
+
+import hashlib
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock heavy dependencies before importing backend code
+mock_flask_login = MagicMock()
+sys.modules.setdefault('flask_login', mock_flask_login)
+
+mock_flask_dance = MagicMock()
+sys.modules.setdefault('flask_dance', mock_flask_dance)
+sys.modules.setdefault('flask_dance.contrib', MagicMock())
+sys.modules.setdefault('flask_dance.contrib.twitter', MagicMock())
+
+from flask import Flask
+from backend.utils.magic_link import (
+    generate_magic_link_token,
+    verify_magic_link_token,
+    hash_token,
+    generate_unique_username,
+)
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret-key"
+    app.config["MAGIC_LINK_EXPIRY_SECONDS"] = 900
+    return app
+
+
+class TestTokenRoundTrip:
+    def test_generate_and_verify(self, app):
+        with app.app_context():
+            token = generate_magic_link_token("user@example.com")
+            payload = verify_magic_link_token(token)
+            assert payload is not None
+            assert payload["email"] == "user@example.com"
+
+    def test_generate_with_next_url(self, app):
+        with app.app_context():
+            token = generate_magic_link_token("user@example.com", "/dashboard")
+            payload = verify_magic_link_token(token)
+            assert payload["next_url"] == "/dashboard"
+
+    def test_generate_without_next_url(self, app):
+        with app.app_context():
+            token = generate_magic_link_token("user@example.com")
+            payload = verify_magic_link_token(token)
+            assert "next_url" not in payload
+
+
+class TestTokenExpiry:
+    def test_expired_token(self, app):
+        app.config["MAGIC_LINK_EXPIRY_SECONDS"] = 1
+        with app.app_context():
+            token = generate_magic_link_token("user@example.com")
+            time.sleep(2)
+            payload = verify_magic_link_token(token)
+            assert payload is None
+
+    def test_invalid_token(self, app):
+        with app.app_context():
+            payload = verify_magic_link_token("not-a-valid-token")
+            assert payload is None
+
+    def test_tampered_token(self, app):
+        with app.app_context():
+            token = generate_magic_link_token("user@example.com")
+            tampered = token + "x"
+            payload = verify_magic_link_token(tampered)
+            assert payload is None
+
+
+class TestHashToken:
+    def test_deterministic(self):
+        assert hash_token("abc") == hash_token("abc")
+
+    def test_different_tokens_different_hashes(self):
+        assert hash_token("abc") != hash_token("xyz")
+
+    def test_returns_hex_digest(self):
+        h = hash_token("test")
+        assert len(h) == 64  # SHA-256 hex digest length
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestGenerateUniqueUsername:
+    """Test username generation from email.
+
+    generate_unique_username does a deferred import of User from
+    backend.models, so we mock it via the module that gets imported.
+    """
+
+    def _make_mock_user(self, side_effect):
+        mock_user = MagicMock()
+        mock_user.query.filter_by.return_value.first.side_effect = side_effect
+        return mock_user
+
+    def test_simple_email(self, app):
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+            # Re-import to pick up the patched module
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("john@gmail.com")
+            assert result == "john"
+
+    def test_collision_adds_suffix(self, app):
+        existing = MagicMock()
+        mock_user = self._make_mock_user([existing, None])
+        with app.app_context(), \
+                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("john@gmail.com")
+            assert result == "john2"
+
+    def test_multiple_collisions(self, app):
+        existing = MagicMock()
+        mock_user = self._make_mock_user([existing, existing, existing, None])
+        with app.app_context(), \
+                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("john@gmail.com")
+            assert result == "john4"
+
+    def test_email_with_dots_and_plus(self, app):
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("john.doe+tag@gmail.com")
+            assert result == "johndoetag"
+
+    def test_empty_prefix_fallback(self, app):
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("@example.com")
+            assert result == "user"

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -1,0 +1,66 @@
+import smtplib
+import logging
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from flask import current_app
+
+logger = logging.getLogger(__name__)
+
+
+def send_magic_link_email(to_email, magic_link_url):
+    config = current_app.config
+    sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Your Write or Perish sign-in link"
+    msg["From"] = sender
+    msg["To"] = to_email
+
+    text_body = (
+        "Sign in to Write or Perish\n\n"
+        f"Click the link below to sign in:\n{magic_link_url}\n\n"
+        "This link expires in 15 minutes and can only be used once.\n\n"
+        "If you didn't request this, you can safely ignore this email."
+    )
+
+    html_body = f"""\
+<html>
+<body style="font-family: -apple-system, sans-serif; background: #121212; color: #e0e0e0; padding: 40px;">
+  <div style="max-width: 480px; margin: 0 auto; background: #1e1e1e; border-radius: 8px; border: 1px solid #333; padding: 40px;">
+    <h2 style="margin-top: 0;">Sign in to Write or Perish</h2>
+    <p>Click the button below to sign in:</p>
+    <a href="{magic_link_url}"
+       style="display: inline-block; padding: 12px 24px; background: #1DA1F2; color: white;
+              text-decoration: none; border-radius: 4px; margin: 16px 0;">
+      Sign in
+    </a>
+    <p style="color: #888; font-size: 14px; margin-top: 24px;">
+      This link expires in 15 minutes and can only be used once.
+    </p>
+    <p style="color: #666; font-size: 12px;">
+      If you didn't request this, you can safely ignore this email.
+    </p>
+  </div>
+</body>
+</html>"""
+
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    server = config.get("MAIL_SERVER", "localhost")
+    port = config.get("MAIL_PORT", 587)
+    use_tls = config.get("MAIL_USE_TLS", True)
+    username = config.get("MAIL_USERNAME")
+    password = config.get("MAIL_PASSWORD")
+
+    try:
+        with smtplib.SMTP(server, port) as smtp:
+            if use_tls:
+                smtp.starttls()
+            if username and password:
+                smtp.login(username, password)
+            smtp.sendmail(sender, to_email, msg.as_string())
+        logger.info(f"Magic link email sent to {to_email}")
+    except Exception:
+        logger.exception(f"Failed to send magic link email to {to_email}")
+        raise

--- a/backend/utils/magic_link.py
+++ b/backend/utils/magic_link.py
@@ -1,0 +1,52 @@
+import hashlib
+from flask import current_app
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+
+
+def _get_serializer():
+    return URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+
+
+def generate_magic_link_token(email, next_url=None):
+    s = _get_serializer()
+    payload = {"email": email}
+    if next_url:
+        payload["next_url"] = next_url
+    return s.dumps(payload, salt="magic-link")
+
+
+def verify_magic_link_token(token):
+    s = _get_serializer()
+    max_age = current_app.config.get("MAGIC_LINK_EXPIRY_SECONDS", 900)
+    try:
+        payload = s.loads(token, salt="magic-link", max_age=max_age)
+        return payload
+    except SignatureExpired:
+        return None
+    except BadSignature:
+        return None
+
+
+def hash_token(token):
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_unique_username(email):
+    from backend.models import User
+
+    prefix = email.split("@")[0]
+    # Clean up prefix: keep only alphanumeric and underscores
+    clean = "".join(c for c in prefix if c.isalnum() or c == "_")
+    if not clean:
+        clean = "user"
+
+    candidate = clean
+    if not User.query.filter_by(username=candidate).first():
+        return candidate
+
+    suffix = 2
+    while True:
+        candidate = f"{clean}{suffix}"
+        if not User.query.filter_by(username=candidate).first():
+            return candidate
+        suffix += 1


### PR DESCRIPTION
## Summary

- Add magic link email login alongside existing Twitter OAuth — users enter email, receive a signed link, click it, and are logged in (no passwords)
- New users created via magic link get `approved=False` (same whitelist/alpha flow as Twitter users)
- Single-use tokens enforced via SHA-256 hash stored on user record, with 15-minute expiry
- No new pip dependencies — uses `itsdangerous` (bundled with Flask) and `smtplib` (stdlib)

## Changes

### Backend
- **models.py**: `twitter_id` now nullable, `email` unique, added `magic_link_token_hash` and `magic_link_expires_at` columns
- **config.py**: Added SMTP config env vars (`MAIL_SERVER`, `MAIL_PORT`, etc.) and `MAGIC_LINK_EXPIRY_SECONDS`
- **routes/auth.py**: Added `POST /auth/magic-link/send` and `GET /auth/magic-link/verify` endpoints
- **routes/admin.py**: Whitelist now creates users with `twitter_id=None`
- **utils/magic_link.py**: Token generation/verification, hashing, username generation from email
- **utils/email.py**: SMTP email sending with HTML + plain text templates

### Frontend
- **LoginPage.js**: Enabled email button, added email input form with loading/success/error states, displays verify redirect errors

### Tests
- **tests/test_magic_link.py**: 14 tests covering token round-trip, expiry, tampering, hash determinism, and username generation with collision handling

## Environment Variables (production)
```
MAIL_SERVER=<smtp server>
MAIL_PORT=587
MAIL_USE_TLS=true
MAIL_USERNAME=login@loore.org
MAIL_PASSWORD=<password>
MAIL_DEFAULT_SENDER=login@loore.org
```

## Test plan
- [x] Visit `/login` → "Sign in with Email" → enter email → send → check inbox
- [x] Click magic link → logged in, redirected to dashboard
- [x] Click same link again → error "link already used"
- [x] Wait 15+ min → error "expired"
- [x] New email user gets `approved=False`, sees AlphaModal
- [x] Existing Twitter user with email can log in via magic link
- [x] Twitter login still works unchanged
- [x] All 82 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)