### PR TITLE
chore: switch domain from writeorperish.org to loore.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         env:
-          REACT_APP_BACKEND_URL: https://writeorperish.org
-          REACT_APP_API_URL: https://writeorperish.org/api
+          REACT_APP_BACKEND_URL: https://loore.org
+          REACT_APP_API_URL: https://loore.org/api
         run: npm run build
 
   security-check:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         env:
-          REACT_APP_BACKEND_URL: https://writeorperish.org
-          REACT_APP_API_URL: https://writeorperish.org/api
+          REACT_APP_BACKEND_URL: https://loore.org
+          REACT_APP_API_URL: https://loore.org/api
         run: npm run build
 
       - name: Create deployment package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The project uses GitHub Actions for CI/CD with direct deployment to production:
 
 - Develop locally on feature branches
 - Push to GitHub to trigger CI checks
-- **Merge to `main` = Deploy to production** (https://writeorperish.org)
+- **Merge to `main` = Deploy to production** (https://loore.org)
 - There is NO staging environment
 
 ### Before Pushing to Main
@@ -56,7 +56,7 @@ The project uses **Flask-Migrate + Alembic**. Migrations are auto-generated and 
 
 ### Production Environment
 
-- URL: https://writeorperish.org
+- URL: https://loore.org
 - Backend: Flask + Gunicorn
 - Frontend: React (built and served via nginx)
 - Database: PostgreSQL

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ SECRET_KEY=your-secret-key
 DATABASE_URL=postgresql://username:password@localhost/writeorperish
 TWITTER_API_KEY=your-twitter-api-key
 TWITTER_API_SECRET=your-twitter-api-secret
-FRONTEND_URL=https://writeorperish.org
+FRONTEND_URL=https://loore.org
 OPENAI_API_KEY=your-openai-api-key
 ```
 

--- a/configs/nginx.txt
+++ b/configs/nginx.txt
@@ -1,5 +1,6 @@
+# Primary domain: loore.org
 server {
-   server_name writeorperish.org www.writeorperish.org;
+   server_name loore.org www.loore.org;
    root /home/hrosspet/write-or-perish/frontend/build;
    index index.html index.htm;
 
@@ -71,29 +72,43 @@ server {
    }
 
     listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/writeorperish.org/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/writeorperish.org/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/loore.org/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/loore.org/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
 
 }
+
+# HTTP -> HTTPS redirect for loore.org
 server {
-    if ($host = www.writeorperish.org) {
+    if ($host = www.loore.org) {
         return 301 https://$host$request_uri;
     } # managed by Certbot
 
 
-    if ($host = writeorperish.org) {
+    if ($host = loore.org) {
         return 301 https://$host$request_uri;
     } # managed by Certbot
 
 
    listen 80;
-   server_name writeorperish.org www.writeorperish.org;
+   server_name loore.org www.loore.org;
     return 404; # managed by Certbot
 
 
+}
 
+# Redirect old domain writeorperish.org -> loore.org
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name writeorperish.org www.writeorperish.org;
 
+    ssl_certificate /etc/letsencrypt/live/writeorperish.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/writeorperish.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://loore.org$request_uri;
 }

--- a/docs/CICD-SETUP.md
+++ b/docs/CICD-SETUP.md
@@ -58,7 +58,7 @@ Add these secrets:
 | Secret Name | Description | Example Value |
 |-------------|-------------|---------------|
 | `SSH_PRIVATE_KEY` | Private SSH key content | Content of `github_deploy_key` file |
-| `VM_HOST` | VM IP address or hostname | `35.123.45.67` or `writeorperish.org` |
+| `VM_HOST` | VM IP address or hostname | `35.123.45.67` or `loore.org` |
 | `VM_USER` | SSH username on VM | `hrosspet` |
 
 To get the private key content:


### PR DESCRIPTION
## Summary

- Switch primary production domain from `writeorperish.org` to `loore.org`
- Old domain `writeorperish.org` 301-redirects to `loore.org` (preserving paths)
- All CI/CD build URLs updated to `loore.org`

## Manual steps required BEFORE merging

1. **DNS**: Point `loore.org` and `www.loore.org` (A records) to the GCP VM IP
2. **SSL**: Run `sudo certbot --nginx -d loore.org -d www.loore.org` on the server
3. **Env**: Update `FRONTEND_URL=https://loore.org` in `/home/hrosspet/write-or-perish/.env.production`
4. **GitHub Secret**: Update `VM_HOST` secret if it uses the domain name instead of IP

## After merging

- `deploy.sh` will copy the new nginx config and reload nginx
- Old `writeorperish.org` visitors get 301-redirected to `loore.org`
- Keep `writeorperish.org` DNS records pointing to the same server so the redirect works

## Test plan
- [ ] DNS propagated: `dig loore.org` returns the VM IP
- [ ] SSL cert obtained for loore.org
- [ ] `.env.production` updated with `FRONTEND_URL=https://loore.org`
- [ ] After merge+deploy: `https://loore.org` serves the app
- [ ] After merge+deploy: `https://writeorperish.org/anything` redirects to `https://loore.org/anything`
- [ ] Login (both Twitter and magic link) works on new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)