### PR TITLE
FIX: auto-play TTS audio when first SSE chunk arrives

### DIFF
--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -29,7 +29,7 @@ const extractMarkdownHeader = (content) => {
  */
 const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage }) => {
   const { user } = useUser();
-  const { loadAudio, loadAudioQueue, appendChunkToQueue, setGeneratingTTS, currentAudio, isPlaying } = useAudio();
+  const { loadAudio, loadAudioQueue, appendChunkToQueue, warmUpAudio, setGeneratingTTS, currentAudio, isPlaying } = useAudio();
   const [loading, setLoading] = useState(false);
   const [audioSrc, setAudioSrc] = useState(null);
   const [audioChunks, setAudioChunks] = useState(null); // For chunked playback
@@ -253,6 +253,8 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage }) => {
           return;
         }
         // Start async TTS generation
+        // Warm up audio during user gesture so first SSE chunk can autoplay
+        warmUpAudio();
         await api.post(`${baseUrl}/tts`);
 
         if (isNode) {


### PR DESCRIPTION
## Summary
- Browsers block `audio.play()` when called outside a user gesture context (e.g. from an SSE callback)
- Added `warmUpAudio()` that plays a silent WAV during the click gesture to "unlock" an Audio element
- `playChunkAtTime` reuses this pre-unlocked element for the first chunk, so playback starts immediately

## Test plan
- [ ] Click speaker icon on a node without cached TTS audio
- [ ] Verify audio starts playing automatically as soon as the first chunk arrives (no need to manually press play)
- [ ] Verify subsequent chunks continue playing seamlessly
- [ ] Verify cached/existing audio still plays correctly on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)