### PR TITLE
Add pin-to-profile feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,13 @@ Ensure:
 
 ### Local Code Verification
 
-**Frontend**: Run **both** of these from the `frontend/` directory before pushing:
-1. `npm run lint 2>&1 | tail -30` — catches ESLint errors that CI will fail on (e.g. `no-use-before-define`). The build step alone does NOT catch all lint errors.
-2. `npm run build 2>&1 | tail -30` — checks for compilation errors.
+**Backend**: Run from the repo root:
+1. `flake8 backend --count --select=E9,F63,F7,F82 --show-source --statistics` — **CI-blocking**: catches Python syntax errors and undefined names. Must pass with 0 errors.
+2. `flake8 backend --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics` — non-blocking warnings (style, complexity). CI runs this with `--exit-zero` so it never fails the build, but review the output.
+3. `cd backend && python -m pytest` — runs all backend tests.
+
+**Frontend**: Run from the `frontend/` directory:
+1. `npm run build 2>&1 | tail -30` — checks for compilation errors and ESLint warnings. The build will fail on errors and report warnings. Note: there is no separate `npm run lint` script configured; the CI skips it gracefully.
 
 **IMPORTANT**: Running `npm run build` changes the working directory to `frontend/`. Always use absolute paths or `cd` back to the repo root before running git commands, otherwise `git add` will fail with `pathspec did not match any files`.
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -19,8 +19,9 @@ class User(db.Model, UserMixin):
     magic_link_expires_at = db.Column(db.DateTime, nullable=True)
     deactivated_at = db.Column(db.DateTime, nullable=True)
     
-    # Relationship to text nodes
-    nodes = db.relationship("Node", backref="user", lazy=True)
+    # Relationship to text nodes (explicit foreign_keys needed because Node has
+    # multiple FKs pointing to User: user_id and pinned_by)
+    nodes = db.relationship("Node", backref="user", lazy=True, foreign_keys="Node.user_id")
 
     # --- Voice‑Mode fields ---
     # Whether the user is an administrator.  Voice‑mode features are currently limited
@@ -119,9 +120,13 @@ class Node(db.Model):
     # Session ID for streaming upload (groups chunks together)
     streaming_session_id = db.Column(db.String(64), nullable=True)
 
+    # Pin-to-profile: surfaces any node on Dashboard & Feed
+    pinned_at = db.Column(db.DateTime, nullable=True)
+    pinned_by = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    
+
     # Self–referential relationships…
     children = db.relationship("Node", backref=db.backref("parent", remote_side=[id]),
                                lazy=True, foreign_keys=[parent_id])

--- a/backend/routes/feed.py
+++ b/backend/routes/feed.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
-from backend.models import Node
+from backend.models import Node, User
 from backend.extensions import db
-from backend.utils.privacy import accessible_nodes_filter
+from backend.utils.privacy import accessible_nodes_filter, find_human_owner
+from sqlalchemy import or_, func
 
 feed_bp = Blueprint("feed_bp", __name__)
 
@@ -10,7 +11,7 @@ feed_bp = Blueprint("feed_bp", __name__)
 @login_required
 def get_feed():
     """
-    Returns top-level nodes (nodes that have no parent) as the global feed.
+    Returns top-level nodes and pinned nodes as the global feed.
     Only shows public nodes and the current user's own nodes.
     Supports pagination via ?page=1&per_page=20 query params.
     """
@@ -19,9 +20,9 @@ def get_feed():
     per_page = min(per_page, 100)  # cap max page size
 
     query = Node.query.filter(
-        Node.parent_id.is_(None),
+        or_(Node.parent_id.is_(None), Node.pinned_at.isnot(None)),
         accessible_nodes_filter(Node, current_user.id)
-    ).order_by(Node.created_at.desc())
+    ).order_by(func.coalesce(Node.pinned_at, Node.created_at).desc())
     pagination = query.paginate(page=page, per_page=per_page, error_out=False)
 
     def make_preview(text, length=200):
@@ -29,13 +30,26 @@ def get_feed():
 
     nodes_list = []
     for node in pagination.items:
+        # Determine human owner username for LLM nodes
+        human_owner_username = None
+        if node.node_type == "llm":
+            human_owner_id = find_human_owner(node)
+            if human_owner_id:
+                human_owner = User.query.get(human_owner_id)
+                if human_owner:
+                    human_owner_username = human_owner.username
+
         nodes_list.append({
             "id": node.id,
             "preview": make_preview(node.get_content()),
             "node_type": node.node_type,
             "child_count": len(node.children),
             "created_at": node.created_at.isoformat(),
-            "username": node.user.username if node.user else "Unknown"
+            "pinned_at": node.pinned_at.isoformat() if node.pinned_at else None,
+            "username": node.user.username if node.user else "Unknown",
+            "human_owner_username": human_owner_username,
+            "llm_model": node.llm_model,
+            "has_audio": bool(node.audio_original_url or node.audio_tts_url),
         })
 
     return jsonify({

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -2,8 +2,9 @@ import React from 'react';
 import NodeFooter from './NodeFooter';
 
 const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => {
-  // Detect voice notes
-  const isVoiceNote = node.has_audio || (node.title && /^voice\s+note/i.test(node.title));
+  // Detect voice notes via backend-provided has_audio flag
+  const isVoiceNote = !!node.has_audio;
+  const isPinned = !!node.pinned_at;
 
   // Use full content if available; otherwise use preview.
   const text = node.content || node.preview || "";
@@ -31,6 +32,17 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
     maxWidth: "1000px",
     width: "calc(100% - 20px)",
     transition: "border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease",
+  };
+
+  const tagStyle = {
+    fontFamily: "var(--sans)",
+    fontSize: "0.65rem",
+    fontWeight: 500,
+    textTransform: "uppercase",
+    letterSpacing: "0.08em",
+    padding: "3px 8px",
+    borderRadius: "4px",
+    marginLeft: "8px",
   };
 
   return (
@@ -72,7 +84,7 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
           {body.length > 250 ? body.substring(0, 250) + "..." : body}
         </div>
       )}
-      {/* Footer row with optional tag + node footer */}
+      {/* Footer row with optional tags + node footer */}
       <div onClick={(e) => e.stopPropagation()} style={{
         display: "flex",
         alignItems: "center",
@@ -82,23 +94,29 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
           username={node.username}
           createdAt={node.created_at}
           childrenCount={childrenCount}
+          humanOwnerUsername={node.human_owner_username}
+          llmModel={node.llm_model}
         />
-        {isVoiceNote && (
-          <span style={{
-            fontFamily: "var(--sans)",
-            fontSize: "0.65rem",
-            fontWeight: 500,
-            textTransform: "uppercase",
-            letterSpacing: "0.08em",
-            color: "var(--accent-dim)",
-            backgroundColor: "var(--accent-subtle)",
-            padding: "3px 8px",
-            borderRadius: "4px",
-            marginLeft: "auto",
-          }}>
-            Voice Note
-          </span>
-        )}
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {isPinned && (
+            <span style={{
+              ...tagStyle,
+              color: "var(--accent-dim)",
+              backgroundColor: "var(--accent-subtle)",
+            }}>
+              Pinned
+            </span>
+          )}
+          {isVoiceNote && (
+            <span style={{
+              ...tagStyle,
+              color: "var(--accent-dim)",
+              backgroundColor: "var(--accent-subtle)",
+            }}>
+              Voice Note
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -554,6 +554,40 @@ function Dashboard() {
       {/* Display the chart with totals */}
       {dashboardData.stats && <DashboardContent dashboardData={dashboardData} username={username} />}
 
+      {/* Pinned nodes section */}
+      {dashboardData.pinned_nodes && dashboardData.pinned_nodes.length > 0 && (
+        <>
+          <h3 style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 300,
+            fontSize: "1.4rem",
+            color: "var(--text-primary)",
+            marginTop: "40px",
+            textAlign: "left"
+          }}>
+            Pinned
+          </h3>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              maxWidth: "1000px",
+              alignItems: "flex-start"
+            }}
+          >
+            {dashboardData.pinned_nodes.map((node) => (
+              <Bubble
+                key={`pinned-${node.id}`}
+                node={node}
+                isHighlighted={true}
+                leftAlign={true}
+                onClick={() => navigate(`/node/${node.id}`)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
       {/* Graphical (bubble-style) view of top-level entries */}
       <h3 style={{
         fontFamily: "var(--serif)",

--- a/frontend/src/components/NodeFooter.js
+++ b/frontend/src/components/NodeFooter.js
@@ -3,17 +3,23 @@ import { Link } from 'react-router-dom';
 import { FaRegCommentDots } from 'react-icons/fa';
 import { useUser } from '../contexts/UserContext';
 
-const NodeFooter = ({ username, createdAt, childrenCount }) => {
+const NodeFooter = ({ username, createdAt, childrenCount, humanOwnerUsername, llmModel, children }) => {
   const { user } = useUser();
-  // If the username passed to NodeFooter is the same as the logged-in user's username,
-  // use "/dashboard" for the link. Otherwise, use "/dashboard/username" for the public dashboard.
-  const linkUrl = user && user.username === username ? '/dashboard' : `/dashboard/${username}`;
+
+  // "via" display: show "humanOwner via model" for LLM nodes
+  const displayUsername = humanOwnerUsername && llmModel
+    ? `${humanOwnerUsername} via ${llmModel}`
+    : username;
+
+  // Link goes to human owner's dashboard for LLM nodes
+  const linkUsername = humanOwnerUsername || username;
+  const linkUrl = user && user.username === linkUsername ? '/dashboard' : `/dashboard/${linkUsername}`;
   const formattedDateTime = createdAt ? new Date(createdAt).toLocaleString() : "";
 
   return (
     <div style={footerStyle}>
       <Link to={linkUrl} style={{ color: "var(--text-muted)", textDecoration: "none", transition: "color 0.3s ease" }}>
-        {username}
+        {displayUsername}
       </Link>
       <span style={{ color: "var(--border)" }}>&middot;</span>
       <span>{formattedDateTime}</span>
@@ -23,6 +29,11 @@ const NodeFooter = ({ username, createdAt, childrenCount }) => {
           <FaRegCommentDots />
           <span>{childrenCount}</span>
         </>
+      )}
+      {children && (
+        <span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "4px" }}>
+          {children}
+        </span>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Users can pin any node they own to their profile, surfacing it on their Dashboard (new "Pinned" section) and in the global Feed (sorted by pin timestamp)
- Pinned LLM nodes display transparent "alice via claude-opus-4.5" attribution in NodeFooter
- Private nodes cannot be pinned; changing a pinned node to private auto-unpins it
- LLM Response button is now restricted to node owners only
- Voice Note tag in Bubble now uses backend-provided `has_audio` flag instead of broken client-side detection
- Documents exact CI linter commands (`flake8`, `pytest`, `npm run build`) in CLAUDE.md

## Test plan
- [x] Backend: `python -m pytest` — 111 tests pass
- [x] Backend: `flake8 backend --select=E9,F63,F7,F82` — 0 fatal errors
- [x] Frontend: `npm run build` — compiles with 0 warnings
- [x] Manual: create a nested node, make it public, pin it → appears in Dashboard pinned section and Feed
- [x] Manual: change pinned node to private → auto-unpins
- [x] Manual: pin an LLM response → "via" display shows on Dashboard and Feed
- [x] Manual: verify pin/speaker/download icons appear in footer row on NodeDetail
- [x] Manual: verify Voice Note tag shows in Bubble for audio nodes
- [x] Manual: verify LLM Response button only shows for node owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)