### PR TITLE
Switch profile TTS to SSE streaming

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -313,8 +313,9 @@ class TTSChunk(db.Model):
     can be played immediately while subsequent chunks are still generating.
     """
     id = db.Column(db.Integer, primary_key=True)
-    # Which node this TTS chunk belongs to
-    node_id = db.Column(db.Integer, db.ForeignKey("node.id"), nullable=False)
+    # Which node or profile this TTS chunk belongs to (one must be set)
+    node_id = db.Column(db.Integer, db.ForeignKey("node.id"), nullable=True)
+    profile_id = db.Column(db.Integer, db.ForeignKey("user_profile.id"), nullable=True)
     # Zero-based index of the chunk
     chunk_index = db.Column(db.Integer, nullable=False)
     # URL to the audio chunk file
@@ -326,10 +327,12 @@ class TTSChunk(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     completed_at = db.Column(db.DateTime, nullable=True)
 
-    # Relationship back to node
+    # Relationships
     node = db.relationship("Node", backref="tts_chunks")
+    profile = db.relationship("UserProfile", backref="tts_chunks")
 
-    # Unique constraint: one chunk per index per node
+    # Unique constraints: one chunk per index per node/profile
     __table_args__ = (
         db.UniqueConstraint('node_id', 'chunk_index', name='uq_node_tts_chunk_index'),
+        db.UniqueConstraint('profile_id', 'chunk_index', name='uq_profile_tts_chunk_index'),
     )

--- a/backend/routes/sse.py
+++ b/backend/routes/sse.py
@@ -8,7 +8,7 @@ These endpoints provide one-way server-to-client communication for:
 
 from flask import Blueprint, Response, request, jsonify, current_app
 from flask_login import login_required, current_user
-from backend.models import Node, NodeTranscriptChunk, TTSChunk, Draft
+from backend.models import Node, UserProfile, NodeTranscriptChunk, TTSChunk, Draft
 from backend.extensions import db
 import json
 import time
@@ -139,6 +139,108 @@ def transcription_stream(node_id):
     )
 
 
+def _tts_stream_generator(app, entity_cls, entity_id, chunk_fk_attr,
+                          entity_label, last_chunk):
+    """
+    Shared SSE generator for TTS chunk streaming.
+
+    Polls the database for new TTSChunk records and yields SSE events.
+    Works for both nodes and profiles since they share the same
+    tts_task_status / audio_tts_url / tts_task_progress interface.
+
+    Args:
+        app: Flask application object (for app context in generator)
+        entity_cls: SQLAlchemy model class (Node or UserProfile)
+        entity_id: Primary key of the entity
+        chunk_fk_attr: TTSChunk foreign key column name ('node_id' or 'profile_id')
+        entity_label: Human-readable label for error messages
+        last_chunk: Last chunk index the client has already received
+    """
+    last_sent_chunk = last_chunk
+    heartbeat_interval = 15  # seconds
+    last_heartbeat = time.time()
+    max_idle_time = 600  # 10 minutes max connection time
+    start_time = time.time()
+    chunk_filter = {chunk_fk_attr: entity_id}
+
+    while True:
+        if time.time() - start_time > max_idle_time:
+            yield format_sse_message({"message": "Connection timeout"}, event="close")
+            break
+
+        with app.app_context():
+            entity = entity_cls.query.get(entity_id)
+            if not entity:
+                yield format_sse_message(
+                    {"error": f"{entity_label} not found"}, event="error"
+                )
+                break
+
+            # Get any new completed TTS chunks
+            new_chunks = TTSChunk.query.filter(
+                getattr(TTSChunk, chunk_fk_attr) == entity_id,
+                TTSChunk.chunk_index > last_sent_chunk,
+                TTSChunk.status == 'completed'
+            ).order_by(TTSChunk.chunk_index).all()
+
+            for chunk in new_chunks:
+                chunk_data = {
+                    "chunk_index": chunk.chunk_index,
+                    "audio_url": chunk.audio_url,
+                    "status": "ready"
+                }
+                if chunk.duration is not None:
+                    chunk_data["duration"] = chunk.duration
+                yield format_sse_message(chunk_data, event="chunk_ready")
+                last_sent_chunk = chunk.chunk_index
+
+            if entity.tts_task_status == 'completed':
+                yield format_sse_message({
+                    "message": "TTS generation complete",
+                    "tts_url": entity.audio_tts_url
+                }, event="all_complete")
+                break
+
+            if entity.tts_task_status == 'failed':
+                yield format_sse_message({
+                    "message": "TTS generation failed"
+                }, event="error")
+                break
+
+            if time.time() - last_heartbeat > heartbeat_interval:
+                total_chunks = TTSChunk.query.filter_by(**chunk_filter).count()
+                completed_chunks = TTSChunk.query.filter_by(
+                    status='completed', **chunk_filter
+                ).count()
+
+                yield format_sse_message({
+                    "timestamp": time.time(),
+                    "completed_chunks": completed_chunks,
+                    "total_chunks": total_chunks,
+                    "progress": entity.tts_task_progress
+                }, event="heartbeat")
+                last_heartbeat = time.time()
+
+        time.sleep(1)
+
+
+def _tts_stream_response(app, entity_cls, entity_id, chunk_fk_attr,
+                          entity_label, last_chunk):
+    """Wrap the TTS stream generator in an SSE Response."""
+    return Response(
+        _tts_stream_generator(
+            app, entity_cls, entity_id, chunk_fk_attr,
+            entity_label, last_chunk
+        ),
+        mimetype='text/event-stream',
+        headers={
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no'
+        }
+    )
+
+
 @sse_bp.route("/nodes/<int:node_id>/tts-stream")
 @login_required
 def tts_stream(node_id):
@@ -158,14 +260,11 @@ def tts_stream(node_id):
 
     # Check ownership or voice mode access
     if node.user_id != current_user.id and not getattr(current_user, "is_admin", False):
-        # For non-owners, check if they can access via privacy settings
         from backend.utils.privacy import can_user_access_node
         if not can_user_access_node(node, current_user.id):
             return jsonify({"error": "Unauthorized"}), 403
 
-    # Check if TTS is in progress
     if node.tts_task_status not in ['pending', 'processing']:
-        # If already completed, return the final URL
         if node.audio_tts_url:
             return jsonify({
                 "status": "completed",
@@ -173,93 +272,43 @@ def tts_stream(node_id):
             }), 200
         return jsonify({"error": "TTS not in progress for this node"}), 400
 
-    # Get the last chunk index the client has seen
     last_chunk = request.args.get('last_chunk', -1, type=int)
-
-    # Capture app reference for use in generator (needed for app context)
     app = current_app._get_current_object()
+    return _tts_stream_response(app, Node, node_id, 'node_id', 'Node', last_chunk)
 
-    def generate():
-        last_sent_chunk = last_chunk
-        heartbeat_interval = 15  # seconds
-        last_heartbeat = time.time()
-        max_idle_time = 600  # 10 minutes max connection time
-        start_time = time.time()
 
-        while True:
-            # Check for timeout
-            if time.time() - start_time > max_idle_time:
-                yield format_sse_message({"message": "Connection timeout"}, event="close")
-                break
+@sse_bp.route("/profiles/<int:profile_id>/tts-stream")
+@login_required
+def profile_tts_stream(profile_id):
+    """
+    SSE endpoint for real-time TTS audio chunk updates for profiles.
 
-            # Use app context for database operations (generator runs outside request context)
-            with app.app_context():
-                # Re-fetch node to get fresh data
-                current_node = Node.query.get(node_id)
-                if not current_node:
-                    yield format_sse_message({"error": "Node not found"}, event="error")
-                    break
+    Sends events as TTS audio chunks are generated:
+    - event: chunk_ready - An audio chunk is ready to play
+    - event: all_complete - All chunks have been generated
+    - event: error - An error occurred
+    - event: heartbeat - Keep-alive ping
 
-                # Get any new completed TTS chunks
-                new_chunks = TTSChunk.query.filter(
-                    TTSChunk.node_id == node_id,
-                    TTSChunk.chunk_index > last_sent_chunk,
-                    TTSChunk.status == 'completed'
-                ).order_by(TTSChunk.chunk_index).all()
+    Query params:
+    - last_chunk: Index of the last chunk the client has received
+    """
+    profile = UserProfile.query.get_or_404(profile_id)
 
-                for chunk in new_chunks:
-                    chunk_data = {
-                        "chunk_index": chunk.chunk_index,
-                        "audio_url": chunk.audio_url,
-                        "status": "ready"
-                    }
-                    if chunk.duration is not None:
-                        chunk_data["duration"] = chunk.duration
-                    yield format_sse_message(chunk_data, event="chunk_ready")
-                    last_sent_chunk = chunk.chunk_index
+    if profile.user_id != current_user.id and not getattr(current_user, "is_admin", False):
+        return jsonify({"error": "Unauthorized"}), 403
 
-                # Check if TTS generation is complete
-                if current_node.tts_task_status == 'completed':
-                    yield format_sse_message({
-                        "message": "TTS generation complete",
-                        "tts_url": current_node.audio_tts_url
-                    }, event="all_complete")
-                    break
+    if profile.tts_task_status not in ['pending', 'processing']:
+        if profile.audio_tts_url:
+            return jsonify({
+                "status": "completed",
+                "tts_url": profile.audio_tts_url
+            }), 200
+        return jsonify({"error": "TTS not in progress for this profile"}), 400
 
-                # Check if TTS generation failed
-                if current_node.tts_task_status == 'failed':
-                    yield format_sse_message({
-                        "message": "TTS generation failed"
-                    }, event="error")
-                    break
-
-                # Send heartbeat to keep connection alive
-                if time.time() - last_heartbeat > heartbeat_interval:
-                    total_chunks = TTSChunk.query.filter_by(node_id=node_id).count()
-                    completed_chunks = TTSChunk.query.filter_by(
-                        node_id=node_id,
-                        status='completed'
-                    ).count()
-
-                    yield format_sse_message({
-                        "timestamp": time.time(),
-                        "completed_chunks": completed_chunks,
-                        "total_chunks": total_chunks,
-                        "progress": current_node.tts_task_progress
-                    }, event="heartbeat")
-                    last_heartbeat = time.time()
-
-            # Sleep briefly before checking again (outside app context)
-            time.sleep(1)
-
-    return Response(
-        generate(),
-        mimetype='text/event-stream',
-        headers={
-            'Cache-Control': 'no-cache',
-            'Connection': 'keep-alive',
-            'X-Accel-Buffering': 'no'  # Disable nginx buffering
-        }
+    last_chunk = request.args.get('last_chunk', -1, type=int)
+    app = current_app._get_current_object()
+    return _tts_stream_response(
+        app, UserProfile, profile_id, 'profile_id', 'Profile', last_chunk
     )
 
 

--- a/backend/tasks/tts.py
+++ b/backend/tasks/tts.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from backend.celery_app import celery, flask_app
 from backend.models import Node, UserProfile, TTSChunk, APICostLog
 from backend.extensions import db
-from backend.utils.audio_processing import chunk_text, adaptive_chunk_text
+from backend.utils.audio_processing import adaptive_chunk_text
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import encrypt_file
 from backend.utils.cost import calculate_audio_cost_microdollars
@@ -57,6 +57,183 @@ class ProfileTTSTask(Task):
                     logger.error(f"TTS generation failed for profile {profile_id}: {exc}")
 
 
+def _generate_tts_chunks(task, entity, text, target_dir, audio_storage_root,
+                         chunk_fk_attr, entity_label):
+    """
+    Shared TTS generation logic for both nodes and profiles.
+
+    Handles text chunking, TTSChunk record creation, audio generation,
+    encryption, concatenation, and cost logging.
+
+    Both Node and UserProfile expose the same interface:
+    tts_task_progress, audio_tts_url, user_id.
+
+    Args:
+        task: Celery task instance (for update_state)
+        entity: Node or UserProfile model instance
+        text: Text content to generate TTS for
+        target_dir: Path to store audio files
+        audio_storage_root: Root path for computing relative media URLs
+        chunk_fk_attr: TTSChunk FK column name ('node_id' or 'profile_id')
+        entity_label: Human-readable label for logging
+
+    Returns:
+        Final media URL string (e.g. '/media/user/1/node/2/tts.mp3')
+    """
+    AUDIO_ROOT = Path(audio_storage_root)
+
+    # Get OpenAI API key
+    api_key = get_openai_chat_key(flask_app.config)
+    if not api_key:
+        raise ValueError(
+            "OpenAI API key not configured "
+            "(set OPENAI_API_KEY_CHAT or OPENAI_API_KEY)"
+        )
+
+    task.update_state(
+        state='PROGRESS', meta={'progress': 20, 'status': 'Preparing'}
+    )
+    entity.tts_task_progress = 20
+    db.session.commit()
+
+    client = OpenAI(api_key=api_key)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    final_path = target_dir / "tts.mp3"
+
+    # Chunk text
+    task.update_state(
+        state='PROGRESS', meta={'progress': 30, 'status': 'Processing text'}
+    )
+    entity.tts_task_progress = 30
+    db.session.commit()
+
+    chunks = adaptive_chunk_text(text)
+    logger.info(
+        f"Text split into {len(chunks)} chunks for TTS "
+        f"for {entity_label} (sizes: {[len(c) for c in chunks]})"
+    )
+
+    # Create TTSChunk records for streaming playback
+    chunk_fk = {chunk_fk_attr: entity.id}
+    for i in range(len(chunks)):
+        tts_chunk = TTSChunk(chunk_index=i, status='pending', **chunk_fk)
+        db.session.add(tts_chunk)
+    db.session.commit()
+
+    if len(chunks) == 1:
+        # Single chunk: direct streaming to MP3
+        task.update_state(
+            state='PROGRESS',
+            meta={'progress': 40, 'status': 'Generating audio'}
+        )
+        entity.tts_task_progress = 40
+        db.session.commit()
+
+        with client.audio.speech.with_streaming_response.create(
+            model="gpt-4o-mini-tts", input=chunks[0], voice="alloy"
+        ) as resp:
+            resp.stream_to_file(final_path)
+
+        segment = AudioSegment.from_file(str(final_path), format="mp3")
+        chunk_duration = len(segment) / 1000.0
+        encrypt_file(str(final_path))
+
+        tts_chunk = TTSChunk.query.filter_by(
+            chunk_index=0, **chunk_fk
+        ).first()
+        if tts_chunk:
+            rel_path = final_path.relative_to(AUDIO_ROOT)
+            tts_chunk.audio_url = f"/media/{rel_path.as_posix()}"
+            tts_chunk.duration = chunk_duration
+            tts_chunk.status = 'completed'
+            tts_chunk.completed_at = datetime.utcnow()
+            db.session.commit()
+
+    else:
+        # Multiple chunks: generate parts for streaming playback
+        audio_parts = []
+        chunk_progress_step = 50 / len(chunks)
+
+        for i, chunk in enumerate(chunks):
+            progress = 40 + int((i + 1) * chunk_progress_step)
+            task.update_state(
+                state='PROGRESS',
+                meta={
+                    'progress': progress,
+                    'status': f'Generating audio chunk {i+1}/{len(chunks)}'
+                }
+            )
+            entity.tts_task_progress = progress
+
+            tts_chunk = TTSChunk.query.filter_by(
+                chunk_index=i, **chunk_fk
+            ).first()
+            if tts_chunk:
+                tts_chunk.status = 'processing'
+            db.session.commit()
+
+            part_path = target_dir / f"tts_chunk_{i}.mp3"
+
+            with client.audio.speech.with_streaming_response.create(
+                model="gpt-4o-mini-tts", input=chunk, voice="alloy"
+            ) as resp:
+                resp.stream_to_file(part_path)
+
+            segment = AudioSegment.from_file(str(part_path), format="mp3")
+            chunk_duration = len(segment) / 1000.0
+            audio_parts.append((i, segment, part_path))
+
+            if tts_chunk:
+                rel_path = part_path.relative_to(AUDIO_ROOT)
+                tts_chunk.audio_url = f"/media/{rel_path.as_posix()}"
+                tts_chunk.duration = chunk_duration
+                tts_chunk.status = 'completed'
+                tts_chunk.completed_at = datetime.utcnow()
+                db.session.commit()
+
+            encrypt_file(str(part_path))
+
+        # Concatenate all segments into final file
+        task.update_state(
+            state='PROGRESS',
+            meta={'progress': 90, 'status': 'Combining audio'}
+        )
+        entity.tts_task_progress = 90
+        db.session.commit()
+
+        combined = sum([part[1] for part in audio_parts])
+        combined.export(final_path, format="mp3")
+        encrypt_file(str(final_path))
+
+    # Log TTS cost based on total audio duration
+    total_duration = 0.0
+    for tc in TTSChunk.query.filter_by(**chunk_fk).all():
+        if tc.duration:
+            total_duration += tc.duration
+    if total_duration > 0:
+        tts_cost = calculate_audio_cost_microdollars(
+            "gpt-4o-mini-tts", total_duration
+        )
+        cost_log = APICostLog(
+            user_id=entity.user_id,
+            model_id="gpt-4o-mini-tts",
+            request_type="tts",
+            audio_duration_seconds=total_duration,
+            cost_microdollars=tts_cost,
+        )
+        db.session.add(cost_log)
+
+    # Finalize
+    task.update_state(
+        state='PROGRESS', meta={'progress': 95, 'status': 'Finalizing'}
+    )
+    entity.tts_task_progress = 95
+    db.session.commit()
+
+    rel_path = final_path.relative_to(AUDIO_ROOT)
+    return f"/media/{rel_path.as_posix()}"
+
+
 @celery.task(base=TTSTask, bind=True)
 def generate_tts_audio(self, node_id: int, audio_storage_root: str):
     """
@@ -69,22 +246,18 @@ def generate_tts_audio(self, node_id: int, audio_storage_root: str):
     logger.info(f"Starting TTS generation task for node {node_id}")
 
     with flask_app.app_context():
-        # Get node from database
         node = Node.query.get(node_id)
         if not node:
             raise ValueError(f"Node {node_id} not found")
 
-        # Update status to processing
         node.tts_task_status = 'processing'
         node.tts_task_progress = 10
         db.session.commit()
 
         try:
-            # Check if original audio exists
             if node.audio_original_url:
                 raise ValueError("Original audio exists – TTS not required")
 
-            # Check if already generated
             if node.audio_tts_url:
                 logger.info(f"TTS already available for node {node_id}")
                 node.tts_task_status = 'completed'
@@ -96,163 +269,20 @@ def generate_tts_audio(self, node_id: int, audio_storage_root: str):
                     'tts_url': node.audio_tts_url
                 }
 
-            # Get OpenAI API key (always use CHAT key for audio operations)
-            api_key = get_openai_chat_key(flask_app.config)
-            if not api_key:
-                raise ValueError("OpenAI API key not configured (set OPENAI_API_KEY_CHAT or OPENAI_API_KEY)")
-
             text = node.get_content() or ""
             if not text:
                 raise ValueError("No content to generate TTS for")
 
-            # Step 1: Initialize client and prepare storage (20% progress)
-            self.update_state(state='PROGRESS', meta={'progress': 20, 'status': 'Preparing'})
-            node.tts_task_progress = 20
-            db.session.commit()
+            target_dir = (
+                Path(audio_storage_root)
+                / f"user/{node.user_id}/node/{node.id}"
+            )
 
-            client = OpenAI(api_key=api_key)
-            AUDIO_STORAGE_ROOT = Path(audio_storage_root)
-            target_dir = AUDIO_STORAGE_ROOT / f"user/{node.user_id}/node/{node.id}"
-            target_dir.mkdir(parents=True, exist_ok=True)
-            final_path = target_dir / "tts.mp3"
+            url = _generate_tts_chunks(
+                self, node, text, target_dir, audio_storage_root,
+                'node_id', f"node {node_id}"
+            )
 
-            # Step 2: Chunk text (30% progress)
-            self.update_state(state='PROGRESS', meta={'progress': 30, 'status': 'Processing text'})
-            node.tts_task_progress = 30
-            db.session.commit()
-
-            chunks = adaptive_chunk_text(text)
-            logger.info(f"Text split into {len(chunks)} chunks for TTS "
-                         f"(sizes: {[len(c) for c in chunks]})")
-
-            # Step 3: Generate TTS (40% -> 90% progress)
-            # Create TTSChunk records for streaming playback
-            for i in range(len(chunks)):
-                tts_chunk = TTSChunk(
-                    node_id=node.id,
-                    chunk_index=i,
-                    status='pending'
-                )
-                db.session.add(tts_chunk)
-            db.session.commit()
-
-            if len(chunks) == 1:
-                # Single chunk: direct streaming to MP3
-                self.update_state(state='PROGRESS', meta={'progress': 40, 'status': 'Generating audio'})
-                node.tts_task_progress = 40
-                db.session.commit()
-
-                with client.audio.speech.with_streaming_response.create(
-                    model="gpt-4o-mini-tts",
-                    input=chunks[0],
-                    voice="alloy"
-                ) as resp:
-                    resp.stream_to_file(final_path)
-
-                # Get duration before encrypting
-                segment = AudioSegment.from_file(str(final_path), format="mp3")
-                chunk_duration = len(segment) / 1000.0  # ms to seconds
-
-                # Encrypt the audio file at rest
-                encrypt_file(str(final_path))
-
-                # Update the single TTSChunk record
-                tts_chunk = TTSChunk.query.filter_by(node_id=node.id, chunk_index=0).first()
-                if tts_chunk:
-                    rel_path = final_path.relative_to(AUDIO_STORAGE_ROOT)
-                    tts_chunk.audio_url = f"/media/{rel_path.as_posix()}"
-                    tts_chunk.duration = chunk_duration
-                    tts_chunk.status = 'completed'
-                    tts_chunk.completed_at = datetime.utcnow()
-                    db.session.commit()
-
-            else:
-                # Multiple chunks: generate parts for streaming playback
-                # Each chunk is immediately available for streaming as soon as it's generated
-                audio_parts = []
-                chunk_progress_step = 50 / len(chunks)  # 40% -> 90% split across chunks
-
-                for i, chunk in enumerate(chunks):
-                    progress = 40 + int((i + 1) * chunk_progress_step)
-                    self.update_state(
-                        state='PROGRESS',
-                        meta={
-                            'progress': progress,
-                            'status': f'Generating audio chunk {i+1}/{len(chunks)}'
-                        }
-                    )
-                    node.tts_task_progress = progress
-
-                    # Update TTSChunk status to processing
-                    tts_chunk = TTSChunk.query.filter_by(node_id=node.id, chunk_index=i).first()
-                    if tts_chunk:
-                        tts_chunk.status = 'processing'
-                    db.session.commit()
-
-                    # Store each chunk separately for streaming playback
-                    part_path = target_dir / f"tts_chunk_{i}.mp3"
-
-                    with client.audio.speech.with_streaming_response.create(
-                        model="gpt-4o-mini-tts",
-                        input=chunk,
-                        voice="alloy"
-                    ) as resp:
-                        resp.stream_to_file(part_path)
-
-                    # Load into AudioSegment for final concatenation BEFORE encrypting
-                    segment = AudioSegment.from_file(str(part_path), format="mp3")
-                    chunk_duration = len(segment) / 1000.0  # ms to seconds
-                    audio_parts.append((i, segment, part_path))
-
-                    # Update TTSChunk with URL and duration immediately (for streaming playback)
-                    if tts_chunk:
-                        rel_path = part_path.relative_to(AUDIO_STORAGE_ROOT)
-                        tts_chunk.audio_url = f"/media/{rel_path.as_posix()}"
-                        tts_chunk.duration = chunk_duration
-                        tts_chunk.status = 'completed'
-                        tts_chunk.completed_at = datetime.utcnow()
-                        db.session.commit()
-
-                    # Encrypt the chunk file at rest (for streaming playback)
-                    encrypt_file(str(part_path))
-
-                # Concatenate all segments into final file
-                self.update_state(state='PROGRESS', meta={'progress': 90, 'status': 'Combining audio'})
-                node.tts_task_progress = 90
-                db.session.commit()
-
-                combined = sum([part[1] for part in audio_parts])
-                combined.export(final_path, format="mp3")
-
-                # Encrypt the combined final file at rest
-                encrypt_file(str(final_path))
-
-            # Log TTS cost based on total audio duration
-            total_tts_duration = 0.0
-            tts_chunks_all = TTSChunk.query.filter_by(node_id=node.id).all()
-            for tc in tts_chunks_all:
-                if tc.duration:
-                    total_tts_duration += tc.duration
-            if total_tts_duration > 0:
-                tts_cost = calculate_audio_cost_microdollars(
-                    "gpt-4o-mini-tts", total_tts_duration
-                )
-                cost_log = APICostLog(
-                    user_id=node.user_id,
-                    model_id="gpt-4o-mini-tts",
-                    request_type="tts",
-                    audio_duration_seconds=total_tts_duration,
-                    cost_microdollars=tts_cost,
-                )
-                db.session.add(cost_log)
-
-            # Step 4: Update node record (95% progress)
-            self.update_state(state='PROGRESS', meta={'progress': 95, 'status': 'Finalizing'})
-            node.tts_task_progress = 95
-            db.session.commit()
-
-            rel_path = final_path.relative_to(AUDIO_STORAGE_ROOT)
-            url = f"/media/{rel_path.as_posix()}"
             node.audio_tts_url = url
             node.audio_mime_type = "audio/mpeg"
             node.tts_task_status = 'completed'
@@ -260,7 +290,6 @@ def generate_tts_audio(self, node_id: int, audio_storage_root: str):
             db.session.commit()
 
             logger.info(f"TTS generation successful for node {node_id}")
-
             return {
                 'node_id': node_id,
                 'status': 'completed',
@@ -268,14 +297,18 @@ def generate_tts_audio(self, node_id: int, audio_storage_root: str):
             }
 
         except Exception as e:
-            logger.error(f"TTS generation error for node {node_id}: {e}", exc_info=True)
+            logger.error(
+                f"TTS generation error for node {node_id}: {e}",
+                exc_info=True
+            )
             node.tts_task_status = 'failed'
             db.session.commit()
             raise
 
 
 @celery.task(base=ProfileTTSTask, bind=True)
-def generate_tts_audio_for_profile(self, profile_id: int, audio_storage_root: str):
+def generate_tts_audio_for_profile(self, profile_id: int,
+                                   audio_storage_root: str):
     """
     Asynchronously generate TTS audio for a user profile.
 
@@ -296,7 +329,9 @@ def generate_tts_audio_for_profile(self, profile_id: int, audio_storage_root: st
 
         try:
             if profile.audio_tts_url:
-                logger.info(f"TTS already available for profile {profile_id}")
+                logger.info(
+                    f"TTS already available for profile {profile_id}"
+                )
                 profile.tts_task_status = 'completed'
                 profile.tts_task_progress = 100
                 db.session.commit()
@@ -306,124 +341,28 @@ def generate_tts_audio_for_profile(self, profile_id: int, audio_storage_root: st
                     'tts_url': profile.audio_tts_url
                 }
 
-            # Get OpenAI API key (always use CHAT key for audio operations)
-            api_key = get_openai_chat_key(flask_app.config)
-            if not api_key:
-                raise ValueError("OpenAI API key not configured (set OPENAI_API_KEY_CHAT or OPENAI_API_KEY)")
-
             text = profile.get_content() or ""
             if not text:
                 raise ValueError("No content to generate TTS for")
 
-            self.update_state(state='PROGRESS', meta={'progress': 20, 'status': 'Preparing'})
-            profile.tts_task_progress = 20
-            db.session.commit()
+            target_dir = (
+                Path(audio_storage_root)
+                / f"user/{profile.user_id}/profile/{profile.id}"
+            )
 
-            client = OpenAI(api_key=api_key)
-            AUDIO_STORAGE_ROOT = Path(audio_storage_root)
-            target_dir = AUDIO_STORAGE_ROOT / f"user/{profile.user_id}/profile/{profile.id}"
-            target_dir.mkdir(parents=True, exist_ok=True)
-            final_path = target_dir / "tts.mp3"
+            url = _generate_tts_chunks(
+                self, profile, text, target_dir, audio_storage_root,
+                'profile_id', f"profile {profile_id}"
+            )
 
-            self.update_state(state='PROGRESS', meta={'progress': 30, 'status': 'Processing text'})
-            profile.tts_task_progress = 30
-            db.session.commit()
-
-            chunks = chunk_text(text, max_chars=4096)
-            logger.info(f"Text split into {len(chunks)} chunks for TTS for profile {profile_id}")
-
-            total_profile_tts_duration = 0.0
-
-            if len(chunks) == 1:
-                self.update_state(state='PROGRESS', meta={'progress': 40, 'status': 'Generating audio'})
-                profile.tts_task_progress = 40
-                db.session.commit()
-
-                with client.audio.speech.with_streaming_response.create(
-                    model="gpt-4o-mini-tts",
-                    input=chunks[0],
-                    voice="alloy"
-                ) as resp:
-                    resp.stream_to_file(final_path)
-
-                # Get duration before encrypting
-                segment = AudioSegment.from_file(str(final_path), format="mp3")
-                total_profile_tts_duration = len(segment) / 1000.0
-
-                # Encrypt the audio file at rest
-                encrypt_file(str(final_path))
-            else:
-                audio_parts = []
-                chunk_progress_step = 50 / len(chunks)
-
-                for i, chunk in enumerate(chunks):
-                    progress = 40 + int((i + 1) * chunk_progress_step)
-                    self.update_state(
-                        state='PROGRESS',
-                        meta={
-                            'progress': progress,
-                            'status': f'Generating audio chunk {i+1}/{len(chunks)}'
-                        }
-                    )
-                    profile.tts_task_progress = progress
-                    db.session.commit()
-
-                    part_path = target_dir / f"tts_part{i}.mp3"
-
-                    with client.audio.speech.with_streaming_response.create(
-                        model="gpt-4o-mini-tts",
-                        input=chunk,
-                        voice="alloy"
-                    ) as resp:
-                        resp.stream_to_file(part_path)
-
-                    segment = AudioSegment.from_file(str(part_path), format="mp3")
-                    total_profile_tts_duration += len(segment) / 1000.0
-                    audio_parts.append(segment)
-
-                    # Encrypt or delete the part file
-                    try:
-                        part_path.unlink()
-                    except Exception as e:
-                        logger.warning(f"Failed to delete part file: {e}")
-
-                self.update_state(state='PROGRESS', meta={'progress': 90, 'status': 'Combining audio'})
-                profile.tts_task_progress = 90
-                db.session.commit()
-
-                combined = sum(audio_parts)
-                combined.export(final_path, format="mp3")
-
-                # Encrypt the combined final file at rest
-                encrypt_file(str(final_path))
-
-            # Log TTS cost
-            if total_profile_tts_duration > 0:
-                tts_cost = calculate_audio_cost_microdollars(
-                    "gpt-4o-mini-tts", total_profile_tts_duration
-                )
-                cost_log = APICostLog(
-                    user_id=profile.user_id,
-                    model_id="gpt-4o-mini-tts",
-                    request_type="tts",
-                    audio_duration_seconds=total_profile_tts_duration,
-                    cost_microdollars=tts_cost,
-                )
-                db.session.add(cost_log)
-
-            self.update_state(state='PROGRESS', meta={'progress': 95, 'status': 'Finalizing'})
-            profile.tts_task_progress = 95
-            db.session.commit()
-
-            rel_path = final_path.relative_to(AUDIO_STORAGE_ROOT)
-            url = f"/media/{rel_path.as_posix()}"
             profile.audio_tts_url = url
             profile.tts_task_status = 'completed'
             profile.tts_task_progress = 100
             db.session.commit()
 
-            logger.info(f"TTS generation successful for profile {profile_id}")
-
+            logger.info(
+                f"TTS generation successful for profile {profile_id}"
+            )
             return {
                 'profile_id': profile_id,
                 'status': 'completed',
@@ -431,7 +370,10 @@ def generate_tts_audio_for_profile(self, profile_id: int, audio_storage_root: st
             }
 
         except Exception as e:
-            logger.error(f"TTS generation error for profile {profile_id}: {e}", exc_info=True)
+            logger.error(
+                f"TTS generation error for profile {profile_id}: {e}",
+                exc_info=True
+            )
             profile.tts_task_status = 'failed'
             db.session.commit()
             raise

--- a/frontend/src/hooks/useSSE.js
+++ b/frontend/src/hooks/useSSE.js
@@ -419,15 +419,17 @@ export function useDraftTranscriptionSSE(sessionId, options = {}) {
 /**
  * useTTSStreamSSE - Specialized hook for streaming TTS playback updates.
  *
- * @param {number} nodeId - Node ID to subscribe to
+ * @param {number} entityId - Node or Profile ID to subscribe to
  * @param {Object} options
  * @param {boolean} options.enabled - Whether to connect
+ * @param {string} options.entityType - 'node' (default) or 'profile'
  * @param {Function} options.onChunkReady - Called when an audio chunk is ready
  * @param {Function} options.onAllComplete - Called when all chunks are done
  */
-export function useTTSStreamSSE(nodeId, options = {}) {
+export function useTTSStreamSSE(entityId, options = {}) {
   const {
     enabled = false,
+    entityType = 'node',
     onChunkReady = null,
     onAllComplete = null,
   } = options;
@@ -447,7 +449,10 @@ export function useTTSStreamSSE(nodeId, options = {}) {
 
   // Use REACT_APP_BACKEND_URL for SSE since EventSource doesn't go through CRA proxy
   const backendUrl = process.env.REACT_APP_BACKEND_URL || '';
-  const url = nodeId ? `${backendUrl}/api/sse/nodes/${nodeId}/tts-stream` : null;
+  const ssePathSegment = entityType === 'profile'
+    ? `profiles/${entityId}`
+    : `nodes/${entityId}`;
+  const url = entityId ? `${backendUrl}/api/sse/${ssePathSegment}/tts-stream` : null;
 
   // Memoize eventHandlers to prevent unnecessary reconnections
   // Handlers use refs internally to always call latest callbacks


### PR DESCRIPTION
## Summary
- Profile TTS now uses SSE streaming instead of polling, so playback starts on the first chunk rather than waiting for all chunks to finish
- Extracted shared helpers (`_generate_tts_chunks`, `_tts_stream_generator`) to eliminate duplication between node and profile TTS code paths
- Added `profile_id` to `TTSChunk` model and new `/profiles/<id>/tts-stream` SSE endpoint
- Generalized `useTTSStreamSSE` hook with `entityType` param; `SpeakerIcon` now uses SSE for both nodes and profiles

## Test plan
- [x] Click speaker icon on a profile — playback should start after first chunk, not after all chunks finish
- [x] Click speaker icon on a node — verify existing SSE streaming still works
- [x] Verify replay of cached audio still works for both nodes and profiles
- [x] Check that TTS cost logging works correctly for profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)