### PR TITLE
Fix voice recording truncated to first chunk on some devices

### DIFF
--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -3,7 +3,6 @@ from flask_login import login_required, current_user
 from backend.models import Draft, Node, NodeTranscriptChunk
 from backend.extensions import db
 from backend.utils.privacy import can_user_edit_node
-from backend.utils.webm_utils import fix_last_chunk_duration, is_ffmpeg_available
 import uuid
 import pathlib
 import os
@@ -457,8 +456,7 @@ def upload_streaming_chunk(session_id):
     # Chunk 0 carries the EBML/Segment/Tracks init segment — the bytes that
     # every later batch needs as a prefix to remain a valid WebM (chunks 1+
     # are raw cluster fragments with no header). Extract and persist it now,
-    # before encrypt_file() deletes the plaintext chunk. Never changes for
-    # the rest of the recording.
+    # before encrypt_file() deletes the plaintext chunk.
     #
     # Reject the upload if extraction fails: batch 1 (chunks 0..19) would
     # still succeed because chunk 0 carries its own header, but any batch
@@ -466,10 +464,9 @@ def upload_streaming_chunk(session_id):
     # Better to surface the problem on the first chunk than silently lose
     # later audio.
     if chunk_index == 0:
-        from backend.utils.webm_utils import extract_webm_init_segment
+        from backend.utils.webm_utils import persist_init_segment
         try:
-            with open(chunk_path, 'rb') as f:
-                init_bytes = extract_webm_init_segment(f.read())
+            persist_init_segment(chunk_path, chunk_dir)
         except Exception as exc:
             current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
@@ -482,11 +479,8 @@ def upload_streaming_chunk(session_id):
             return jsonify({
                 "error": "Could not parse WebM header from first chunk",
                 "detail": str(exc),
+                "code": "webm_header_parse_failed",
             }), 500
-        init_path = chunk_dir / "init.webm"
-        with open(init_path, 'wb') as f:
-            f.write(init_bytes)
-        encrypt_file(str(init_path))
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
@@ -815,20 +809,15 @@ def save_streaming_as_node(session_id):
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
     if draft_audio_dir.exists():
-        # Fix the last chunk's duration metadata before moving (if not already fixed during finalization)
-        if is_ffmpeg_available():
-            success, message = fix_last_chunk_duration(str(draft_audio_dir))
-            if success:
-                current_app.logger.info(f"Fixed last chunk duration: {message}")
-            else:
-                current_app.logger.warning(f"Could not fix last chunk duration: {message}")
-
         try:
             # Create node audio directory
             node_audio_dir.mkdir(parents=True, exist_ok=True)
 
-            # Move all files
+            # Move all files (init.webm is ephemeral — drop instead of move)
             for file_path in draft_audio_dir.iterdir():
+                if file_path.name.startswith("init.webm"):
+                    file_path.unlink()
+                    continue
                 shutil.move(str(file_path), str(node_audio_dir / file_path.name))
 
             # Remove the empty draft directory

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -7,6 +7,7 @@ import uuid
 import pathlib
 import os
 import shutil
+from backend.utils.audio_storage import move_draft_audio_to_node_dir
 from backend.utils.encryption import encrypt_file
 from backend.utils.webm_utils import persist_init_segment
 
@@ -482,11 +483,14 @@ def upload_streaming_chunk(session_id):
                 chunk_path.unlink()
             except OSError:
                 pass
+            # 400 Bad Request: the client sent bytes the server can't
+            # parse. Not a server failure, so it shouldn't count in the
+            # 5xx alert dashboards.
             return jsonify({
                 "error": "Could not parse WebM header from first chunk",
                 "detail": str(exc),
                 "code": "webm_header_parse_failed",
-            }), 500
+            }), 400
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
@@ -814,7 +818,6 @@ def save_streaming_as_node(session_id):
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{current_user.id}/{session_id}"
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
-    from backend.utils.audio_storage import move_draft_audio_to_node_dir
     move_draft_audio_to_node_dir(
         draft_audio_dir, node_audio_dir, current_app.logger,
     )

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -454,6 +454,27 @@ def upload_streaming_chunk(session_id):
     chunk_path = chunk_dir / chunk_filename
     chunk_file.save(chunk_path)
 
+    # Chunk 0 carries the EBML/Segment/Tracks init segment — the bytes that
+    # every later batch needs as a prefix to remain a valid WebM (chunks 1+
+    # are raw cluster fragments with no header). Extract and persist it now,
+    # before encrypt_file() deletes the plaintext chunk. Never changes for
+    # the rest of the recording.
+    if chunk_index == 0:
+        from backend.utils.webm_utils import extract_webm_init_segment
+        try:
+            with open(chunk_path, 'rb') as f:
+                init_bytes = extract_webm_init_segment(f.read())
+        except Exception as exc:
+            current_app.logger.warning(
+                f"Failed to extract init segment from chunk 0 of "
+                f"session {session_id}: {exc}"
+            )
+        else:
+            init_path = chunk_dir / "init.webm"
+            with open(init_path, 'wb') as f:
+                f.write(init_bytes)
+            encrypt_file(str(init_path))
+
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
 

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -8,6 +8,7 @@ import pathlib
 import os
 import shutil
 from backend.utils.encryption import encrypt_file
+from backend.utils.webm_utils import persist_init_segment
 
 drafts_bp = Blueprint("drafts_bp", __name__)
 
@@ -464,7 +465,6 @@ def upload_streaming_chunk(session_id):
     # Better to surface the problem on the first chunk than silently lose
     # later audio.
     if chunk_index == 0:
-        from backend.utils.webm_utils import persist_init_segment
         # Narrow to the failure modes that actually signal "bad browser
         # output": ValueError from the EBML walker and OSError from the
         # file write. Anything else (e.g. KMS outage in encrypt_file) is
@@ -814,26 +814,10 @@ def save_streaming_as_node(session_id):
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{current_user.id}/{session_id}"
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
-    if draft_audio_dir.exists():
-        try:
-            # Create node audio directory
-            node_audio_dir.mkdir(parents=True, exist_ok=True)
-
-            # Move all files (init.webm is ephemeral — drop instead of move)
-            for file_path in draft_audio_dir.iterdir():
-                if file_path.name.startswith("init.webm"):
-                    file_path.unlink()
-                    continue
-                shutil.move(str(file_path), str(node_audio_dir / file_path.name))
-
-            # Remove the empty draft directory
-            draft_audio_dir.rmdir()
-
-            current_app.logger.info(
-                f"Moved audio files from {draft_audio_dir} to {node_audio_dir}"
-            )
-        except Exception as e:
-            current_app.logger.warning(f"Failed to move audio files: {e}")
+    from backend.utils.audio_storage import move_draft_audio_to_node_dir
+    move_draft_audio_to_node_dir(
+        draft_audio_dir, node_audio_dir, current_app.logger,
+    )
 
     # Update transcript chunks to reference the node
     NodeTranscriptChunk.query.filter_by(session_id=session_id).update({

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -465,9 +465,15 @@ def upload_streaming_chunk(session_id):
     # later audio.
     if chunk_index == 0:
         from backend.utils.webm_utils import persist_init_segment
+        # Narrow to the failure modes that actually signal "bad browser
+        # output": ValueError from the EBML walker and OSError from the
+        # file write. Anything else (e.g. KMS outage in encrypt_file) is
+        # not the client's fault and should propagate as a 500 by the
+        # usual Flask error path rather than getting misattributed to a
+        # parse failure the user can't do anything about.
         try:
             persist_init_segment(chunk_path, chunk_dir)
-        except Exception as exc:
+        except (ValueError, OSError) as exc:
             current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
                 f"session {session_id}: {exc}"

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -459,21 +459,34 @@ def upload_streaming_chunk(session_id):
     # are raw cluster fragments with no header). Extract and persist it now,
     # before encrypt_file() deletes the plaintext chunk. Never changes for
     # the rest of the recording.
+    #
+    # Reject the upload if extraction fails: batch 1 (chunks 0..19) would
+    # still succeed because chunk 0 carries its own header, but any batch
+    # starting at chunk 20+ would fail silently for want of an init segment.
+    # Better to surface the problem on the first chunk than silently lose
+    # later audio.
     if chunk_index == 0:
         from backend.utils.webm_utils import extract_webm_init_segment
         try:
             with open(chunk_path, 'rb') as f:
                 init_bytes = extract_webm_init_segment(f.read())
         except Exception as exc:
-            current_app.logger.warning(
+            current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
                 f"session {session_id}: {exc}"
             )
-        else:
-            init_path = chunk_dir / "init.webm"
-            with open(init_path, 'wb') as f:
-                f.write(init_bytes)
-            encrypt_file(str(init_path))
+            try:
+                chunk_path.unlink()
+            except OSError:
+                pass
+            return jsonify({
+                "error": "Could not parse WebM header from first chunk",
+                "detail": str(exc),
+            }), 500
+        init_path = chunk_dir / "init.webm"
+        with open(init_path, 'wb') as f:
+            f.write(init_bytes)
+        encrypt_file(str(init_path))
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -9,6 +9,7 @@ import os
 import shutil
 from backend.utils.encryption import encrypt_file
 from backend.utils.llm_nodes import pick_model_for_generation
+from backend.utils.webm_utils import persist_init_segment
 
 drafts_bp = Blueprint("drafts_bp", __name__)
 
@@ -465,7 +466,6 @@ def upload_streaming_chunk(session_id):
     # Better to surface the problem on the first chunk than silently lose
     # later audio.
     if chunk_index == 0:
-        from backend.utils.webm_utils import persist_init_segment
         # Narrow to the failure modes that actually signal "bad browser
         # output": ValueError from the EBML walker and OSError from the
         # file write. Anything else (e.g. KMS outage in encrypt_file) is
@@ -818,26 +818,10 @@ def save_streaming_as_node(session_id):
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{current_user.id}/{session_id}"
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
-    if draft_audio_dir.exists():
-        try:
-            # Create node audio directory
-            node_audio_dir.mkdir(parents=True, exist_ok=True)
-
-            # Move all files (init.webm is ephemeral — drop instead of move)
-            for file_path in draft_audio_dir.iterdir():
-                if file_path.name.startswith("init.webm"):
-                    file_path.unlink()
-                    continue
-                shutil.move(str(file_path), str(node_audio_dir / file_path.name))
-
-            # Remove the empty draft directory
-            draft_audio_dir.rmdir()
-
-            current_app.logger.info(
-                f"Moved audio files from {draft_audio_dir} to {node_audio_dir}"
-            )
-        except Exception as e:
-            current_app.logger.warning(f"Failed to move audio files: {e}")
+    from backend.utils.audio_storage import move_draft_audio_to_node_dir
+    move_draft_audio_to_node_dir(
+        draft_audio_dir, node_audio_dir, current_app.logger,
+    )
 
     # Update transcript chunks to reference the node
     NodeTranscriptChunk.query.filter_by(session_id=session_id).update({

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -466,9 +466,15 @@ def upload_streaming_chunk(session_id):
     # later audio.
     if chunk_index == 0:
         from backend.utils.webm_utils import persist_init_segment
+        # Narrow to the failure modes that actually signal "bad browser
+        # output": ValueError from the EBML walker and OSError from the
+        # file write. Anything else (e.g. KMS outage in encrypt_file) is
+        # not the client's fault and should propagate as a 500 by the
+        # usual Flask error path rather than getting misattributed to a
+        # parse failure the user can't do anything about.
         try:
             persist_init_segment(chunk_path, chunk_dir)
-        except Exception as exc:
+        except (ValueError, OSError) as exc:
             current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
                 f"session {session_id}: {exc}"

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -460,21 +460,34 @@ def upload_streaming_chunk(session_id):
     # are raw cluster fragments with no header). Extract and persist it now,
     # before encrypt_file() deletes the plaintext chunk. Never changes for
     # the rest of the recording.
+    #
+    # Reject the upload if extraction fails: batch 1 (chunks 0..19) would
+    # still succeed because chunk 0 carries its own header, but any batch
+    # starting at chunk 20+ would fail silently for want of an init segment.
+    # Better to surface the problem on the first chunk than silently lose
+    # later audio.
     if chunk_index == 0:
         from backend.utils.webm_utils import extract_webm_init_segment
         try:
             with open(chunk_path, 'rb') as f:
                 init_bytes = extract_webm_init_segment(f.read())
         except Exception as exc:
-            current_app.logger.warning(
+            current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
                 f"session {session_id}: {exc}"
             )
-        else:
-            init_path = chunk_dir / "init.webm"
-            with open(init_path, 'wb') as f:
-                f.write(init_bytes)
-            encrypt_file(str(init_path))
+            try:
+                chunk_path.unlink()
+            except OSError:
+                pass
+            return jsonify({
+                "error": "Could not parse WebM header from first chunk",
+                "detail": str(exc),
+            }), 500
+        init_path = chunk_dir / "init.webm"
+        with open(init_path, 'wb') as f:
+            f.write(init_bytes)
+        encrypt_file(str(init_path))
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -7,6 +7,7 @@ import uuid
 import pathlib
 import os
 import shutil
+from backend.utils.audio_storage import move_draft_audio_to_node_dir
 from backend.utils.encryption import encrypt_file
 from backend.utils.llm_nodes import pick_model_for_generation
 from backend.utils.webm_utils import persist_init_segment
@@ -483,11 +484,14 @@ def upload_streaming_chunk(session_id):
                 chunk_path.unlink()
             except OSError:
                 pass
+            # 400 Bad Request: the client sent bytes the server can't
+            # parse. Not a server failure, so it shouldn't count in the
+            # 5xx alert dashboards.
             return jsonify({
                 "error": "Could not parse WebM header from first chunk",
                 "detail": str(exc),
                 "code": "webm_header_parse_failed",
-            }), 500
+            }), 400
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
@@ -818,7 +822,6 @@ def save_streaming_as_node(session_id):
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{current_user.id}/{session_id}"
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
-    from backend.utils.audio_storage import move_draft_audio_to_node_dir
     move_draft_audio_to_node_dir(
         draft_audio_dir, node_audio_dir, current_app.logger,
     )

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -3,7 +3,6 @@ from flask_login import login_required, current_user
 from backend.models import Draft, Node, NodeTranscriptChunk
 from backend.extensions import db
 from backend.utils.privacy import can_user_edit_node
-from backend.utils.webm_utils import fix_last_chunk_duration, is_ffmpeg_available
 import uuid
 import pathlib
 import os
@@ -458,8 +457,7 @@ def upload_streaming_chunk(session_id):
     # Chunk 0 carries the EBML/Segment/Tracks init segment — the bytes that
     # every later batch needs as a prefix to remain a valid WebM (chunks 1+
     # are raw cluster fragments with no header). Extract and persist it now,
-    # before encrypt_file() deletes the plaintext chunk. Never changes for
-    # the rest of the recording.
+    # before encrypt_file() deletes the plaintext chunk.
     #
     # Reject the upload if extraction fails: batch 1 (chunks 0..19) would
     # still succeed because chunk 0 carries its own header, but any batch
@@ -467,10 +465,9 @@ def upload_streaming_chunk(session_id):
     # Better to surface the problem on the first chunk than silently lose
     # later audio.
     if chunk_index == 0:
-        from backend.utils.webm_utils import extract_webm_init_segment
+        from backend.utils.webm_utils import persist_init_segment
         try:
-            with open(chunk_path, 'rb') as f:
-                init_bytes = extract_webm_init_segment(f.read())
+            persist_init_segment(chunk_path, chunk_dir)
         except Exception as exc:
             current_app.logger.error(
                 f"Failed to extract init segment from chunk 0 of "
@@ -483,11 +480,8 @@ def upload_streaming_chunk(session_id):
             return jsonify({
                 "error": "Could not parse WebM header from first chunk",
                 "detail": str(exc),
+                "code": "webm_header_parse_failed",
             }), 500
-        init_path = chunk_dir / "init.webm"
-        with open(init_path, 'wb') as f:
-            f.write(init_bytes)
-        encrypt_file(str(init_path))
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
@@ -819,20 +813,15 @@ def save_streaming_as_node(session_id):
     node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{current_user.id}/{node.id}"
 
     if draft_audio_dir.exists():
-        # Fix the last chunk's duration metadata before moving (if not already fixed during finalization)
-        if is_ffmpeg_available():
-            success, message = fix_last_chunk_duration(str(draft_audio_dir))
-            if success:
-                current_app.logger.info(f"Fixed last chunk duration: {message}")
-            else:
-                current_app.logger.warning(f"Could not fix last chunk duration: {message}")
-
         try:
             # Create node audio directory
             node_audio_dir.mkdir(parents=True, exist_ok=True)
 
-            # Move all files
+            # Move all files (init.webm is ephemeral — drop instead of move)
             for file_path in draft_audio_dir.iterdir():
+                if file_path.name.startswith("init.webm"):
+                    file_path.unlink()
+                    continue
                 shutil.move(str(file_path), str(node_audio_dir / file_path.name))
 
             # Remove the empty draft directory

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -455,6 +455,27 @@ def upload_streaming_chunk(session_id):
     chunk_path = chunk_dir / chunk_filename
     chunk_file.save(chunk_path)
 
+    # Chunk 0 carries the EBML/Segment/Tracks init segment — the bytes that
+    # every later batch needs as a prefix to remain a valid WebM (chunks 1+
+    # are raw cluster fragments with no header). Extract and persist it now,
+    # before encrypt_file() deletes the plaintext chunk. Never changes for
+    # the rest of the recording.
+    if chunk_index == 0:
+        from backend.utils.webm_utils import extract_webm_init_segment
+        try:
+            with open(chunk_path, 'rb') as f:
+                init_bytes = extract_webm_init_segment(f.read())
+        except Exception as exc:
+            current_app.logger.warning(
+                f"Failed to extract init segment from chunk 0 of "
+                f"session {session_id}: {exc}"
+            )
+        else:
+            init_path = chunk_dir / "init.webm"
+            with open(init_path, 'wb') as f:
+                f.write(init_bytes)
+            encrypt_file(str(init_path))
+
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
 

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -17,7 +17,7 @@ from backend.celery_app import celery, flask_app
 from backend.models import Node, NodeTranscriptChunk, Draft, APICostLog
 from backend.extensions import db
 from backend.utils.audio_processing import compress_audio_if_needed, get_audio_duration
-from backend.utils.webm_utils import concat_audio_files
+from backend.utils.webm_utils import concat_webm_fragments
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import decrypt_file_to_temp
 from backend.utils.cost import calculate_audio_cost_microdollars
@@ -527,25 +527,17 @@ class BatchTranscriptionTask(Task):
 
 
 @celery.task(base=BatchTranscriptionTask, bind=True)
-def transcribe_chunk_batch(self, session_id: str, chunk_indices: list,
-                           is_final_batch: bool = False):
+def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
     """
     Transcribe a batch of audio chunks by merging them and sending to Whisper.
 
     Instead of transcribing each 15s chunk individually, this task:
     1. Decrypts all chunk files in the batch
-    2. Merges audio using ffmpeg concat demuxer
+    2. Merges MediaRecorder fragments into one valid WebM
     3. Sends merged audio to Whisper (gpt-4o-transcribe)
     4. Stores transcript, marks all chunks as completed
     5. Reassembles draft.content from all completed chunks
     6. Encrypts the merged audio and deletes individual chunk files
-
-    Args:
-        session_id: UUID of the streaming session
-        chunk_indices: List of chunk indices to transcribe in this batch
-        is_final_batch: If True, fix the last chunk's WebM duration before
-            merging (MediaRecorder often writes incorrect duration on the
-            final chunk)
     """
     logger.info(
         f"Starting batch transcription for session {session_id}, "
@@ -591,23 +583,10 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list,
                     f"indices {chunk_indices}"
                 )
 
-            # Fix the last chunk's WebM duration before merging.
-            # MediaRecorder often writes incorrect/missing duration on the
-            # final recorded chunk, which causes playback issues.
-            if is_final_batch and decrypted_paths:
-                from backend.utils.webm_utils import (
-                    fix_webm_duration, is_ffmpeg_available,
-                )
-                if is_ffmpeg_available():
-                    last_path = decrypted_paths[-1]
-                    success, msg, _ = fix_webm_duration(last_path)
-                    if success:
-                        logger.info(
-                            f"Fixed last chunk duration before merge: {msg}"
-                        )
-
-            # Merge audio chunks into a single file
-            merged_path = concat_audio_files(decrypted_paths)
+            # Merge MediaRecorder fragments into a single valid WebM.
+            # Binary-append the fragments and remux — see
+            # concat_webm_fragments for the full rationale.
+            merged_path = concat_webm_fragments(decrypted_paths)
             merge_input = merged_path
 
             # Compress if needed (webm -> mp3)
@@ -838,7 +817,6 @@ def finalize_draft_streaming(self, session_id: str, total_chunks: int,
             batch_task = transcribe_chunk_batch.delay(
                 session_id=session_id,
                 chunk_indices=remaining_indices,
-                is_final_batch=True,
             )
             for c in stored_chunks:
                 c.status = 'processing'

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -583,10 +583,33 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                     f"indices {chunk_indices}"
                 )
 
+            # If this batch doesn't include chunk 0, decrypt the cached
+            # init segment so concat_webm_fragments can prepend it — only
+            # chunk 0 carries the EBML/Segment/Tracks header, so later
+            # batches would otherwise be header-less cluster data that
+            # ffmpeg can't remux.
+            init_segment_path = None
+            if chunk_indices and min(chunk_indices) > 0:
+                init_enc = chunk_dir / "init.webm.enc"
+                init_plain = chunk_dir / "init.webm"
+                if init_enc.exists():
+                    init_segment_path = decrypt_file_to_temp(str(init_enc))
+                    temp_files.append(init_segment_path)
+                elif init_plain.exists():
+                    init_segment_path = str(init_plain)
+                else:
+                    logger.warning(
+                        f"No init segment found for session {session_id} "
+                        f"batch starting at chunk {min(chunk_indices)}; "
+                        "concat will likely fail"
+                    )
+
             # Merge MediaRecorder fragments into a single valid WebM.
             # Binary-append the fragments and remux — see
             # concat_webm_fragments for the full rationale.
-            merged_path = concat_webm_fragments(decrypted_paths)
+            merged_path = concat_webm_fragments(
+                decrypted_paths, init_segment_path=init_segment_path,
+            )
             merge_input = merged_path
 
             # Compress if needed (webm -> mp3)

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -1043,21 +1043,9 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
     ).resolve()
     draft_audio_dir = audio_storage_root / f"drafts/{user_id}/{session_id}"
 
-    if draft_audio_dir.exists():
-        node_audio_dir = (
-            audio_storage_root / f"nodes/{user_id}/{user_node.id}"
-        )
-        try:
-            node_audio_dir.mkdir(parents=True, exist_ok=True)
-            for fp in draft_audio_dir.iterdir():
-                # init.webm is ephemeral (see audio_storage.py)
-                if fp.name.startswith("init.webm"):
-                    fp.unlink()
-                    continue
-                shutil.move(str(fp), str(node_audio_dir / fp.name))
-            draft_audio_dir.rmdir()
-        except Exception as e:
-            logger.warning(f"Failed to move audio files: {e}")
+    node_audio_dir = audio_storage_root / f"nodes/{user_id}/{user_node.id}"
+    from backend.utils.audio_storage import move_draft_audio_to_node_dir
+    move_draft_audio_to_node_dir(draft_audio_dir, node_audio_dir, logger)
 
     # Point transcript-chunk rows at the node
     NodeTranscriptChunk.query.filter_by(

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -17,6 +17,7 @@ from backend.celery_app import celery, flask_app
 from backend.models import Node, NodeTranscriptChunk, Draft, APICostLog
 from backend.extensions import db
 from backend.utils.audio_processing import compress_audio_if_needed, get_audio_duration
+from backend.utils.audio_storage import move_draft_audio_to_node_dir
 from backend.utils.webm_utils import concat_webm_fragments
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import decrypt_file_to_temp
@@ -1044,7 +1045,6 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
     draft_audio_dir = audio_storage_root / f"drafts/{user_id}/{session_id}"
 
     node_audio_dir = audio_storage_root / f"nodes/{user_id}/{user_node.id}"
-    from backend.utils.audio_storage import move_draft_audio_to_node_dir
     move_draft_audio_to_node_dir(draft_audio_dir, node_audio_dir, logger)
 
     # Point transcript-chunk rows at the node

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -588,8 +588,9 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
             # chunk 0 carries the EBML/Segment/Tracks header, so later
             # batches would otherwise be header-less cluster data that
             # ffmpeg can't remux.
+            first_chunk = min(chunk_indices) if chunk_indices else 0
             init_segment_path = None
-            if chunk_indices and min(chunk_indices) > 0:
+            if first_chunk > 0:
                 init_enc = chunk_dir / "init.webm.enc"
                 init_plain = chunk_dir / "init.webm"
                 if init_enc.exists():
@@ -600,7 +601,7 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 else:
                     logger.warning(
                         f"No init segment found for session {session_id} "
-                        f"batch starting at chunk {min(chunk_indices)}; "
+                        f"batch starting at chunk {first_chunk}; "
                         "concat will likely fail"
                     )
 
@@ -1049,6 +1050,10 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
         try:
             node_audio_dir.mkdir(parents=True, exist_ok=True)
             for fp in draft_audio_dir.iterdir():
+                # init.webm is ephemeral (see audio_storage.py)
+                if fp.name.startswith("init.webm"):
+                    fp.unlink()
+                    continue
                 shutil.move(str(fp), str(node_audio_dir / fp.name))
             draft_audio_dir.rmdir()
         except Exception as e:

--- a/backend/tests/test_webm_utils.py
+++ b/backend/tests/test_webm_utils.py
@@ -9,9 +9,14 @@ be fooled by those bytes appearing inside other EBML elements. These tests
 pin the structural-parse behavior.
 """
 
+import json
+import shutil
+import subprocess
+
 import pytest
 
 from backend.utils.webm_utils import (
+    concat_webm_fragments,
     extract_webm_init_segment,
     find_first_cluster_offset,
 )
@@ -138,3 +143,84 @@ def test_raises_on_segment_with_no_cluster():
 
     with pytest.raises(ValueError, match="No Cluster"):
         find_first_cluster_offset(buf)
+
+
+# --- integration tests for concat_webm_fragments -----------------------------
+# These exercise the full binary-append + ffmpeg remux pipeline and require
+# ffmpeg on PATH; skipped locally if absent. CI installs ffmpeg (see ci.yml).
+
+requires_ffmpeg = pytest.mark.skipif(
+    shutil.which('ffmpeg') is None or shutil.which('ffprobe') is None,
+    reason="ffmpeg/ffprobe not available on PATH",
+)
+
+
+def _ffprobe_duration(path: str) -> float:
+    out = subprocess.run(
+        ['ffprobe', '-v', 'error', '-show_format', '-of', 'json', path],
+        capture_output=True, text=True, check=True,
+    )
+    return float(json.loads(out.stdout)['format']['duration'])
+
+
+@pytest.fixture
+def webm_fixture(tmp_path):
+    """Produce a real WebM bytestring via ffmpeg. 3 s sine wave, Opus/WebM —
+    mirrors the codec MediaRecorder uses in Chrome."""
+    out_path = tmp_path / "source.webm"
+    subprocess.run(
+        ['ffmpeg', '-y', '-f', 'lavfi', '-i',
+         'sine=frequency=440:duration=3',
+         '-c:a', 'libopus', '-b:a', '64k', str(out_path)],
+        capture_output=True, check=True,
+    )
+    return out_path.read_bytes()
+
+
+@requires_ffmpeg
+def test_concat_single_fragment_including_init(tmp_path, webm_fixture):
+    """Batch-1 path: the fragment list includes chunk 0, so no separate init
+    segment needs prepending. concat_webm_fragments should produce a valid
+    WebM whose duration matches the source."""
+    chunk_0 = tmp_path / "chunk_0000.webm"
+    chunk_0.write_bytes(webm_fixture)
+
+    out = concat_webm_fragments([str(chunk_0)])
+
+    assert _ffprobe_duration(out) == pytest.approx(3.0, abs=0.2)
+
+
+@requires_ffmpeg
+def test_concat_with_init_segment_for_batch_without_chunk_zero(
+        tmp_path, webm_fixture):
+    """Batch-2+ path: the fragment list does NOT include chunk 0, so the
+    caller supplies init_segment_path with the cached header. Split the
+    source at the first-cluster boundary to simulate this: `init.webm`
+    holds everything up to the first Cluster; `body.webm` holds the
+    cluster data. Feeding body alone would fail; feeding body with the
+    init segment prepended must produce a valid WebM."""
+    split = find_first_cluster_offset(webm_fixture)
+    init_path = tmp_path / "init.webm"
+    body_path = tmp_path / "chunk_0020.webm"
+    init_path.write_bytes(webm_fixture[:split])
+    body_path.write_bytes(webm_fixture[split:])
+
+    out = concat_webm_fragments(
+        [str(body_path)], init_segment_path=str(init_path),
+    )
+
+    assert _ffprobe_duration(out) == pytest.approx(3.0, abs=0.2)
+
+
+@requires_ffmpeg
+def test_concat_without_init_on_body_only_input_fails(
+        tmp_path, webm_fixture):
+    """Guard: confirm the batch-boundary scenario genuinely requires the
+    init prepend. A body-only input (no EBML header) should fail the
+    ffmpeg remux — otherwise Test B's success would be unconvincing."""
+    split = find_first_cluster_offset(webm_fixture)
+    body_path = tmp_path / "chunk_0020.webm"
+    body_path.write_bytes(webm_fixture[split:])
+
+    with pytest.raises(RuntimeError, match="ffmpeg"):
+        concat_webm_fragments([str(body_path)])

--- a/backend/tests/test_webm_utils.py
+++ b/backend/tests/test_webm_utils.py
@@ -1,0 +1,140 @@
+"""Tests for EBML init-segment extraction in webm_utils.
+
+The motivation is documented on extract_webm_init_segment: MediaRecorder emits
+Matroska fragments and only chunk 0 carries the EBML/Segment/Tracks prefix, so
+the batching pipeline needs to extract that prefix from chunk 0 and prepend it
+to any later batch to produce a parseable WebM. The prior implementation did
+a byte-pattern search for the Cluster magic (0x1F 0x43 0xB6 0x75) which could
+be fooled by those bytes appearing inside other EBML elements. These tests
+pin the structural-parse behavior.
+"""
+
+import pytest
+
+from backend.utils.webm_utils import (
+    extract_webm_init_segment,
+    find_first_cluster_offset,
+)
+
+
+# --- tiny EBML encoder helpers ------------------------------------------------
+
+def _encode_size_vint(value: int, length: int = None) -> bytes:
+    """Encode `value` as an EBML size VINT. If length is None, use minimal."""
+    if length is None:
+        length = 1
+        while value >= (1 << (7 * length)) - 1:
+            length += 1
+    marker = 1 << (7 * length)
+    return (marker | value).to_bytes(length, 'big')
+
+
+def _encode_unknown_size(length: int = 1) -> bytes:
+    """The reserved 'size unknown' VINT: all data bits set after the marker."""
+    marker = 1 << (7 * length)
+    data_bits = (1 << (7 * length)) - 1
+    return (marker | data_bits).to_bytes(length, 'big')
+
+
+def _element(id_hex: str, body: bytes, unknown_size: bool = False) -> bytes:
+    id_bytes = bytes.fromhex(id_hex)
+    size = _encode_unknown_size() if unknown_size else _encode_size_vint(len(body))
+    return id_bytes + size + body
+
+
+# Element IDs we use below
+EBML_HEADER_ID = '1A45DFA3'
+SEGMENT_ID = '18538067'
+INFO_ID = '1549A966'
+TRACKS_ID = '1654AE6B'
+CLUSTER_ID = '1F43B675'
+CODEC_PRIVATE_ID = '63A2'
+
+
+# --- tests --------------------------------------------------------------------
+
+def test_finds_first_cluster_in_fixed_size_segment():
+    info = _element(INFO_ID, b'\x00' * 10)
+    tracks = _element(TRACKS_ID, b'\x00' * 20)
+    cluster = _element(CLUSTER_ID, b'\xAA' * 15)
+    segment = _element(SEGMENT_ID, info + tracks + cluster)
+    header = _element(EBML_HEADER_ID, b'\x00' * 8)
+    buf = header + segment
+
+    offset = find_first_cluster_offset(buf)
+    assert offset == len(buf) - len(cluster)
+    assert buf[offset:offset + 4] == bytes.fromhex(CLUSTER_ID)
+
+
+def test_handles_unknown_size_segment_from_media_recorder():
+    """MediaRecorder emits Segment with an unknown-size VINT (0xFF) because
+    the total recording length isn't known when streaming starts. The walker
+    must treat that as 'parse children until we find a Cluster'."""
+    info = _element(INFO_ID, b'\x00' * 10)
+    tracks = _element(TRACKS_ID, b'\x00' * 20)
+    cluster1 = _element(CLUSTER_ID, b'\xAA' * 12)
+    cluster2 = _element(CLUSTER_ID, b'\xBB' * 12)
+    segment = _element(
+        SEGMENT_ID, info + tracks + cluster1 + cluster2, unknown_size=True,
+    )
+    header = _element(EBML_HEADER_ID, b'\x00' * 8)
+    buf = header + segment
+
+    offset = find_first_cluster_offset(buf)
+    # Expected: right before cluster1 (not cluster2)
+    expected = len(header) + len(bytes.fromhex(SEGMENT_ID)) + 1 + len(info) + len(tracks)
+    assert offset == expected
+
+
+def test_ignores_cluster_magic_inside_codec_private():
+    """Regression guard: the old byte-pattern search mistook 0x1F 0x43 0xB6
+    0x75 inside a CodecPrivate payload for the start of a Cluster element and
+    truncated the header. The structural walker must skip past Tracks' body
+    without looking at its bytes as element IDs."""
+    # Bytes identical to the Cluster element ID embedded inside CodecPrivate
+    codec_private = _element(
+        CODEC_PRIVATE_ID, b'\x1F\x43\xB6\x75\x00\x00\x00\x00',
+    )
+    tracks_with_cp = _element(TRACKS_ID, codec_private)
+    cluster = _element(CLUSTER_ID, b'\xCC' * 10)
+    segment = _element(SEGMENT_ID, tracks_with_cp + cluster)
+    header = _element(EBML_HEADER_ID, b'\x00' * 8)
+    buf = header + segment
+
+    offset = find_first_cluster_offset(buf)
+    # The "fake" cluster magic inside codec_private is at an earlier offset.
+    # We must return the later one — the real Cluster element.
+    real_cluster_pos = len(buf) - len(cluster)
+    assert offset == real_cluster_pos
+
+
+def test_extract_init_segment_returns_bytes_before_cluster():
+    info = _element(INFO_ID, b'\x01' * 5)
+    tracks = _element(TRACKS_ID, b'\x02' * 7)
+    cluster = _element(CLUSTER_ID, b'\xFF' * 20)
+    segment = _element(SEGMENT_ID, info + tracks + cluster)
+    header = _element(EBML_HEADER_ID, b'\x03' * 4)
+    buf = header + segment
+
+    init = extract_webm_init_segment(buf)
+    assert buf.startswith(init)
+    assert len(init) == len(buf) - len(cluster)
+    # The init segment should end right before the cluster's ID bytes
+    assert init + cluster == buf
+
+
+def test_raises_on_buffer_with_no_segment():
+    header = _element(EBML_HEADER_ID, b'\x00' * 8)
+    with pytest.raises(ValueError, match="No Segment"):
+        find_first_cluster_offset(header)
+
+
+def test_raises_on_segment_with_no_cluster():
+    info = _element(INFO_ID, b'\x00' * 5)
+    tracks = _element(TRACKS_ID, b'\x00' * 5)
+    segment = _element(SEGMENT_ID, info + tracks)
+    header = _element(EBML_HEADER_ID, b'\x00' * 4)
+    buf = header + segment
+
+    with pytest.raises(ValueError, match="No Cluster"):
+        find_first_cluster_offset(buf)

--- a/backend/tests/test_webm_utils.py
+++ b/backend/tests/test_webm_utils.py
@@ -18,7 +18,9 @@ import pytest
 from backend.utils.webm_utils import (
     concat_webm_fragments,
     extract_webm_init_segment,
+    find_all_cluster_offsets,
     find_first_cluster_offset,
+    persist_init_segment,
 )
 
 
@@ -134,6 +136,38 @@ def test_raises_on_buffer_with_no_segment():
         find_first_cluster_offset(header)
 
 
+def test_extract_init_rejects_segment_missing_tracks():
+    """A malformed chunk 0 with no Tracks element would pass the cluster walk
+    but produce a WebM with no decodable stream. extract_webm_init_segment
+    must refuse it so the upload fails on chunk 0 rather than at batch 2
+    ffmpeg remux time."""
+    info = _element(INFO_ID, b'\x00' * 5)
+    cluster = _element(CLUSTER_ID, b'\x00' * 10)
+    segment = _element(SEGMENT_ID, info + cluster)  # No Tracks
+    header = _element(EBML_HEADER_ID, b'\x00' * 4)
+    buf = header + segment
+
+    with pytest.raises(ValueError, match="Tracks"):
+        extract_webm_init_segment(buf)
+
+
+def test_find_all_cluster_offsets_multi_cluster():
+    info = _element(INFO_ID, b'\x00' * 4)
+    tracks = _element(TRACKS_ID, b'\x00' * 4)
+    c1 = _element(CLUSTER_ID, b'\xAA' * 6)
+    c2 = _element(CLUSTER_ID, b'\xBB' * 6)
+    c3 = _element(CLUSTER_ID, b'\xCC' * 6)
+    segment = _element(SEGMENT_ID, info + tracks + c1 + c2 + c3)
+    header = _element(EBML_HEADER_ID, b'\x00' * 4)
+    buf = header + segment
+
+    offsets = find_all_cluster_offsets(buf)
+    assert len(offsets) == 3
+    # Each offset should land on the Cluster element's ID bytes
+    for off in offsets:
+        assert buf[off:off + 4] == bytes.fromhex(CLUSTER_ID)
+
+
 def test_raises_on_segment_with_no_cluster():
     info = _element(INFO_ID, b'\x00' * 5)
     tracks = _element(TRACKS_ID, b'\x00' * 5)
@@ -165,59 +199,129 @@ def _ffprobe_duration(path: str) -> float:
 
 @pytest.fixture
 def webm_fixture(tmp_path):
-    """Produce a real WebM bytestring via ffmpeg. 3 s sine wave, Opus/WebM —
-    mirrors the codec MediaRecorder uses in Chrome."""
+    """Produce a real multi-cluster WebM bytestring via ffmpeg.
+
+    Uses -cluster_time_limit 1000 (ms) so the 5-second source is emitted as
+    multiple ~1-second Clusters, matching what a real 15s-timeslice
+    MediaRecorder session looks like (one Cluster per timeslice fragment).
+    """
     out_path = tmp_path / "source.webm"
     subprocess.run(
         ['ffmpeg', '-y', '-f', 'lavfi', '-i',
-         'sine=frequency=440:duration=3',
-         '-c:a', 'libopus', '-b:a', '64k', str(out_path)],
+         'sine=frequency=440:duration=5',
+         '-c:a', 'libopus', '-b:a', '64k',
+         '-cluster_time_limit', '1000',
+         str(out_path)],
         capture_output=True, check=True,
     )
-    return out_path.read_bytes()
+    data = out_path.read_bytes()
+    # Sanity: the fixture is only useful if it exercises multi-cluster
+    # concat. If ffmpeg ever collapses to a single cluster, tests below
+    # would silently degenerate — fail loudly here instead.
+    assert len(find_all_cluster_offsets(data)) >= 3, (
+        f"fixture has only {len(find_all_cluster_offsets(data))} clusters; "
+        "multi-cluster concat not exercised"
+    )
+    return data
 
 
 @requires_ffmpeg
 def test_concat_single_fragment_including_init(tmp_path, webm_fixture):
     """Batch-1 path: the fragment list includes chunk 0, so no separate init
-    segment needs prepending. concat_webm_fragments should produce a valid
-    WebM whose duration matches the source."""
+    segment needs prepending. Whole source as one file in, valid WebM out
+    with duration matching the source."""
     chunk_0 = tmp_path / "chunk_0000.webm"
     chunk_0.write_bytes(webm_fixture)
 
     out = concat_webm_fragments([str(chunk_0)])
 
-    assert _ffprobe_duration(out) == pytest.approx(3.0, abs=0.2)
+    assert _ffprobe_duration(out) == pytest.approx(5.0, abs=0.3)
 
 
 @requires_ffmpeg
-def test_concat_with_init_segment_for_batch_without_chunk_zero(
-        tmp_path, webm_fixture):
-    """Batch-2+ path: the fragment list does NOT include chunk 0, so the
-    caller supplies init_segment_path with the cached header. Split the
-    source at the first-cluster boundary to simulate this: `init.webm`
-    holds everything up to the first Cluster; `body.webm` holds the
-    cluster data. Feeding body alone would fail; feeding body with the
-    init segment prepended must produce a valid WebM."""
-    split = find_first_cluster_offset(webm_fixture)
+def test_concat_multi_cluster_batch_with_init_segment(tmp_path, webm_fixture):
+    """Batch-2+ path, real shape: the fragment list is multiple cluster-only
+    files (one per real MediaRecorder chunk), none of them contain an EBML
+    header, and the caller supplies init_segment_path with the cached
+    chunk-0 prefix. Splits the multi-cluster fixture at each Cluster
+    boundary so each fragment is exactly one Cluster — matching the
+    real-world 20-fragments-per-batch shape."""
+    cluster_offsets = find_all_cluster_offsets(webm_fixture)
+    assert len(cluster_offsets) >= 3
+
     init_path = tmp_path / "init.webm"
-    body_path = tmp_path / "chunk_0020.webm"
-    init_path.write_bytes(webm_fixture[:split])
-    body_path.write_bytes(webm_fixture[split:])
+    init_path.write_bytes(webm_fixture[:cluster_offsets[0]])
+
+    # One file per cluster. Element boundaries are at cluster_offsets[i];
+    # the last cluster runs to end of buffer.
+    fragment_paths = []
+    boundaries = cluster_offsets + [len(webm_fixture)]
+    for i in range(len(cluster_offsets)):
+        fpath = tmp_path / f"chunk_{i + 20:04d}.webm"
+        fpath.write_bytes(webm_fixture[boundaries[i]:boundaries[i + 1]])
+        fragment_paths.append(str(fpath))
 
     out = concat_webm_fragments(
-        [str(body_path)], init_segment_path=str(init_path),
+        fragment_paths, init_segment_path=str(init_path),
     )
 
-    assert _ffprobe_duration(out) == pytest.approx(3.0, abs=0.2)
+    # Duration should cover all clusters — i.e. the full source
+    assert _ffprobe_duration(out) == pytest.approx(5.0, abs=0.3)
+
+
+@requires_ffmpeg
+def test_persist_init_segment_writes_init_file(tmp_path, webm_fixture):
+    """Happy path for the chunk-0 upload glue: given a real WebM blob,
+    persist_init_segment must write an init.webm(.enc) file on disk. Guards
+    against mutations that drop the write or the encrypt_file call."""
+    chunk_path = tmp_path / "chunk_0000.webm"
+    chunk_path.write_bytes(webm_fixture)
+
+    persist_init_segment(chunk_path, tmp_path)
+
+    init_files = list(tmp_path.glob("init.webm*"))
+    assert len(init_files) == 1, (
+        f"expected exactly one init.webm file, got {init_files}"
+    )
+    assert init_files[0].stat().st_size > 0
+
+
+def test_persist_init_segment_raises_on_unparseable_bytes(tmp_path):
+    """Error path for the chunk-0 upload glue: if the file doesn't parse as
+    WebM, persist_init_segment must raise rather than silently succeed."""
+    chunk_path = tmp_path / "chunk_0000.webm"
+    chunk_path.write_bytes(b"this is not a webm file")
+
+    with pytest.raises(ValueError):
+        persist_init_segment(chunk_path, tmp_path)
+
+    # And no init file should have been left behind
+    assert not list(tmp_path.glob("init.webm*"))
+
+
+def test_persist_init_segment_raises_on_missing_tracks(tmp_path):
+    """Chunk 0 with a Segment but no Tracks element must be rejected by
+    persist_init_segment even though the Cluster walk would succeed — the
+    resulting init segment has no decodable stream description."""
+    info = _element(INFO_ID, b'\x00' * 4)
+    cluster = _element(CLUSTER_ID, b'\x00' * 8)
+    segment = _element(SEGMENT_ID, info + cluster)
+    header = _element(EBML_HEADER_ID, b'\x00' * 4)
+    chunk_path = tmp_path / "chunk_0000.webm"
+    chunk_path.write_bytes(header + segment)
+
+    with pytest.raises(ValueError, match="Tracks"):
+        persist_init_segment(chunk_path, tmp_path)
 
 
 @requires_ffmpeg
 def test_concat_without_init_on_body_only_input_fails(
         tmp_path, webm_fixture):
-    """Guard: confirm the batch-boundary scenario genuinely requires the
-    init prepend. A body-only input (no EBML header) should fail the
-    ffmpeg remux — otherwise Test B's success would be unconvincing."""
+    """Guard: confirm the batch-boundary test actually exercises the init
+    prepend. A fragment list of cluster-only bytes with no init_segment_path
+    must fail the ffmpeg remux — otherwise the previous test's success
+    could come from ffmpeg being lenient rather than from the prepend doing
+    its job."""
     split = find_first_cluster_offset(webm_fixture)
     body_path = tmp_path / "chunk_0020.webm"
     body_path.write_bytes(webm_fixture[split:])

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -82,7 +82,6 @@ def get_audio_duration(file_path: pathlib.Path, logger=None) -> float:
 
     # Fallback: remux with ffmpeg (stream copy, no re-encoding) to produce
     # a file with correct duration metadata, then read it with ffprobe.
-    # Same approach used in webm_utils.fix_webm_duration().
     from backend.utils.webm_utils import get_webm_duration
     try:
         fd, temp_path = tempfile.mkstemp(suffix=file_path.suffix)

--- a/backend/utils/audio_storage.py
+++ b/backend/utils/audio_storage.py
@@ -11,7 +11,6 @@ from flask import current_app
 
 from backend.extensions import db
 from backend.models import Draft, NodeTranscriptChunk
-from backend.utils.webm_utils import fix_last_chunk_duration, is_ffmpeg_available
 
 AUDIO_STORAGE_ROOT = pathlib.Path(
     os.environ.get("AUDIO_STORAGE_PATH", "data/audio")
@@ -42,24 +41,18 @@ def attach_streaming_audio_to_node(session_id, node, user_id):
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{user_id}/{session_id}"
 
     if draft_audio_dir.exists():
-        # Fix last-chunk WebM duration metadata if possible
-        if is_ffmpeg_available():
-            success, message = fix_last_chunk_duration(str(draft_audio_dir))
-            if success:
-                current_app.logger.info(
-                    f"Fixed last chunk duration: {message}"
-                )
-            else:
-                current_app.logger.warning(
-                    f"Could not fix last chunk duration: {message}"
-                )
-
         node_audio_dir = (
             AUDIO_STORAGE_ROOT / f"nodes/{user_id}/{node.id}"
         )
         try:
             node_audio_dir.mkdir(parents=True, exist_ok=True)
             for file_path in draft_audio_dir.iterdir():
+                # init.webm is ephemeral — used only during batch
+                # transcription to prepend the EBML header to batches that
+                # don't start at chunk 0. It has no purpose on the node side.
+                if file_path.name.startswith("init.webm"):
+                    file_path.unlink()
+                    continue
                 shutil.move(
                     str(file_path),
                     str(node_audio_dir / file_path.name),

--- a/backend/utils/audio_storage.py
+++ b/backend/utils/audio_storage.py
@@ -17,6 +17,41 @@ AUDIO_STORAGE_ROOT = pathlib.Path(
 ).resolve()
 
 
+def move_draft_audio_to_node_dir(
+    draft_audio_dir: pathlib.Path,
+    node_audio_dir: pathlib.Path,
+    logger,
+) -> None:
+    """Move every audio file from a streaming-session draft dir into the
+    node's permanent audio dir, then remove the emptied draft dir.
+
+    Skips `init.webm` (and `init.webm.enc`) — that file is the extracted
+    EBML/Segment/Tracks prefix cached on chunk-0 upload so later batches
+    can remux into valid WebM, and has no purpose in node storage.
+    Callers pass their own logger so the messages land with the right
+    request/task context.
+
+    Best-effort: exceptions are logged at warning level rather than
+    raised, since by the time this is called the DB record has already
+    been committed and a move failure shouldn't undo that.
+    """
+    if not draft_audio_dir.exists():
+        return
+    try:
+        node_audio_dir.mkdir(parents=True, exist_ok=True)
+        for fp in draft_audio_dir.iterdir():
+            if fp.name.startswith("init.webm"):
+                fp.unlink()
+                continue
+            shutil.move(str(fp), str(node_audio_dir / fp.name))
+        draft_audio_dir.rmdir()
+        logger.info(
+            f"Moved audio from {draft_audio_dir} -> {node_audio_dir}"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to move audio files: {e}")
+
+
 def attach_streaming_audio_to_node(session_id, node, user_id):
     """
     Move audio chunks from a draft streaming session to a node.
@@ -40,31 +75,10 @@ def attach_streaming_audio_to_node(session_id, node, user_id):
 
     draft_audio_dir = AUDIO_STORAGE_ROOT / f"drafts/{user_id}/{session_id}"
 
-    if draft_audio_dir.exists():
-        node_audio_dir = (
-            AUDIO_STORAGE_ROOT / f"nodes/{user_id}/{node.id}"
-        )
-        try:
-            node_audio_dir.mkdir(parents=True, exist_ok=True)
-            for file_path in draft_audio_dir.iterdir():
-                # init.webm is ephemeral — used only during batch
-                # transcription to prepend the EBML header to batches that
-                # don't start at chunk 0. It has no purpose on the node side.
-                if file_path.name.startswith("init.webm"):
-                    file_path.unlink()
-                    continue
-                shutil.move(
-                    str(file_path),
-                    str(node_audio_dir / file_path.name),
-                )
-            draft_audio_dir.rmdir()
-            current_app.logger.info(
-                f"Moved audio from {draft_audio_dir} -> {node_audio_dir}"
-            )
-        except Exception as e:
-            current_app.logger.warning(
-                f"Failed to move audio files: {e}"
-            )
+    node_audio_dir = AUDIO_STORAGE_ROOT / f"nodes/{user_id}/{node.id}"
+    move_draft_audio_to_node_dir(
+        draft_audio_dir, node_audio_dir, current_app.logger,
+    )
 
     # Point transcript-chunk rows at the node
     NodeTranscriptChunk.query.filter_by(

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -1,240 +1,29 @@
 """
 Utility functions for WebM audio file handling.
 
-WebM files recorded via MediaRecorder with timeslice often lack proper duration
-metadata in their headers. These utilities help fix that issue.
-
-The problem: MediaRecorder with timeslice creates chunks with continuous timestamps
-(chunk 0: 0-300s, chunk 1: 300-600s, etc.) but no duration metadata.
-
-When ffmpeg remuxes these files, it sets duration = start_time + actual_duration,
-which is incorrect. We need to:
-1. Remux with ffmpeg to get the (wrong) duration
-2. Calculate actual_duration = ffmpeg_duration - start_time
-3. Directly edit the EBML Duration metadata with the correct value
+Covers:
+- Probing duration via ffprobe (`get_webm_duration`).
+- Extracting a MediaRecorder session's init segment (EBML header +
+  Segment header + Info + Tracks, everything before the first Cluster)
+  via a proper EBML element walk (`extract_webm_init_segment`,
+  `find_first_cluster_offset`, `find_all_cluster_offsets`).
+- Persisting that init segment alongside a streaming session so later
+  batches that don't include chunk 0 can still be remuxed into valid
+  WebM (`persist_init_segment`).
+- Concatenating MediaRecorder fragments into a single valid WebM via
+  binary append + a single ffmpeg remux (`concat_webm_fragments`), and
+  concatenating multiple standalone WebM files via the ffmpeg concat
+  demuxer (`concat_audio_files`).
 """
 
 import logging
 import os
 import shutil
-import struct
 import subprocess
 import tempfile
-from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 logger = logging.getLogger(__name__)
-
-
-# =============================================================================
-# EBML Direct Duration Editing
-# =============================================================================
-
-# EBML Element IDs (as bytes, variable length)
-EBML_ID = b'\x1a\x45\xdf\xa3'
-SEGMENT_ID = b'\x18\x53\x80\x67'
-INFO_ID = b'\x15\x49\xa9\x66'
-DURATION_ID = b'\x44\x89'
-TIMECODE_SCALE_ID = b'\x2a\xd7\xb1'
-
-
-def _read_vint(data, pos):
-    """Read a variable-length integer (VINT) from EBML data."""
-    if pos >= len(data):
-        return None, pos
-
-    first_byte = data[pos]
-
-    if first_byte & 0x80:
-        length = 1
-        value = first_byte & 0x7f
-    elif first_byte & 0x40:
-        length = 2
-        value = first_byte & 0x3f
-    elif first_byte & 0x20:
-        length = 3
-        value = first_byte & 0x1f
-    elif first_byte & 0x10:
-        length = 4
-        value = first_byte & 0x0f
-    elif first_byte & 0x08:
-        length = 5
-        value = first_byte & 0x07
-    elif first_byte & 0x04:
-        length = 6
-        value = first_byte & 0x03
-    elif first_byte & 0x02:
-        length = 7
-        value = first_byte & 0x01
-    elif first_byte & 0x01:
-        length = 8
-        value = 0
-    else:
-        return None, pos
-
-    for i in range(1, length):
-        if pos + i >= len(data):
-            return None, pos
-        value = (value << 8) | data[pos + i]
-
-    return value, pos + length
-
-
-def _read_element_id(data, pos):
-    """Read an EBML element ID."""
-    if pos >= len(data):
-        return None, pos
-
-    first_byte = data[pos]
-
-    if first_byte & 0x80:
-        length = 1
-    elif first_byte & 0x40:
-        length = 2
-    elif first_byte & 0x20:
-        length = 3
-    elif first_byte & 0x10:
-        length = 4
-    else:
-        return None, pos
-
-    if pos + length > len(data):
-        return None, pos
-
-    return data[pos:pos + length], pos + length
-
-
-def _find_duration_in_info(data, info_start, info_size):
-    """Find the Duration element within the Info element."""
-    pos = info_start
-    end = info_start + info_size
-    timecode_scale = 1000000  # Default: 1ms
-    duration_pos = None
-    duration_size = None
-
-    while pos < end:
-        elem_id, pos = _read_element_id(data, pos)
-        if elem_id is None:
-            break
-
-        elem_size, pos = _read_vint(data, pos)
-        if elem_size is None:
-            break
-
-        if elem_id == TIMECODE_SCALE_ID:
-            timecode_scale = 0
-            for i in range(elem_size):
-                timecode_scale = (timecode_scale << 8) | data[pos + i]
-
-        if elem_id == DURATION_ID:
-            duration_pos = pos
-            duration_size = elem_size
-
-        pos += elem_size
-
-    return duration_pos, duration_size, timecode_scale
-
-
-def _find_info_element(data):
-    """Find the Info element in the WebM file."""
-    pos = 0
-
-    elem_id, pos = _read_element_id(data, pos)
-    if elem_id != EBML_ID:
-        return None, None
-
-    elem_size, pos = _read_vint(data, pos)
-    pos += elem_size
-
-    elem_id, pos = _read_element_id(data, pos)
-    if elem_id != SEGMENT_ID:
-        return None, None
-
-    segment_size, pos = _read_vint(data, pos)
-    search_limit = min(pos + 100000, len(data))
-
-    while pos < search_limit:
-        elem_id, new_pos = _read_element_id(data, pos)
-        if elem_id is None:
-            break
-
-        elem_size, new_pos = _read_vint(data, new_pos)
-        if elem_size is None:
-            break
-
-        if elem_id == INFO_ID:
-            return new_pos, elem_size
-
-        if elem_size == 0xffffffffffffff:
-            pos = new_pos
-            continue
-
-        pos = new_pos + elem_size
-
-    return None, None
-
-
-def _set_ebml_duration(filepath: str, duration_seconds: float) -> bool:
-    """
-    Directly set the Duration metadata in a WebM file's EBML structure.
-
-    Args:
-        filepath: Path to the WebM file
-        duration_seconds: The correct duration in seconds
-
-    Returns:
-        True if successful, False otherwise
-    """
-    try:
-        with open(filepath, 'rb') as f:
-            data = bytearray(f.read())
-
-        info_start, info_size = _find_info_element(data)
-        if info_start is None:
-            logger.error(f"Could not find Info element in {filepath}")
-            return False
-
-        duration_pos, duration_size, timecode_scale = _find_duration_in_info(
-            data, info_start, info_size
-        )
-
-        if duration_pos is None:
-            logger.error(f"Could not find Duration element in {filepath}")
-            return False
-
-        # Calculate new duration value (duration * timecode_scale = nanoseconds)
-        new_duration_ns = duration_seconds * 1e9
-        new_duration_value = new_duration_ns / timecode_scale
-
-        # Encode new duration
-        if duration_size == 8:
-            new_duration_bytes = struct.pack('>d', new_duration_value)
-        elif duration_size == 4:
-            new_duration_bytes = struct.pack('>f', new_duration_value)
-        else:
-            logger.error(f"Unexpected duration size: {duration_size}")
-            return False
-
-        # Replace duration in data
-        data[duration_pos:duration_pos + duration_size] = new_duration_bytes
-
-        # Write back
-        with open(filepath, 'wb') as f:
-            f.write(data)
-
-        # Ensure file is readable by web server (644 = rw-r--r--)
-        os.chmod(filepath, 0o644)
-
-        return True
-
-    except Exception as e:
-        logger.error(f"Error setting EBML duration for {filepath}: {e}")
-        return False
-
-
-# =============================================================================
-# Public API
-# =============================================================================
 
 
 def get_webm_duration(filepath: str) -> Optional[float]:
@@ -268,178 +57,10 @@ def get_webm_duration(filepath: str) -> Optional[float]:
         return None
 
 
-def _get_webm_start_time(filepath: str) -> Optional[float]:
-    """
-    Get the start_time of a WebM file using ffprobe.
-
-    Args:
-        filepath: Path to the WebM file
-
-    Returns:
-        Start time in seconds, or None if unavailable
-    """
-    try:
-        result = subprocess.run(
-            [
-                'ffprobe', '-v', 'error',
-                '-show_entries', 'format=start_time',
-                '-of', 'csv=p=0',
-                filepath
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30
-        )
-        start_str = result.stdout.strip()
-        if start_str and start_str != 'N/A':
-            return float(start_str)
-        return None
-    except (subprocess.TimeoutExpired, ValueError, FileNotFoundError) as e:
-        logger.warning(f"Could not get start_time for {filepath}: {e}")
-        return None
-
-
-def fix_webm_duration(filepath: str) -> Tuple[bool, str, Optional[float]]:
-    """
-    Fix the duration metadata of a WebM file.
-
-    WebM files from MediaRecorder with timeslice have continuous timestamps
-    but no duration metadata. When ffmpeg remuxes them, it incorrectly sets
-    duration = start_time + actual_duration.
-
-    This function:
-    1. Remuxes with ffmpeg to get duration metadata (even if wrong)
-    2. Calculates actual_duration = ffmpeg_duration - start_time
-    3. Directly edits the EBML Duration to set the correct value
-
-    Args:
-        filepath: Path to the WebM file
-
-    Returns:
-        tuple: (success: bool, message: str, new_duration: Optional[float])
-    """
-    if not os.path.exists(filepath):
-        return False, f"File not found: {filepath}", None
-
-    if not filepath.endswith('.webm'):
-        return False, f"Not a WebM file: {filepath}", None
-
-    # Get current duration for logging
-    old_duration = get_webm_duration(filepath)
-    old_str = f"{old_duration:.2f}s" if old_duration else "N/A"
-
-    # Create a temporary file for the remuxed output
-    fd, temp_path = tempfile.mkstemp(suffix='.webm')
-    os.close(fd)
-
-    try:
-        # Step 1: Remux the file with ffmpeg to get duration metadata
-        result = subprocess.run(
-            [
-                'ffmpeg', '-y',
-                '-copyts',
-                '-i', filepath,
-                '-c', 'copy',
-                temp_path
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120
-        )
-
-        if result.returncode != 0:
-            logger.error(f"ffmpeg failed for {filepath}: {result.stderr}")
-            os.unlink(temp_path)
-            return False, f"ffmpeg failed: {result.stderr[:200]}", None
-
-        # Step 2: Get the (wrong) duration and start_time from the remuxed file
-        ffmpeg_duration = get_webm_duration(temp_path)
-        start_time = _get_webm_start_time(temp_path)
-
-        if ffmpeg_duration is None:
-            os.unlink(temp_path)
-            return False, "Remuxed file has no duration", None
-
-        # Step 3: Calculate the actual duration
-        # ffmpeg sets: duration = start_time + actual_duration
-        # So: actual_duration = duration - start_time
-        if start_time is not None and start_time > 0:
-            actual_duration = ffmpeg_duration - start_time
-            logger.info(
-                f"Calculating actual duration: {ffmpeg_duration:.2f} - {start_time:.2f} = {actual_duration:.2f}"
-            )
-        else:
-            # No start_time offset, use ffmpeg duration as-is
-            actual_duration = ffmpeg_duration
-
-        # Step 4: Replace original with remuxed file
-        shutil.move(temp_path, filepath)
-
-        # Ensure file is readable by web server (644 = rw-r--r--)
-        os.chmod(filepath, 0o644)
-
-        # Step 5: Directly set the correct duration in EBML metadata
-        if start_time is not None and start_time > 0:
-            if _set_ebml_duration(filepath, actual_duration):
-                logger.info(f"Set correct EBML duration: {actual_duration:.2f}s")
-            else:
-                logger.warning(f"Could not set EBML duration, file may have wrong duration")
-
-        # Verify final duration
-        final_duration = get_webm_duration(filepath)
-        new_str = f"{final_duration:.2f}s" if final_duration else "N/A"
-        logger.info(f"Fixed WebM duration: {filepath} ({old_str} -> {new_str})")
-
-        return True, f"Fixed: {old_str} -> {new_str}", final_duration
-
-    except subprocess.TimeoutExpired:
-        if os.path.exists(temp_path):
-            os.unlink(temp_path)
-        logger.error(f"ffmpeg timed out for {filepath}")
-        return False, "ffmpeg timed out", None
-    except Exception as e:
-        if os.path.exists(temp_path):
-            os.unlink(temp_path)
-        logger.error(f"Error fixing {filepath}: {e}")
-        return False, f"Error: {str(e)}", None
-
-
-def fix_last_chunk_duration(chunk_dir: str) -> Tuple[bool, str]:
-    """
-    Fix the duration metadata of the last chunk file in a directory.
-
-    Args:
-        chunk_dir: Path to directory containing chunk_*.webm files
-
-    Returns:
-        tuple: (success: bool, message: str)
-    """
-    chunk_path = Path(chunk_dir)
-
-    if not chunk_path.exists():
-        return False, f"Directory not found: {chunk_dir}"
-
-    # Find all chunk files
-    chunk_files = sorted(chunk_path.glob("chunk_*.webm"))
-
-    if not chunk_files:
-        return False, f"No chunk files found in {chunk_dir}"
-
-    # Fix the last chunk
-    last_chunk = str(chunk_files[-1])
-    logger.info(f"Fixing last chunk duration: {last_chunk}")
-
-    success, message, new_duration = fix_webm_duration(last_chunk)
-
-    if success:
-        return True, f"Fixed {os.path.basename(last_chunk)}: {message}"
-    else:
-        return False, f"Failed to fix {os.path.basename(last_chunk)}: {message}"
-
-
 # Matroska element IDs we care about for init-segment extraction.
 _EBML_ID_SEGMENT = 0x18538067
 _EBML_ID_CLUSTER = 0x1F43B675
+_EBML_ID_TRACKS = 0x1654AE6B
 
 
 def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
@@ -487,15 +108,43 @@ def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
     return value, length, is_unknown
 
 
-def find_first_cluster_offset(data: bytes) -> int:
-    """Return the byte offset of the first Matroska Cluster element.
+def persist_init_segment(chunk_path, chunk_dir) -> None:
+    """Extract the init segment from a chunk-0 file on disk and persist it
+    at `chunk_dir/init.webm.enc` (or `init.webm` if encryption is disabled).
 
-    Walks the EBML element tree — top-level elements, then the Segment's
-    children — and stops at the first element with ID 0x1F43B675. Does *not*
-    do a byte-pattern search, so magic bytes that happen to occur inside
-    other elements (CodecPrivate, track UIDs) are ignored.
+    Raises ValueError if the chunk's WebM bytes can't be parsed or are
+    missing a Tracks element. The caller is responsible for deleting the
+    offending chunk and surfacing an error — retaining a chunk 0 we can't
+    extract the init from would let batch 1 succeed and batch 2 fail
+    silently for want of an init segment.
+    """
+    # Local import avoids circular imports; encryption depends on this
+    # module's sibling files.
+    from backend.utils.encryption import encrypt_file
 
-    Raises ValueError on malformed EBML or if no Cluster is found.
+    with open(chunk_path, 'rb') as f:
+        init_bytes = extract_webm_init_segment(f.read())
+
+    init_path = chunk_dir / "init.webm"
+    with open(init_path, 'wb') as f:
+        f.write(init_bytes)
+    # encrypt_file is a no-op returning the original path when encryption
+    # is disabled; no return value to track.
+    encrypt_file(str(init_path))
+
+
+def _walk_segment_children(data: bytes):
+    """Yield (child_id, child_start_offset) for each direct child of the first
+    Segment element.
+
+    Walks the EBML element tree properly — top-level elements, then Segment's
+    children — so magic bytes appearing inside non-master elements
+    (CodecPrivate, track UIDs) are skipped by their declared size rather than
+    misread as element IDs.
+
+    Raises ValueError on malformed EBML or if no Segment element is found.
+    Stops after yielding a child with unknown size, since the sibling
+    boundary can't be computed without parsing into the child.
     """
     offset = 0
     while offset < len(data):
@@ -507,28 +156,25 @@ def find_first_cluster_offset(data: bytes) -> int:
         offset += size_len
 
         if id_val == _EBML_ID_SEGMENT:
-            # Parse children of Segment linearly. MediaRecorder emits the
-            # Segment with unknown size; in that case walk until we run out
-            # of bytes or hit a Cluster.
+            # MediaRecorder emits the Segment with unknown size (it's still
+            # recording when the header is written). Parse children until
+            # we run out of bytes or hit the declared end.
             seg_end = len(data) if size_unknown else offset + size_val
             while offset < seg_end:
+                child_start = offset
                 child_id, child_id_len, _ = _ebml_read_vint(
                     data, offset, keep_marker=True,
                 )
-                if child_id == _EBML_ID_CLUSTER:
-                    return offset
                 offset += child_id_len
                 child_size, child_size_len, child_unknown = _ebml_read_vint(
                     data, offset, keep_marker=False,
                 )
                 offset += child_size_len
+                yield child_id, child_start
                 if child_unknown:
-                    raise ValueError(
-                        "Unexpected unknown-size element inside Segment "
-                        "before first Cluster"
-                    )
+                    return
                 offset += child_size
-            raise ValueError("No Cluster element found inside Segment")
+            return
 
         # Top-level non-Segment element (typically just the EBML header);
         # skip its body entirely.
@@ -541,6 +187,30 @@ def find_first_cluster_offset(data: bytes) -> int:
     raise ValueError("No Segment element found in buffer")
 
 
+def find_first_cluster_offset(data: bytes) -> int:
+    """Return the byte offset of the first Matroska Cluster element.
+
+    Raises ValueError on malformed EBML or if no Cluster is found.
+    """
+    for child_id, start in _walk_segment_children(data):
+        if child_id == _EBML_ID_CLUSTER:
+            return start
+    raise ValueError("No Cluster element found inside Segment")
+
+
+def find_all_cluster_offsets(data: bytes) -> list:
+    """Return byte offsets of every Cluster element in the first Segment.
+
+    Useful for splitting a complete MediaRecorder WebM into per-cluster
+    fragment files (e.g. for integration tests that want to simulate a
+    batch of 20 raw-cluster chunks).
+    """
+    return [
+        start for child_id, start in _walk_segment_children(data)
+        if child_id == _EBML_ID_CLUSTER
+    ]
+
+
 def extract_webm_init_segment(data: bytes) -> bytes:
     """Return the init segment of a MediaRecorder WebM blob.
 
@@ -550,8 +220,28 @@ def extract_webm_init_segment(data: bytes) -> bytes:
     we persist them once and prepend to future batches that don't start at
     chunk 0 — otherwise those batches would be header-less cluster data
     that ffmpeg can't remux.
+
+    Verifies a Tracks element is present in the extracted prefix. Without
+    it the WebM has no decodable stream description; returning such an init
+    would let chunk-0 upload succeed and batch 2 silently fail at ffmpeg
+    remux time.
     """
-    return data[:find_first_cluster_offset(data)]
+    cluster_offset = None
+    saw_tracks = False
+    for child_id, start in _walk_segment_children(data):
+        if child_id == _EBML_ID_TRACKS:
+            saw_tracks = True
+        elif child_id == _EBML_ID_CLUSTER:
+            cluster_offset = start
+            break
+    if cluster_offset is None:
+        raise ValueError("No Cluster element found inside Segment")
+    if not saw_tracks:
+        raise ValueError(
+            "Init segment is missing a Tracks element — "
+            "chunk 0 is structurally malformed"
+        )
+    return data[:cluster_offset]
 
 
 def concat_webm_fragments(paths: list,

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -133,9 +133,20 @@ def persist_init_segment(
     init_path = chunk_dir / "init.webm"
     with open(init_path, 'wb') as f:
         f.write(init_bytes)
-    # encrypt_file is a no-op returning the original path when encryption
-    # is disabled; no return value to track.
-    encrypt_file(str(init_path))
+    try:
+        # encrypt_file is a no-op returning the original path when
+        # encryption is disabled; no return value to track. On success it
+        # removes the plaintext init.webm and writes init.webm.enc.
+        encrypt_file(str(init_path))
+    except Exception:
+        # KMS outage or any other encrypt failure — don't leave a
+        # plaintext init.webm on disk for a subsequent batch to pick up
+        # and mistakenly treat as its own (unencrypted) init segment.
+        try:
+            init_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _walk_segment_children(data: bytes):

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -437,6 +437,56 @@ def fix_last_chunk_duration(chunk_dir: str) -> Tuple[bool, str]:
         return False, f"Failed to fix {os.path.basename(last_chunk)}: {message}"
 
 
+def concat_webm_fragments(paths: list, output_suffix: str = '.webm') -> str:
+    """Concatenate MediaRecorder timeslice fragments into one valid WebM.
+
+    MediaRecorder with a timeslice emits Matroska *fragments* of a single
+    continuous stream — only the first blob carries the EBML/Segment/Tracks
+    header; subsequent blobs are header-less cluster data with timestamps
+    absolute to the original recording. Per the MSE byte-stream format, those
+    fragments concatenated in order as raw bytes form exactly one valid
+    Matroska file. This function does that append, then runs a single ffmpeg
+    remux pass to rewrite the container's Duration/Cues so the output is
+    seekable and reports the correct length.
+    """
+    if not paths:
+        raise ValueError("No fragments to concatenate")
+
+    # Step 1: binary-append fragments in order
+    fd, raw_path = tempfile.mkstemp(suffix=output_suffix, prefix='frag_raw_')
+    os.close(fd)
+    try:
+        with open(raw_path, 'wb') as out:
+            for p in paths:
+                with open(p, 'rb') as src:
+                    shutil.copyfileobj(src, out)
+
+        # Step 2: remux so Duration/Cues reflect all clusters, not just the
+        # first (MediaRecorder never writes a final Duration element, and
+        # browsers/Whisper rely on it).
+        fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
+        os.close(fd)
+        result = subprocess.run(
+            ['ffmpeg', '-y', '-fflags', '+genpts',
+             '-i', raw_path, '-c', 'copy', out_path],
+            capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode != 0:
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"ffmpeg remux failed: {result.stderr[:500]}"
+            )
+        return out_path
+    finally:
+        try:
+            os.unlink(raw_path)
+        except OSError:
+            pass
+
+
 def concat_audio_files(paths: list, output_suffix: str = '.webm') -> str:
     """Concatenate multiple audio files using ffmpeg concat demuxer.
 

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -18,6 +18,7 @@ Covers:
 
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -80,7 +81,9 @@ def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
         raise ValueError(f"VINT read past end of buffer at offset {offset}")
     first = data[offset]
     if first == 0:
-        # Would imply a VINT longer than 8 bytes; invalid for our purposes.
+        # A first byte of 0x00 would indicate a VINT of 9+ bytes (per the
+        # spec, the length is derived from the leading zeros before the
+        # first set bit). EBML caps VINT length at 8, so 0x00 is invalid.
         raise ValueError(f"Invalid VINT at offset {offset}: first byte is 0")
 
     length = 1
@@ -108,7 +111,9 @@ def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
     return value, length, is_unknown
 
 
-def persist_init_segment(chunk_path, chunk_dir) -> None:
+def persist_init_segment(
+    chunk_path: pathlib.Path, chunk_dir: pathlib.Path,
+) -> None:
     """Extract the init segment from a chunk-0 file on disk and persist it
     at `chunk_dir/init.webm.enc` (or `init.webm` if encryption is disabled).
 
@@ -262,6 +267,9 @@ def concat_webm_fragments(paths: list,
     pass `init_segment_path` pointing at a previously-extracted init segment
     (see `extract_webm_init_segment`). Its bytes are binary-prepended so the
     resulting file has a valid EBML/Segment/Tracks prefix.
+
+    Returns the path to the merged output file. Caller is responsible for
+    cleaning it up (parity with `concat_audio_files`).
     """
     if not paths:
         raise ValueError("No fragments to concatenate")

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -437,7 +437,126 @@ def fix_last_chunk_duration(chunk_dir: str) -> Tuple[bool, str]:
         return False, f"Failed to fix {os.path.basename(last_chunk)}: {message}"
 
 
-def concat_webm_fragments(paths: list, output_suffix: str = '.webm') -> str:
+# Matroska element IDs we care about for init-segment extraction.
+_EBML_ID_SEGMENT = 0x18538067
+_EBML_ID_CLUSTER = 0x1F43B675
+
+
+def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
+    """Read an EBML variable-length integer at `offset`.
+
+    With `keep_marker=True` the full VINT bytes are returned verbatim as the
+    value — used for element IDs, whose canonical form keeps the length
+    marker bit. With `keep_marker=False` the marker is stripped — used for
+    element sizes.
+
+    Returns (value, bytes_consumed, is_unknown_size). `is_unknown_size` is
+    only meaningful for size fields (keep_marker=False) and is True when all
+    data bits are set, which the spec reserves for "size unknown" (e.g.
+    MediaRecorder emits this for its open-ended Segment element).
+    """
+    if offset >= len(data):
+        raise ValueError(f"VINT read past end of buffer at offset {offset}")
+    first = data[offset]
+    if first == 0:
+        # Would imply a VINT longer than 8 bytes; invalid for our purposes.
+        raise ValueError(f"Invalid VINT at offset {offset}: first byte is 0")
+
+    length = 1
+    mask = 0x80
+    while (first & mask) == 0:
+        length += 1
+        mask >>= 1
+        if length > 8:
+            raise ValueError(f"VINT too long at offset {offset}")
+    if offset + length > len(data):
+        raise ValueError(f"VINT truncated at offset {offset}")
+
+    if keep_marker:
+        value = 0
+        for i in range(length):
+            value = (value << 8) | data[offset + i]
+        is_unknown = False
+    else:
+        value = first & (mask - 1)
+        for i in range(1, length):
+            value = (value << 8) | data[offset + i]
+        # Unknown-size marker: all data bits set (2^(7N) - 1 for length N)
+        is_unknown = value == ((1 << (7 * length)) - 1)
+
+    return value, length, is_unknown
+
+
+def find_first_cluster_offset(data: bytes) -> int:
+    """Return the byte offset of the first Matroska Cluster element.
+
+    Walks the EBML element tree — top-level elements, then the Segment's
+    children — and stops at the first element with ID 0x1F43B675. Does *not*
+    do a byte-pattern search, so magic bytes that happen to occur inside
+    other elements (CodecPrivate, track UIDs) are ignored.
+
+    Raises ValueError on malformed EBML or if no Cluster is found.
+    """
+    offset = 0
+    while offset < len(data):
+        id_val, id_len, _ = _ebml_read_vint(data, offset, keep_marker=True)
+        offset += id_len
+        size_val, size_len, size_unknown = _ebml_read_vint(
+            data, offset, keep_marker=False,
+        )
+        offset += size_len
+
+        if id_val == _EBML_ID_SEGMENT:
+            # Parse children of Segment linearly. MediaRecorder emits the
+            # Segment with unknown size; in that case walk until we run out
+            # of bytes or hit a Cluster.
+            seg_end = len(data) if size_unknown else offset + size_val
+            while offset < seg_end:
+                child_id, child_id_len, _ = _ebml_read_vint(
+                    data, offset, keep_marker=True,
+                )
+                if child_id == _EBML_ID_CLUSTER:
+                    return offset
+                offset += child_id_len
+                child_size, child_size_len, child_unknown = _ebml_read_vint(
+                    data, offset, keep_marker=False,
+                )
+                offset += child_size_len
+                if child_unknown:
+                    raise ValueError(
+                        "Unexpected unknown-size element inside Segment "
+                        "before first Cluster"
+                    )
+                offset += child_size
+            raise ValueError("No Cluster element found inside Segment")
+
+        # Top-level non-Segment element (typically just the EBML header);
+        # skip its body entirely.
+        if size_unknown:
+            raise ValueError(
+                "Unexpected unknown-size top-level element before Segment"
+            )
+        offset += size_val
+
+    raise ValueError("No Segment element found in buffer")
+
+
+def extract_webm_init_segment(data: bytes) -> bytes:
+    """Return the init segment of a MediaRecorder WebM blob.
+
+    Everything up to the first Matroska Cluster is the init segment
+    (EBML header + Segment header + SeekHead? + Info + Tracks). Those bytes
+    never change over the lifetime of a single MediaRecorder recording, so
+    we persist them once and prepend to future batches that don't start at
+    chunk 0 — otherwise those batches would be header-less cluster data
+    that ffmpeg can't remux.
+    """
+    return data[:find_first_cluster_offset(data)]
+
+
+def concat_webm_fragments(paths: list,
+                          init_segment_path: Optional[str] = None,
+                          output_suffix: str = '.webm') -> str:
     """Concatenate MediaRecorder timeslice fragments into one valid WebM.
 
     MediaRecorder with a timeslice emits Matroska *fragments* of a single
@@ -448,15 +567,23 @@ def concat_webm_fragments(paths: list, output_suffix: str = '.webm') -> str:
     Matroska file. This function does that append, then runs a single ffmpeg
     remux pass to rewrite the container's Duration/Cues so the output is
     seekable and reports the correct length.
+
+    For batches that don't include the first fragment of the recording,
+    pass `init_segment_path` pointing at a previously-extracted init segment
+    (see `extract_webm_init_segment`). Its bytes are binary-prepended so the
+    resulting file has a valid EBML/Segment/Tracks prefix.
     """
     if not paths:
         raise ValueError("No fragments to concatenate")
 
-    # Step 1: binary-append fragments in order
+    # Step 1: binary-append init segment (if any) + fragments in order
     fd, raw_path = tempfile.mkstemp(suffix=output_suffix, prefix='frag_raw_')
     os.close(fd)
     try:
         with open(raw_path, 'wb') as out:
+            if init_segment_path:
+                with open(init_segment_path, 'rb') as src:
+                    shutil.copyfileobj(src, out)
             for p in paths:
                 with open(p, 'rb') as src:
                     shutil.copyfileobj(src, out)

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -1,32 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 
 /**
- * Extract the WebM header (initialization segment) from an ArrayBuffer.
- * The header includes EBML, Segment, Info, and Tracks elements.
- * Everything before the first Cluster element (ID: 0x1F 0x43 0xB6 0x75) is the header.
- *
- * @param {ArrayBuffer} buffer - The first chunk's data
- * @returns {ArrayBuffer} - The header bytes
- */
-function extractWebMHeader(buffer) {
-  const data = new Uint8Array(buffer);
-
-  // WebM Cluster element ID: 0x1F 0x43 0xB6 0x75
-  // Find the first occurrence of this sequence
-  for (let i = 0; i < data.length - 3; i++) {
-    if (data[i] === 0x1F && data[i + 1] === 0x43 && data[i + 2] === 0xB6 && data[i + 3] === 0x75) {
-      // Found the Cluster element - everything before it is the header
-      return buffer.slice(0, i);
-    }
-  }
-
-  // If no Cluster found, return a reasonable portion as header (first 4KB)
-  // This shouldn't happen in normal recordings
-  console.warn('WebM Cluster element not found, using first 4KB as header');
-  return buffer.slice(0, Math.min(4096, buffer.byteLength));
-}
-
-/**
  * useStreamingMediaRecorder hook for recording audio with real-time chunk emission.
  *
  * This hook uses MediaRecorder with timeslice to emit audio chunks at regular intervals
@@ -51,7 +25,6 @@ export function useStreamingMediaRecorder({
   const chunksRef = useRef([]); // All chunks for final assembly
   const chunkIndexRef = useRef(0);
   const durationIntervalRef = useRef(null);
-  const webmHeaderRef = useRef(null); // Store WebM header from first chunk
   const stopResolveRef = useRef(null); // Resolve fn for the stop promise
   const dataAvailableFiredRef = useRef(false); // Track if ondataavailable ran during stop
   const pausedAtRef = useRef(null); // Timestamp when paused
@@ -89,7 +62,6 @@ export function useStreamingMediaRecorder({
     streamRef.current = null;
     chunksRef.current = [];
     chunkIndexRef.current = 0;
-    webmHeaderRef.current = null;
     pausedAtRef.current = null;
     totalPausedMsRef.current = 0;
     setMediaBlob(null);
@@ -121,53 +93,34 @@ export function useStreamingMediaRecorder({
       chunksRef.current = [];
       chunkIndexRef.current = startingChunkIndex;
 
-      mediaRecorder.ondataavailable = async (e) => {
+      // MediaRecorder with a timeslice emits Matroska *fragments* of one
+      // continuous stream — only chunk 0 has an EBML header; chunks 1+ are
+      // header-less cluster data whose timestamps are absolute to the
+      // original recording. These fragments, concatenated in order as raw
+      // bytes on the server, form exactly one valid WebM. So we upload each
+      // blob verbatim and let the backend do the binary concat + a single
+      // remux pass to rewrite duration metadata.
+      mediaRecorder.ondataavailable = (e) => {
         const recorderState = recorderRef.current?.state || 'unknown';
         console.log(`[StreamingRecorder] ondataavailable fired: size=${e.data?.size || 0}, recorderState=${recorderState}, timeSinceStart=${Date.now() - startTimeRef.current}ms`);
 
-        // Flag set synchronously so onstop knows we ran (before any await)
         dataAvailableFiredRef.current = true;
 
         if (e.data && e.data.size > 0) {
           chunksRef.current.push(e.data);
 
-          // Call the onChunkReady callback for streaming transcription
-          // Upload ALL chunks including the final one - needed for short recordings
           if (onChunkReady) {
             const chunkIndex = chunkIndexRef.current;
             chunkIndexRef.current += 1;
             setChunkCount(prev => prev + 1);
 
-            let chunkBlob;
-
-            if (chunkIndex === 0) {
-              // First chunk contains the WebM header - extract and store it
-              // The header includes EBML, Segment, Info, and Tracks elements
-              const arrayBuffer = await e.data.arrayBuffer();
-              const header = extractWebMHeader(arrayBuffer);
-              webmHeaderRef.current = header;
-
-              // First chunk is already valid, use as-is
-              chunkBlob = new Blob([e.data], { type: mediaRecorder.mimeType });
-            } else {
-              // Subsequent chunks need the header prepended to be valid WebM files
-              if (webmHeaderRef.current) {
-                chunkBlob = new Blob([webmHeaderRef.current, e.data], { type: mediaRecorder.mimeType });
-              } else {
-                // Fallback if header extraction failed
-                chunkBlob = new Blob([e.data], { type: mediaRecorder.mimeType });
-              }
-            }
-
-            console.log(`[StreamingRecorder] Chunk ${chunkIndex} ready: blobSize=${chunkBlob.size}, rawSize=${e.data.size}, totalChunks=${chunksRef.current.length}`);
-            onChunkReady(chunkBlob, chunkIndex);
+            console.log(`[StreamingRecorder] Chunk ${chunkIndex} ready: size=${e.data.size}, totalChunks=${chunksRef.current.length}`);
+            onChunkReady(e.data, chunkIndex);
           }
         } else {
           console.warn(`[StreamingRecorder] ondataavailable with empty data: size=${e.data?.size}, recorderState=${recorderState}`);
         }
 
-        // If we're stopping, the final chunk has been processed and upload enqueued.
-        // Resolve the stop promise so stopStreaming knows it's safe to finalize.
         if (stopResolveRef.current) {
           stopResolveRef.current();
           stopResolveRef.current = null;

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -159,10 +159,12 @@ export function useStreamingTranscription(options = {}) {
         setUploadedChunks(prev => prev + 1);
         totalChunksRef.current = Math.max(totalChunksRef.current, chunkIndex + 1);
       } else {
-        // Store failed chunk for retry when network returns. (Pointless for
-        // the fatal-error case, but keeping the same path for simplicity —
-        // the fatalError branch just doesn't wait for network.)
-        failedChunksRef.current.push({ blob, chunkIndex, sessionId });
+        // Queue for reconnect retry only if the failure wasn't fatal —
+        // retrying a parse-failed chunk will produce the same bytes and
+        // the same 500, so it would just loop on every online event.
+        if (!result.fatalError) {
+          failedChunksRef.current.push({ blob, chunkIndex, sessionId });
+        }
         playErrorSound();
         if (onError) {
           onError(new Error(
@@ -329,12 +331,14 @@ export function useStreamingTranscription(options = {}) {
         failedChunksRef.current = [];
 
         for (const { blob, chunkIndex, sessionId } of chunksToRetry) {
-          const success = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
-          if (success) {
+          const result = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
+          if (result.success) {
             setUploadedChunks(prev => prev + 1);
             totalChunksRef.current = Math.max(totalChunksRef.current, chunkIndex + 1);
-          } else {
-            // Still failing — put it back
+          } else if (!result.fatalError) {
+            // Still failing for a retryable reason — put it back for the
+            // next online event. Fatal errors (e.g. webm_header_parse_failed)
+            // are deterministic, so we drop them rather than loop.
             failedChunksRef.current.push({ blob, chunkIndex, sessionId });
           }
         }

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -124,9 +124,9 @@ export function useStreamingTranscription(options = {}) {
         // (MediaRecorder on this browser produced bytes we don't recognize).
         // Retrying will yield the exact same bytes, so short-circuit with a
         // fatal-error message the caller can surface distinctly from
-        // ordinary network flakiness.
-        const serverCode = err.response?.data?.code;
-        if (err.response?.status === 500 && serverCode === 'webm_header_parse_failed') {
+        // ordinary network flakiness. Key only on the stable code field so
+        // the status code can change without regressing this check.
+        if (err.response?.data?.code === 'webm_header_parse_failed') {
           const detail = err.response?.data?.detail || 'unknown parse error';
           console.error(`[StreamingTranscription] Fatal: server could not parse chunk ${chunkIndex}'s WebM header (${detail}); not retrying`);
           return {

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -91,7 +91,10 @@ export function useStreamingTranscription(options = {}) {
 
   /**
    * Upload a single chunk with exponential backoff retry.
-   * Returns true on success, false if all retries exhausted.
+   * Returns { success: true } on success, or { success: false, fatalError?: string }
+   * on failure. `fatalError` is set when the server returned a deterministic
+   * error (e.g. chunk 0's WebM header didn't parse) where retrying wouldn't
+   * help — retries are skipped and the caller surfaces a distinct message.
    */
   const uploadChunkWithRetry = useCallback(async (blob, chunkIndex, sessionId) => {
     const maxRetries = 4;
@@ -109,19 +112,34 @@ export function useStreamingTranscription(options = {}) {
         });
 
         console.log(`[StreamingTranscription] Upload complete: chunk=${chunkIndex}` + (attempt > 0 ? ` (after ${attempt} retries)` : ''));
-        return true;
+        return { success: true };
       } catch (err) {
+        // Server rejected chunk 0 because it couldn't parse the WebM header
+        // (MediaRecorder on this browser produced bytes we don't recognize).
+        // Retrying will yield the exact same bytes, so short-circuit with a
+        // fatal-error message the caller can surface distinctly from
+        // ordinary network flakiness.
+        const serverCode = err.response?.data?.code;
+        if (err.response?.status === 500 && serverCode === 'webm_header_parse_failed') {
+          const detail = err.response?.data?.detail || 'unknown parse error';
+          console.error(`[StreamingTranscription] Fatal: server could not parse chunk ${chunkIndex}'s WebM header (${detail}); not retrying`);
+          return {
+            success: false,
+            fatalError: `Your browser produced an audio format we can't process. Please try a different browser or device. (${detail})`,
+          };
+        }
+
         if (attempt < maxRetries) {
           const delay = baseDelay * Math.pow(2, attempt); // 2s, 4s, 8s, 16s
           console.warn(`[StreamingTranscription] Upload failed (attempt ${attempt + 1}/${maxRetries + 1}): chunk=${chunkIndex}, retrying in ${delay}ms...`, err.message);
           await new Promise(resolve => setTimeout(resolve, delay));
         } else {
           console.error(`[StreamingTranscription] Upload FAILED after ${maxRetries + 1} attempts: chunk=${chunkIndex}`, err);
-          return false;
+          return { success: false };
         }
       }
     }
-    return false;
+    return { success: false };
   }, []);
 
   // Handle chunk upload
@@ -135,17 +153,22 @@ export function useStreamingTranscription(options = {}) {
     console.log(`[StreamingTranscription] Starting upload: chunk=${chunkIndex}, blobSize=${blob.size}, session=${sessionId}`);
 
     const uploadPromise = (async () => {
-      const success = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
+      const result = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
 
-      if (success) {
+      if (result.success) {
         setUploadedChunks(prev => prev + 1);
         totalChunksRef.current = Math.max(totalChunksRef.current, chunkIndex + 1);
       } else {
-        // Store failed chunk for retry when network returns
+        // Store failed chunk for retry when network returns. (Pointless for
+        // the fatal-error case, but keeping the same path for simplicity —
+        // the fatalError branch just doesn't wait for network.)
         failedChunksRef.current.push({ blob, chunkIndex, sessionId });
         playErrorSound();
         if (onError) {
-          onError(new Error(`Failed to upload chunk ${chunkIndex} after retries`));
+          onError(new Error(
+            result.fatalError
+            || `Failed to upload chunk ${chunkIndex} after retries`
+          ));
         }
       }
     })();

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -86,6 +86,12 @@ export function useStreamingTranscription(options = {}) {
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
 
+  // Indirection ref: uploadChunk (defined below) needs to stop the recorder
+  // on a fatal upload error, but the recorder's reset fn isn't in scope yet
+  // because useStreamingMediaRecorder is called *after* uploadChunk. Wire it
+  // up via a ref that gets populated once the recorder hook has returned.
+  const resetMediaRecorderRef = useRef(null);
+
   // Network status
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
@@ -164,6 +170,16 @@ export function useStreamingTranscription(options = {}) {
         // the same 500, so it would just loop on every online event.
         if (!result.fatalError) {
           failedChunksRef.current.push({ blob, chunkIndex, sessionId });
+        } else {
+          // Stop the MediaRecorder so the mic turns off and no further
+          // chunks are recorded into a doomed session. The user has already
+          // been shown a device-compatibility error; letting them keep
+          // talking into the void would be worse than silent.
+          if (resetMediaRecorderRef.current) {
+            resetMediaRecorderRef.current();
+          }
+          setSessionState('error');
+          setErrorMessage(result.fatalError);
         }
         playErrorSound();
         if (onError) {
@@ -197,6 +213,11 @@ export function useStreamingTranscription(options = {}) {
     chunkIntervalMs,
     onChunkReady: uploadChunk,
   });
+
+  // Populate the indirection ref so uploadChunk can stop the recorder
+  // on a fatal upload error (declared above, resetMediaRecorder not yet
+  // in scope there).
+  resetMediaRecorderRef.current = resetMediaRecorder;
 
   // SSE subscription for transcription updates (draft-based)
   const {

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -159,10 +159,12 @@ export function useStreamingTranscription(options = {}) {
         setUploadedChunks(prev => prev + 1);
         totalChunksRef.current = Math.max(totalChunksRef.current, chunkIndex + 1);
       } else {
-        // Store failed chunk for retry when network returns. (Pointless for
-        // the fatal-error case, but keeping the same path for simplicity —
-        // the fatalError branch just doesn't wait for network.)
-        failedChunksRef.current.push({ blob, chunkIndex, sessionId });
+        // Queue for reconnect retry only if the failure wasn't fatal —
+        // retrying a parse-failed chunk will produce the same bytes and
+        // the same 500, so it would just loop on every online event.
+        if (!result.fatalError) {
+          failedChunksRef.current.push({ blob, chunkIndex, sessionId });
+        }
         playErrorSound();
         if (onError) {
           onError(new Error(
@@ -333,12 +335,14 @@ export function useStreamingTranscription(options = {}) {
         failedChunksRef.current = [];
 
         for (const { blob, chunkIndex, sessionId } of chunksToRetry) {
-          const success = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
-          if (success) {
+          const result = await uploadChunkWithRetry(blob, chunkIndex, sessionId);
+          if (result.success) {
             setUploadedChunks(prev => prev + 1);
             totalChunksRef.current = Math.max(totalChunksRef.current, chunkIndex + 1);
-          } else {
-            // Still failing — put it back
+          } else if (!result.fatalError) {
+            // Still failing for a retryable reason — put it back for the
+            // next online event. Fatal errors (e.g. webm_header_parse_failed)
+            // are deterministic, so we drop them rather than loop.
             failedChunksRef.current.push({ blob, chunkIndex, sessionId });
           }
         }


### PR DESCRIPTION
## Summary

Voice recordings were being silently truncated on some browser/device combos — Peter hit it as a 3.5 min recording that only played back ~14s. Two cooperating issues and one additional surface:

1. **Byte-pattern header search was fooled.** `useStreamingMediaRecorder.js` extracted chunk 0's WebM header by scanning for the Cluster magic `1F 43 B6 75`. Those four bytes can appear inside other EBML elements (CodecPrivate, track UIDs), so the search sometimes returned a **truncated header** that corrupted chunks 1+. The backend's `ffmpeg -f concat -c copy` then gagged on those chunks at a garbage EBML VINT around byte 400, silently dropped them, and wrote a 226 KB batch file containing only chunk 0's ~14s of audio. Whisper transcribed the stub. Everything downstream thought it was fine.

2. **Chunks 1+ aren't standalone WebMs.** MediaRecorder timeslice blobs are Matroska *fragments* — only chunk 0 carries the EBML/Segment/Tracks prefix. Chunks are batched server-side in groups of 20 (~5 min), so any recording longer than ~5 min has multi-batch runs where batches 2+ need an init segment from elsewhere.

3. **Error handling was silent.** Parse failures logged a warning but accepted the upload; later batches failed with one-line logs visible only in worker output. No user-facing signal.

## What changed

### Backend
- **New `extract_webm_init_segment` + `find_first_cluster_offset` in `webm_utils.py`** — proper EBML walker via a shared `_walk_segment_children` generator. Handles unknown-size VINTs for MediaRecorder's open-ended Segment. Ignores magic bytes inside CodecPrivate / track UIDs by skipping past declared element sizes. Sanity-checks that the extracted prefix contains a Tracks element; rejects malformed chunk 0 before it can hurt batch 2.
- **`persist_init_segment` helper** — extracted from the route handler so the chunk-0 persistence path (extract → write `init.webm` → encrypt) is unit-testable.
- **`concat_webm_fragments` replaces `-f concat -c copy` for the streaming path** — binary-appends fragments into one file and runs a single `ffmpeg -fflags +genpts -c copy` remux. Optional `init_segment_path` is binary-prepended first, so batches 2+ (which lack chunk 0's header) come out as valid WebM.
- **On chunk 0 upload** (`routes/drafts.py`): extract the init segment and persist as `session_dir/init.webm.enc` before encryption deletes the plaintext. On parse failure: delete the chunk, skip DB insert, return `HTTP 400 {"error": "...", "detail": "...", "code": "webm_header_parse_failed"}` so the frontend can surface a device-compatibility message rather than retry silently.
- **`init.webm.enc` is ephemeral.** All three draft→node move sites unlink it rather than moving it into node storage.
- **Existing `concat_audio_files` untouched.** The download-node-audio endpoint still needs the ffmpeg concat demuxer for stitching standalone batch files; that path is safe.

### Frontend
- `useStreamingMediaRecorder.js`: removed `extractWebMHeader` and the header-prepend branch. Each `ondataavailable` blob is uploaded verbatim.
- `useStreamingTranscription.js`: chunk-upload retry loop short-circuits when the server returns `code: "webm_header_parse_failed"`, calls `onError` with `"Your browser produced an audio format we can't process. Please try a different browser or device. (<detail>)"` instead of the generic retry-exhausted message.

### Cleanup
- Deleted dead code: `fix_webm_duration`, `fix_last_chunk_duration`, `_set_ebml_duration`, `_find_info_element`, `_find_duration_in_info`, `_read_vint` (old variant), `_read_element_id`, `_get_webm_start_time`, plus their two callers in `routes/drafts.py` and `utils/audio_storage.py`. Net −197 lines across the PR.
- Removed the `is_final_batch` parameter from `transcribe_chunk_batch` — only existed to gate the now-deleted duration-fix call.
- Stale comment in `audio_processing.py` updated.

## Migration / deploy note

Sessions whose chunk 0 was uploaded before this deploy have no `init.webm.enc` on disk. After deploy, any batch 2+ that runs for those in-flight sessions will log `"No init segment found for session ..."` and `concat_webm_fragments` will raise `RuntimeError`, marking those chunks `failed`. This is a net improvement over the pre-fix silent truncation — loud failure is visible in worker logs and surfaces to the user — but worth noting. Low practical impact since typical sessions are short.

No ongoing-session data at rest needs migrating: existing finalized nodes and their `batch_*.webm.enc` files were produced by the old path and are untouched here.

## Test plan

### Automated (CI)
- [x] `flake8 backend --select=E9,F63,F7,F82` → 0 errors
- [x] `pytest` → 202 passed, including:
  - 8 unit tests for the EBML walker (multi-byte IDs, unknown-size Segment, Tracks-missing rejection, cluster magic inside CodecPrivate, `find_all_cluster_offsets` happy path)
  - 3 unit tests for `persist_init_segment` (happy path, unparseable bytes, missing Tracks — covers the route glue without Flask boilerplate)
  - 3 integration tests for `concat_webm_fragments`: batch-1 (chunk-0-included), batch-2+ (multi-cluster fragments with init prepended, using a 5s source split at every cluster boundary), and a guard that body-only-without-init genuinely fails ffmpeg
- [x] `npm run build` → compiled successfully

### Manual — staging end-to-end (Apr 29)

Replayed an 8-minute Loore voice note from a second device while recording via Voice mode on staging. The recording crosses the 20-chunk (5 min) batch boundary, so the server runs `batch_0000-0019.webm.enc` (chunks 0–19, includes chunk 0's header) **and** `batch_0020-0031.webm.enc` (chunks 20–31, requires the cached init segment). Both batches transcribed correctly; the second-batch path is what the PR fixes.

**Run 1 — iPhone Safari (the previously-failing device):**
- [x] **Batch 1** (chunks 0–19): full transcript, no truncation. Substantively matches the original recording end-to-end.
- [x] **Batch 2** (chunks 20–31): full transcript with intelligible content. The earlier "こんばんは" Whisper-on-silence hallucination was caused by the source phone pausing replay after 5 min; with the source playing through to the end, batch 2 produces real text. Init-segment + concat path produces a valid WebM that decodes correctly.
- [x] **Boundary handoff:** batch 1 ended at "I went back to finishing my taxes, I did, I did file"; batch 2 began at "or like start working on the steps for filing the claim to the Irish tax". 4-word overlap rather than a gap or duplication — cluster timestamps line up across the cut.
- [x] **Original byte-pattern bug** no longer reproduces on this device.

**Run 2 — normal device (cross-check on a second browser/OS):**
- [x] **Batch 1**: full transcript with the leading "April 28" intact (caught the very start of the source). Same content as Run 1.
- [x] **Batch 2**: full transcript with intelligible content; no silence-hallucination artifacts.
- [x] **Boundary handoff:** batch 1 ended at "I went back to finishing my taxes, I did."; batch 2 began at "I filed or like start working on the steps…". The source has these phrases adjacent ("I did, I did file…"), so the cut landed exactly between them — no drop, no duplication.
- [x] **Whisper variance only** between the two runs (proper-noun substitutions like Herbert → "my birds"/"Albert", Paya → "Baya"/"Maya"; word swaps like "low"/"lull"). Names also vary between batches inside the same run, confirming this is Whisper, not the chunk pipeline.

### Manual — known-good paths (smoke)

- [x] Short (≤30 s) recording on the same device — single-batch, no regression.
- [x] `GET /api/nodes/<id>/audio-download?format=webm` on a multi-batch node — unchanged path, still serves the merged file.

### Out of scope (separate issue)

- iOS Safari pauses playback at the batch boundary in the global audio queue when auto-advancing (skip-ahead and skip-back across the boundary work). This is `<audio>`-element autoplay restriction (per-`(element, src)` user-gesture requirement on iOS) — orthogonal to the chunk-header-corruption fix in this PR. Fix path is server-side concat into one file or Web Audio API; tracked for a follow-up.

## Commit summary

1. `d4560fc` — Frontend uploads fragments verbatim; new `concat_webm_fragments` (binary-append + remux); drop pre-concat `fix_webm_duration`.
2. `1b8c487` — EBML walker + `extract_webm_init_segment`; persist init at chunk-0 upload; batch-2+ prepends cached init.
3. `0ac0d58` — Reject chunk-0 upload on init parse failure.
4. `a461de2` — Initial integration tests for `concat_webm_fragments`.
5. `7e2b278` — Multi-cluster test upgrade, Tracks sanity check, route-glue helper + tests, frontend error distinction, init-segment cleanup on move, dead-code removal.
6. `78e2a67` — Fix reconnect-retry reading `uploadChunkWithRetry`'s return as a boolean after the `{success, fatalError}` refactor; drop fatal chunks from the reconnect queue; narrow chunk-0 except clause; type hints + docstring polish.
7. `a43dd79` — Hoist `persist_init_segment` to module-level import; extract shared `move_draft_audio_to_node_dir` helper so the three draft→node move sites aren't copy-pasted.
8. `9590b52` — Stop `MediaRecorder` on fatal chunk-upload error at the hook level, so consumers don't need to wire `stopRecording` into their `onError` handlers. User's mic actually turns off instead of them talking into the void.
9. `1366327` — Review nits: hoist `move_draft_audio_to_node_dir` imports for consistency; unlink plaintext `init.webm` if `encrypt_file` raises; return `400` instead of `500` for `webm_header_parse_failed` (it's bad client input, not a server failure) and key the frontend short-circuit only on the stable `code` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
