### PR TITLE
Broaden {user_export} to engagement graph; add max_export_tokens modifier

### DIFF
--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -770,25 +770,36 @@ def build_user_export_content(
     user, max_tokens=None, filter_ai_usage=False,
     created_before=None, created_after=None,
     chronological_order=False, return_metadata=False,
-    collapse_artifacts=False
+    collapse_artifacts=False,
+    include_strategy="authored_threads",
 ):
     """
     Core export logic: Build a human-readable text export of threads for a user.
 
-    Two modes:
-      - **Legacy (default, `created_after is None`)**: includes top-level
-        threads owned by the user (`Node.user_id == user.id`,
-        `parent_id IS NULL`) and walks their accessible descendants.
-        Used for user-facing data export and full-archive profile gen.
-      - **Incremental (`created_after is not None`)**: includes the user's
-        post-cutoff "anchors" (own or addressed nodes) plus their accessible
-        post-cutoff ancestors and descendants. Foreign post-cutoff ancestors
-        the target replied to are pulled in (conversational context);
-        foreign siblings the target never engaged with are excluded.
-        Renders entry points (a node in scope whose parent is not in scope)
-        with a short preamble when the entry point sits beneath a pre-cutoff
-        / out-of-scope parent. Used by `recent_context` and iterative
-        profile regen.
+    Two scope topologies, selected by `include_strategy`:
+      - **`authored_threads`** (default): includes top-level threads owned by
+        the user (`Node.user_id == user.id`, `parent_id IS NULL`) and walks
+        their accessible descendants top-down via `format_node_tree`. The
+        user does not need to author every node — replies from others on
+        their threads are included if accessible. Does NOT include foreign
+        threads the user replied to. Matches the user-facing `/export/threads`
+        data dump.
+      - **`engaged_threads`**: anchored on every node where the user is author
+        or `human_owner_id`. From each anchor, climb up through accessible
+        parents to the root or first inaccessible node, and climb down
+        through all accessible descendants. For user-rooted subtrees this is
+        a superset of `authored_threads` (climb-down from the owned root
+        picks up every accessible descendant). For foreign-rooted threads it
+        includes only the climb-up + climb-down path through user replies —
+        foreign sibling branches off the foreign root that the user did not
+        engage with are excluded. Used by `{user_export}` placeholder and
+        `recent_context` summaries.
+
+    NOTE: `include_strategy` is only consulted when `created_after` is None.
+    If `created_after` is set, the function always routes to the anchor-based
+    incremental path regardless of `include_strategy` (the time-floor
+    semantics imply the anchor topology). Preserves backwards compat with
+    existing recent_context callers.
 
     When `max_tokens` is specified, uses `ExportQuoteResolver` for smart
     quote resolution. The resolver may pull in pre-cutoff quoted nodes for
@@ -805,8 +816,9 @@ def build_user_export_content(
                         generation, False for user data export.
         created_before: Optional datetime. If provided, only includes
                        nodes created before this timestamp.
-        created_after: Optional datetime. If provided, switches to the
-                      incremental mode described above.
+        created_after: Optional datetime. If provided, forces the anchor-based
+                      incremental path with a time floor on anchors,
+                      regardless of `include_strategy`.
         chronological_order: If True and max_tokens is set, select oldest
                            nodes first (for iterative profile building).
         return_metadata: If True, return a dict with `content`,
@@ -815,12 +827,22 @@ def build_user_export_content(
                         `node_ids` (set of in-scope node IDs).
         collapse_artifacts: If True, suppress full artifact preambles
                            (artifact ID refs are still inlined).
+        include_strategy: Scope topology when `created_after` is None.
+                         "authored_threads" (default) or "engaged_threads".
+                         Any other value raises ValueError. See module
+                         docstring above for details.
 
     Returns:
         str or dict: Formatted export content (or None if no threads found).
                     If return_metadata=True, returns the dict described above.
     """
-    if created_after is not None:
+    if include_strategy not in ("authored_threads", "engaged_threads"):
+        raise ValueError(
+            f"include_strategy must be 'authored_threads' or "
+            f"'engaged_threads', got {include_strategy!r}"
+        )
+
+    if created_after is not None or include_strategy == "engaged_threads":
         return _build_user_export_incremental(
             user, max_tokens=max_tokens, filter_ai_usage=filter_ai_usage,
             created_before=created_before, created_after=created_after,

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -6,7 +6,6 @@ import re
 from celery import Task
 from celery.utils.log import get_task_logger
 from datetime import datetime
-from urllib.parse import parse_qs
 
 from backend.celery_app import celery, flask_app
 from backend.models import (
@@ -23,20 +22,17 @@ from backend.utils.api_keys import determine_api_key_type, get_api_keys_for_usag
 from backend.utils.cost import calculate_llm_cost_microdollars
 from backend.utils.tool_meta import update_tool_meta, parse_github_issue
 from backend.utils.privacy import AI_ALLOWED
+from backend.utils.placeholders import (
+    USER_EXPORT_PATTERN,
+    parse_placeholder_params,
+    parse_max_export_tokens,
+)
 
 logger = get_task_logger(__name__)
 
-# Pattern for detecting {user_export} with optional URL-style params.
-#
-# Syntax: {user_export} or {user_export?param=value&param2=value2}
-#
-# Supported params:
-#   keep=oldest  - When truncating to fit the context window, keep the oldest
-#                  threads instead of the newest (default). Useful for tasks
-#                  that need early/foundational writing.
-#   keep=newest  - Explicit default: keep the newest threads when truncating.
-#
-USER_EXPORT_PATTERN = re.compile(r"\{user_export(\?[^}]*)?\}")
+# See backend/utils/placeholders.py for USER_EXPORT_PATTERN and the
+# {user_export} placeholder syntax/modifier reference.
+
 # Placeholder for injecting user's AI-generated profile into messages
 USER_PROFILE_PLACEHOLDER = "{user_profile}"
 # Placeholder for injecting user's todo list into messages
@@ -491,20 +487,14 @@ def _execute_tool_calls(tool_calls, llm_node, node_chain, user_id):
     return tool_results
 
 
-def parse_placeholder_params(match_str):
-    """Parse URL-style params from a placeholder like {user_export?keep=oldest}."""
-    if '?' in match_str:
-        qs = match_str.split('?', 1)[1].rstrip('}')
-        return {k: v[0] for k, v in parse_qs(qs).items()}
-    return {}
-
-
 def build_user_export_content(user, max_tokens=None, filter_ai_usage=False,
-                              created_before=None, chronological_order=False):
+                              created_before=None, chronological_order=False,
+                              include_strategy="authored_threads"):
     """Import the actual implementation from export_data routes."""
     from backend.routes.export_data import build_user_export_content as _build
     return _build(user, max_tokens, filter_ai_usage, created_before,
-                  chronological_order=chronological_order)
+                  chronological_order=chronological_order,
+                  include_strategy=include_strategy)
 
 
 def get_user_profile_content(user_id):
@@ -804,7 +794,15 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             # _scan_proposal_statuses above)
 
             if needs_export:
-                max_export_tokens = None  # Send entire archive; let retry loop converge
+                # None = full archive; the retry loop converges if the
+                # prompt overflows. A user-supplied max_export_tokens
+                # becomes the initial budget instead.
+                max_export_tokens = parse_max_export_tokens(
+                    export_params.get('max_export_tokens'),
+                    user_id=user_id,
+                    placeholder=export_placeholder_match,
+                    log=logger,
+                )
 
             # Determine which API key to use based on ai_usage settings
             key_type = determine_api_key_type(node_chain, logger=logger)
@@ -833,9 +831,19 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                             max_tokens=max_export_tokens,
                             filter_ai_usage=True,
                             created_before=created_before,
-                            chronological_order=chronological
+                            chronological_order=chronological,
+                            include_strategy="engaged_threads",
                         )
-                        logger.info(f"Built user export for {user_id}: {len(user_export_content or '')} chars, ~{approximate_token_count(user_export_content or '')} tokens, cutoff={created_before} (attempt {attempt + 1})")
+                        requested_max = export_params.get('max_export_tokens')
+                        logger.info(
+                            f"Built user export for {user_id}: "
+                            f"{len(user_export_content or '')} chars, "
+                            f"~{approximate_token_count(user_export_content or '')} tokens, "
+                            f"cutoff={created_before}, "
+                            f"strategy=engaged_threads, "
+                            f"requested_max={requested_max} "
+                            f"(attempt {attempt + 1})"
+                        )
 
                 # Track which heavy-context placeholders have been replaced
                 # so subsequent occurrences get emptied (dedup).

--- a/backend/tests/test_exports_incremental.py
+++ b/backend/tests/test_exports_incremental.py
@@ -701,3 +701,244 @@ class TestFullArchiveRegression:
             assert f"thread {i} marker text" in result
         # Legacy path doesn't emit the Layer 2 preamble
         assert "Continuation of thread" not in result
+
+
+# ── 15. engaged_threads strategy (created_after=None, anchor-based) ─────
+
+class TestEngagedThreadsStrategy:
+    def test_user_owned_tree_fully_covered_when_only_root_anchor(self, app):
+        """Alice owns a root; Bob posts an accessible public reply; Alice
+        never engages further. With engaged_threads + no cutoff, climb-down
+        from Alice's root anchor must still include Bob's reply (parity
+        with authored_threads on user-owned subtrees)."""
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        _db.session.commit()
+
+        root = _make_node(
+            alice, content="alice owned root marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=100, created_at=DEC_15,
+        )
+        bob_reply = _make_node(
+            bob, parent_id=root.id,
+            content="bob foreign public reply marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=80, created_at=APR_18,
+        )
+        _db.session.commit()
+
+        result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="engaged_threads",
+            return_metadata=True,
+        )
+        assert result is not None
+        content = result["content"]
+
+        assert "alice owned root marker" in content
+        assert "bob foreign public reply marker" in content
+        assert {root.id, bob_reply.id}.issubset(result["node_ids"])
+
+    def test_foreign_public_thread_included_when_user_replied_no_cutoff(self, app):
+        """Bob's public thread; Alice replied. Without a cutoff, Alice's
+        reply is an anchor; climb-up must reach Bob's accessible public
+        root."""
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        _db.session.commit()
+
+        bob_root = _make_node(
+            bob, content="bob public root marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=100, created_at=DEC_15,
+        )
+        bob_reply = _make_node(
+            bob, parent_id=bob_root.id,
+            content="bob public reply marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=80, created_at=APR_18,
+        )
+        alice_reply = _make_node(
+            alice, parent_id=bob_reply.id,
+            content="alice reply marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=60, created_at=APR_19,
+        )
+        _db.session.commit()
+
+        result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="engaged_threads",
+            return_metadata=True,
+        )
+        assert result is not None
+        content = result["content"]
+
+        assert "bob public root marker" in content
+        assert "bob public reply marker" in content
+        assert "alice reply marker" in content
+        assert {bob_root.id, bob_reply.id, alice_reply.id}.issubset(
+            result["node_ids"]
+        )
+
+    def test_private_foreign_ancestor_blocks_climb_no_cutoff(self, app):
+        """Bob's private root; Alice replies inside. Climb-up must stop
+        at the private parent — content & date must not leak."""
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        _db.session.commit()
+
+        bob_private_root = _make_node(
+            bob, content="bob private root secret",
+            privacy_level="private", ai_usage="chat",
+            token_count=100, created_at=DEC_15,
+        )
+        bob_private_reply = _make_node(
+            bob, parent_id=bob_private_root.id,
+            content="bob private reply secret",
+            privacy_level="private", ai_usage="chat",
+            token_count=80, created_at=APR_18,
+        )
+        alice_reply = _make_node(
+            alice, parent_id=bob_private_reply.id,
+            content="alice in private marker",
+            privacy_level="private", ai_usage="chat",
+            token_count=60, created_at=APR_19,
+        )
+        _db.session.commit()
+
+        result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="engaged_threads",
+            return_metadata=True,
+        )
+        content = result["content"]
+
+        assert "alice in private marker" in content
+        assert "bob private root secret" not in content
+        assert "bob private reply secret" not in content
+        # Bob's private root date must NOT leak
+        assert "2025-12-15" not in content
+        assert alice_reply.id in result["node_ids"]
+        assert bob_private_root.id not in result["node_ids"]
+        assert bob_private_reply.id not in result["node_ids"]
+
+    def test_max_tokens_with_engaged_threads_keeps_newest(self, app):
+        """With engaged_threads + a small max_tokens budget and
+        chronological_order=False, newest anchors win."""
+        alice = _make_user("alice")
+        _db.session.commit()
+
+        old_root = _make_node(
+            alice, content="OLD anchor marker",
+            ai_usage="chat", token_count=200, created_at=DEC_15,
+        )
+        new_root = _make_node(
+            alice, content="NEW anchor marker",
+            ai_usage="chat", token_count=200,
+            created_at=APR_22,
+        )
+        _db.session.commit()
+
+        # Budget that fits one root but not both (200 tokens each + 100
+        # header_footer reserve; budget = 250 → only newest fits).
+        result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="engaged_threads",
+            max_tokens=350,
+            chronological_order=False,
+            return_metadata=True,
+        )
+        assert result is not None
+        content = result["content"]
+        assert "NEW anchor marker" in content
+        assert "OLD anchor marker" not in content
+        # node_ids reflects the full CTE row set (pre-budget); selected_ids
+        # (post-budget) drives rendering. Content is the truth-source for
+        # what the budget kept, so no node_ids assertion here.
+
+    def test_invalid_include_strategy_raises(self, app):
+        alice = _make_user("alice")
+        _db.session.commit()
+        with pytest.raises(ValueError):
+            _build(alice, include_strategy="bogus")
+
+    def test_authored_threads_default_byte_identical_to_legacy(
+        self, app, monkeypatch
+    ):
+        """Default (no include_strategy arg) must produce byte-identical
+        output to explicit include_strategy='authored_threads'. Freeze
+        utcnow so the **Export Date:** field doesn't drift between the
+        two calls."""
+        from backend.routes import export_data as ed
+
+        frozen = datetime(2026, 4, 26, 12, 0, 0)
+
+        class _FrozenDT(datetime):
+            @classmethod
+            def utcnow(cls):
+                return frozen
+
+        monkeypatch.setattr(ed, "datetime", _FrozenDT)
+
+        alice = _make_user("alice")
+        _db.session.commit()
+
+        for i in range(2):
+            _make_node(
+                alice, content=f"thread {i} marker text",
+                ai_usage="chat", token_count=100,
+                created_at=DEC_15 + timedelta(days=i),
+            )
+        _db.session.commit()
+
+        default_result = _build(alice, filter_ai_usage=True)
+        explicit_result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="authored_threads",
+        )
+
+        assert default_result == explicit_result
+
+    def test_created_after_overrides_authored_threads(self, app):
+        """When created_after is set, the function takes the anchor-based
+        incremental path regardless of include_strategy. Verify by using
+        a fixture that exercises the foreign-ancestor climb (which only
+        the incremental path does)."""
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        _db.session.commit()
+
+        bob_root = _make_node(
+            bob, content="bob pre-cutoff public root",
+            privacy_level="public", ai_usage="chat",
+            token_count=100, created_at=DEC_15,
+        )
+        bob_post = _make_node(
+            bob, parent_id=bob_root.id,
+            content="bob april public reply marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=80, created_at=APR_18,
+        )
+        alice_post = _make_node(
+            alice, parent_id=bob_post.id,
+            content="alice april reply marker",
+            privacy_level="public", ai_usage="chat",
+            token_count=60, created_at=APR_19,
+        )
+        _db.session.commit()
+
+        # Even with include_strategy='authored_threads', created_after
+        # forces the incremental path → climb-up picks up bob_post.
+        result = _build(
+            alice, filter_ai_usage=True,
+            include_strategy="authored_threads",
+            created_after=APR_07,
+            return_metadata=True,
+        )
+        assert result is not None
+        content = result["content"]
+        assert "bob april public reply marker" in content
+        assert "alice april reply marker" in content
+        assert {bob_post.id, alice_post.id}.issubset(result["node_ids"])

--- a/backend/tests/test_user_export_placeholder.py
+++ b/backend/tests/test_user_export_placeholder.py
@@ -5,9 +5,13 @@ Covers:
 - parse_max_export_tokens: int conversion + structured-warning behavior on
   non-numeric / negative values.
 - USER_EXPORT_PATTERN: regex matches new modifier forms.
+- Wiring regression: the placeholder handler in llm_completion.py
+  passes include_strategy="engaged_threads".
 """
 
+import ast
 import logging
+import os
 
 import pytest
 
@@ -136,4 +140,112 @@ class TestUserExportPattern:
         assert m is not None
         assert m.group(0) == (
             "{user_export?keep=newest&max_export_tokens=50000}"
+        )
+
+
+# ── wiring regression ──────────────────────────────────────────────────
+
+class TestPlaceholderHandlerWiring:
+    """Regression guards for the one-line wiring in llm_completion.py.
+
+    We parse the source file with `ast` (rather than importing the
+    module, whose Celery + LLM-providers chain is too heavy and conflicts
+    with sys.modules mocks in other test files) and scan for the
+    relevant Call nodes.
+    """
+
+    @pytest.fixture(scope="class")
+    def llm_completion_ast(self):
+        path = os.path.join(
+            os.path.dirname(__file__),
+            "..", "tasks", "llm_completion.py",
+        )
+        with open(path) as f:
+            return ast.parse(f.read())
+
+    @staticmethod
+    def _calls_named(tree, name):
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            actual = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name)
+                else None
+            )
+            if actual == name:
+                yield node
+
+    @staticmethod
+    def _kwarg_constant(call, name):
+        for kw in call.keywords:
+            if kw.arg == name and isinstance(kw.value, ast.Constant):
+                return kw.value.value
+        return None
+
+    def test_placeholder_handler_passes_engaged_threads(
+        self, llm_completion_ast
+    ):
+        """The {user_export} handler must pass
+        include_strategy='engaged_threads' to build_user_export_content.
+        Catches accidental removal of the literal arg."""
+        engaged_calls = [
+            c for c in self._calls_named(
+                llm_completion_ast, "build_user_export_content"
+            )
+            if self._kwarg_constant(c, "include_strategy")
+            == "engaged_threads"
+        ]
+        assert engaged_calls, (
+            "Expected at least one call to build_user_export_content "
+            "with include_strategy='engaged_threads' in "
+            "backend/tasks/llm_completion.py"
+        )
+
+    def test_placeholder_handler_threads_max_export_tokens(
+        self, llm_completion_ast
+    ):
+        """The handler must thread the parsed max_export_tokens into
+        build_user_export_content via the max_tokens kwarg. Verifies the
+        call uses the local `max_export_tokens` variable (not a literal,
+        not None)."""
+        for call in self._calls_named(
+            llm_completion_ast, "build_user_export_content"
+        ):
+            if (
+                self._kwarg_constant(call, "include_strategy")
+                != "engaged_threads"
+            ):
+                continue
+            for kw in call.keywords:
+                if kw.arg == "max_tokens":
+                    assert isinstance(kw.value, ast.Name), (
+                        "max_tokens should be passed as a variable "
+                        "(the parsed budget), not a literal"
+                    )
+                    assert kw.value.id == "max_export_tokens"
+                    return
+            pytest.fail(
+                "build_user_export_content call missing max_tokens kwarg"
+            )
+        pytest.fail("No engaged_threads call found")
+
+    def test_parse_max_export_tokens_called_with_logger(
+        self, llm_completion_ast
+    ):
+        """The handler must pass log=logger to parse_max_export_tokens
+        so warnings go to the Celery task logger, not the helper's
+        default stdlib logger."""
+        for call in self._calls_named(
+            llm_completion_ast, "parse_max_export_tokens"
+        ):
+            for kw in call.keywords:
+                if kw.arg == "log":
+                    assert isinstance(kw.value, ast.Name)
+                    assert kw.value.id == "logger"
+                    return
+        pytest.fail(
+            "Expected parse_max_export_tokens(..., log=logger) call in "
+            "backend/tasks/llm_completion.py"
         )

--- a/backend/tests/test_user_export_placeholder.py
+++ b/backend/tests/test_user_export_placeholder.py
@@ -1,0 +1,139 @@
+"""Tests for {user_export} placeholder helpers.
+
+Covers:
+- parse_placeholder_params: URL-style param extraction.
+- parse_max_export_tokens: int conversion + structured-warning behavior on
+  non-numeric / negative values.
+- USER_EXPORT_PATTERN: regex matches new modifier forms.
+"""
+
+import logging
+
+import pytest
+
+from backend.utils.placeholders import (
+    USER_EXPORT_PATTERN,
+    parse_max_export_tokens,
+    parse_placeholder_params,
+)
+
+
+# ── parse_placeholder_params ────────────────────────────────────────────
+
+class TestParsePlaceholderParams:
+    def test_no_params(self):
+        assert parse_placeholder_params("{user_export}") == {}
+
+    def test_keep_only(self):
+        assert parse_placeholder_params(
+            "{user_export?keep=oldest}"
+        ) == {"keep": "oldest"}
+
+    def test_max_export_tokens_only(self):
+        assert parse_placeholder_params(
+            "{user_export?max_export_tokens=100000}"
+        ) == {"max_export_tokens": "100000"}
+
+    def test_keep_and_max_export_tokens_combined(self):
+        params = parse_placeholder_params(
+            "{user_export?keep=oldest&max_export_tokens=50000}"
+        )
+        assert params == {"keep": "oldest", "max_export_tokens": "50000"}
+
+
+# ── parse_max_export_tokens ─────────────────────────────────────────────
+
+class TestParseMaxExportTokens:
+    @pytest.fixture
+    def real_log(self):
+        log = logging.getLogger("test_parse_max_export_tokens")
+        log.propagate = True
+        return log
+
+    def test_none_returns_none(self):
+        assert parse_max_export_tokens(None) is None
+
+    def test_valid_numeric_string(self):
+        assert parse_max_export_tokens("100000") == 100000
+
+    def test_zero_returns_zero(self):
+        # 0 is a valid value — caller short-circuits the export when it sees
+        # 0, mirroring today's `max_export_tokens != 0` guard.
+        assert parse_max_export_tokens("0") == 0
+
+    def test_non_numeric_falls_back_with_warning(self, caplog, real_log):
+        with caplog.at_level(logging.WARNING):
+            result = parse_max_export_tokens(
+                "abc",
+                user_id=42,
+                placeholder="{user_export?max_export_tokens=abc}",
+                log=real_log,
+            )
+        assert result is None
+        assert any(
+            "non-numeric max_export_tokens" in r.getMessage()
+            and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_negative_falls_back_with_warning(self, caplog, real_log):
+        with caplog.at_level(logging.WARNING):
+            result = parse_max_export_tokens(
+                "-100",
+                user_id=42,
+                placeholder="{user_export?max_export_tokens=-100}",
+                log=real_log,
+            )
+        assert result is None
+        assert any(
+            "negative max_export_tokens" in r.getMessage()
+            and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_warning_includes_user_id_and_placeholder(
+        self, caplog, real_log
+    ):
+        with caplog.at_level(logging.WARNING):
+            parse_max_export_tokens(
+                "abc",
+                user_id=99,
+                placeholder="{user_export?max_export_tokens=abc}",
+                log=real_log,
+            )
+        record = next(
+            r for r in caplog.records
+            if "non-numeric max_export_tokens" in r.getMessage()
+        )
+        # Structured args (user_id, raw, placeholder)
+        assert 99 in record.args
+        assert "abc" in record.args
+        assert "{user_export?max_export_tokens=abc}" in record.args
+
+
+# ── regex compatibility ─────────────────────────────────────────────────
+
+class TestUserExportPattern:
+    def test_matches_bare(self):
+        assert USER_EXPORT_PATTERN.search("hello {user_export} world")
+
+    def test_matches_with_keep(self):
+        m = USER_EXPORT_PATTERN.search("{user_export?keep=oldest}")
+        assert m is not None
+        assert m.group(0) == "{user_export?keep=oldest}"
+
+    def test_matches_with_max_export_tokens(self):
+        m = USER_EXPORT_PATTERN.search(
+            "{user_export?max_export_tokens=100000}"
+        )
+        assert m is not None
+        assert m.group(0) == "{user_export?max_export_tokens=100000}"
+
+    def test_matches_combined(self):
+        m = USER_EXPORT_PATTERN.search(
+            "{user_export?keep=newest&max_export_tokens=50000}"
+        )
+        assert m is not None
+        assert m.group(0) == (
+            "{user_export?keep=newest&max_export_tokens=50000}"
+        )

--- a/backend/utils/placeholders.py
+++ b/backend/utils/placeholders.py
@@ -1,0 +1,76 @@
+"""Helpers for {user_export} placeholder parsing.
+
+Lives in `utils/` so tests can import it without pulling in the full
+Celery + LLM-providers chain that comes with `backend.tasks.llm_completion`.
+"""
+
+import logging
+import re
+from urllib.parse import parse_qs
+
+# Pattern for detecting {user_export} with optional URL-style params.
+#
+# Syntax: {user_export} or {user_export?param=value&param2=value2}
+#
+# Scope: {user_export} always uses the "engaged_threads" topology — every
+# node where the user is author or human_owner_id is an anchor; ancestors
+# are climbed up to the root or first inaccessible node, and descendants
+# are climbed down. Foreign public threads the user replied to are
+# included (climb-up reaches the foreign root). Foreign sibling branches
+# the user did not engage with are excluded.
+#
+# Supported params:
+#   keep=oldest             - When truncating to fit the budget, keep the
+#                             oldest threads instead of the newest (default).
+#                             Useful for tasks that need early/foundational
+#                             writing.
+#   keep=newest             - Explicit default: keep the newest threads.
+#   max_export_tokens=<int> - Initial token budget for the export. If the
+#                             prompt still overflows the LLM context, the
+#                             retry loop will shrink further from this
+#                             ceiling. Non-numeric or negative values are
+#                             logged and ignored (treated as no cap). 0
+#                             disables the export entirely.
+#
+USER_EXPORT_PATTERN = re.compile(r"\{user_export(\?[^}]*)?\}")
+
+_default_logger = logging.getLogger(__name__)
+
+
+def parse_placeholder_params(match_str):
+    """Parse URL-style params from a placeholder like {user_export?keep=oldest}."""
+    if '?' in match_str:
+        qs = match_str.split('?', 1)[1].rstrip('}')
+        return {k: v[0] for k, v in parse_qs(qs).items()}
+    return {}
+
+
+def parse_max_export_tokens(raw, *, user_id=None, placeholder=None,
+                            log=None):
+    """Parse the `max_export_tokens` value from a {user_export} placeholder.
+
+    Returns the parsed int when valid (>= 0), or None when absent /
+    non-numeric / negative. Non-numeric and negative values emit a
+    structured warning so user typos surface in logs rather than silently
+    producing a different budget than intended.
+    """
+    if raw is None:
+        return None
+    log = log if log is not None else _default_logger
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "Ignoring non-numeric max_export_tokens for user_id=%s: "
+            "raw=%r placeholder=%r",
+            user_id, raw, placeholder,
+        )
+        return None
+    if parsed < 0:
+        log.warning(
+            "Ignoring negative max_export_tokens for user_id=%s: "
+            "raw=%r placeholder=%r",
+            user_id, raw, placeholder,
+        )
+        return None
+    return parsed

--- a/frontend/src/pages/HowToPage.js
+++ b/frontend/src/pages/HowToPage.js
@@ -191,7 +191,7 @@ export default function HowToPage() {
         <Fade delay={0.14}>
           <WorkflowCard
             title="Chat with your archive"
-            description="Use the user_export keyword to bring your full archive into a conversation. Ask Loore to assess your personal type (e.g. Enneagram, MBTI, or any typology of your choosing) with reasoning, find recurring themes across months of entries, or surface connections between experiences you hadn't noticed."
+            description="Use the user_export keyword to bring everything you've engaged with — your own threads plus public threads you replied to — into a conversation. Tune scope with modifiers like {user_export?keep=newest&max_export_tokens=100000}. Ask Loore to assess your personal type (e.g. Enneagram, MBTI, or any typology of your choosing) with reasoning, find recurring themes across months of entries, or surface connections between experiences you hadn't noticed."
             steps={["Your archive", "A question", "Deep analysis"]}
           />
         </Fade>

--- a/frontend/src/pages/HowToPage.js
+++ b/frontend/src/pages/HowToPage.js
@@ -191,7 +191,7 @@ export default function HowToPage() {
         <Fade delay={0.14}>
           <WorkflowCard
             title="Chat with your archive"
-            description="Use the user_export keyword to bring everything you've engaged with — your own threads plus public threads you replied to — into a conversation. Tune scope with modifiers like {user_export?keep=newest&max_export_tokens=100000}. Ask Loore to assess your personal type (e.g. Enneagram, MBTI, or any typology of your choosing) with reasoning, find recurring themes across months of entries, or surface connections between experiences you hadn't noticed."
+            description="Use the user_export keyword to bring everything you've engaged with — your own threads plus public threads you replied to — into a conversation. Ask Loore to assess your personal type (e.g. Enneagram, MBTI, or any typology of your choosing) with reasoning, find recurring themes across months of entries, or surface connections between experiences you hadn't noticed."
             steps={["Your archive", "A question", "Deep analysis"]}
           />
         </Fade>


### PR DESCRIPTION
## Summary

- **`{user_export}` now uses an anchor-based engagement-graph topology** instead of "user-owned top-level threads only." Every node where the user is author or `human_owner_id` is an anchor; ancestors are climbed up to the root or first inaccessible node; descendants are climbed down. Public threads the user replied to are now included. Foreign sibling branches the user never engaged with stay excluded (existing `accessible_nodes_filter` semantics).
- **New modifier `{user_export?max_export_tokens=N}`** sets an initial token budget. The existing `reduce_export_tokens` retry loop continues to shrink further on overflow. Non-numeric or negative values are logged and ignored; `0` short-circuits the export.
- **`build_user_export_content` gains `include_strategy`** with two accepted values: `"authored_threads"` (default, matches today's `/export/threads` data dump exactly) and `"engaged_threads"` (the new placeholder behavior, also used internally by `recent_context`). When `created_after` is set the function always uses the anchor-based path regardless of `include_strategy` — preserves backwards compat with existing `recent_context` callers.
- **Refactor:** placeholder helpers (`USER_EXPORT_PATTERN`, `parse_placeholder_params`, `parse_max_export_tokens`) extracted to `backend/utils/placeholders.py` so tests can cover them without pulling in the Celery import chain.

## Test plan

- [x] `backend/tests/test_exports_incremental.py` — added `TestEngagedThreadsStrategy` (7 cases): user-owned tree parity, foreign-thread climb-up no-cutoff, private-ancestor blocks climb, max_tokens with engaged_threads keeps newest, invalid strategy raises, byte-identical default vs explicit `authored_threads` (with frozen clock), `created_after` overrides `authored_threads`. All existing tests still green.
- [x] `backend/tests/test_user_export_placeholder.py` (new, 14 cases) — `parse_placeholder_params`, `parse_max_export_tokens` (valid / 0 / non-numeric / negative / structured warning fields), `USER_EXPORT_PATTERN` matches.
- [x] Full backend suite: 239 passed.
- [x] flake8 syntax/undefined-name (CI-blocking): 0 errors.
- [x] Frontend `npm run build`: compiled successfully.
- [ ] Manual smoke (Docker / staging): use `{user_export?keep=newest&max_export_tokens=10000}` in a prompt; confirm log line `strategy=engaged_threads, requested_max=10000`; reply into another user's public thread and verify the foreign root appears in a subsequent `{user_export}`.

## Out of scope

- No change to `/export/threads` user-facing data dump (defaults to `authored_threads`).
- No change to `recent_context.py` — touching its `_build_export` calls would risk a silent behavior change when `data_cutoff` is `None`.
- No change to `filter_ai_usage` defaults — LLM-authored nodes are already included whenever `ai_usage IN ('chat','train')` and the node is accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)