### PR TITLE
Fix voice replay skipping middle batch on 10+ minute recordings

### DIFF
--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -1304,14 +1304,23 @@ def download_audio(node_id):
                 decrypted_paths.append(str(f))
 
         # Detect source container so we ask ffmpeg for a matching output and
-        # report the right Content-Type to the browser.
+        # report the right Content-Type to the browser. MP4 sources need
+        # re-encode during concat — stream-copy preserves duration but
+        # corrupts per-packet timestamps across fMP4 batch boundaries,
+        # producing a mostly-silent output.
         first = chunk_files[0].name
         if first.endswith('.mp4') or first.endswith('.mp4.enc'):
             src_suffix, mimetype, ext = '.mp4', 'audio/mp4', 'mp4'
+            concat_codec = 'aac'
         else:
             src_suffix, mimetype, ext = '.webm', 'audio/webm', 'webm'
+            concat_codec = None
 
-        merged_path = concat_audio_files(decrypted_paths, output_suffix=src_suffix)
+        merged_path = concat_audio_files(
+            decrypted_paths,
+            output_suffix=src_suffix,
+            reencode_codec=concat_codec,
+        )
         temp_files.append(merged_path)
 
         output_path = merged_path

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -1267,15 +1267,25 @@ def download_audio(node_id):
     """Download all audio chunks merged into a single file.
 
     Query params:
-        format: 'webm' (default) or 'mp3'
+        format: 'original' (default) returns the merged source container
+                as-is — .webm for desktop recordings, .mp4 for iOS
+                recordings. The Content-Disposition filename carries
+                the real extension.
+                'mp3' re-encodes the merged audio to MP3 for portability.
+                'webm' is accepted as a deprecated alias for 'original'
+                — it predates MP4 recording, when source was always WebM.
     """
     from flask import send_file
     import subprocess
     from backend.utils.webm_utils import concat_audio_files
 
-    fmt = request.args.get('format', 'webm').lower()
-    if fmt not in ('webm', 'mp3'):
-        return jsonify({"error": "Unsupported format, use 'webm' or 'mp3'"}), 400
+    fmt = request.args.get('format', 'original').lower()
+    if fmt == 'webm':
+        # Deprecated alias — the param's literal meaning got misleading
+        # once iOS recordings could be MP4. Treat as passthrough.
+        fmt = 'original'
+    if fmt not in ('original', 'mp3'):
+        return jsonify({"error": "Unsupported format, use 'original' or 'mp3'"}), 400
 
     node = Node.query.get_or_404(node_id)
 

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -28,6 +28,7 @@ from backend.utils.quotes import find_quote_ids, get_quote_data, has_quotes
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.webm_utils import get_webm_duration
 from backend.utils.encryption import encrypt_file, decrypt_file_to_temp
+from backend.utils.audio_storage import list_streaming_audio_files
 from backend.utils.llm_nodes import (
     create_llm_placeholder, pick_model_for_generation,
 )
@@ -1168,14 +1169,7 @@ def get_audio_urls(node_id):
     has_audio_chunks = False
     if node.streaming_transcription:
         chunk_dir = AUDIO_STORAGE_ROOT / f"nodes/{node.user_id}/{node_id}"
-        if chunk_dir.exists():
-            has_chunks = (
-                list(chunk_dir.glob("chunk_*.webm")) or
-                list(chunk_dir.glob("chunk_*.webm.enc")) or
-                list(chunk_dir.glob("batch_*.webm")) or
-                list(chunk_dir.glob("batch_*.webm.enc"))
-            )
-            has_audio_chunks = bool(has_chunks)
+        has_audio_chunks = bool(list_streaming_audio_files(chunk_dir))
 
     if original_url or tts_url or has_audio_chunks:
         return jsonify({
@@ -1224,26 +1218,10 @@ def get_audio_chunks(node_id):
     if not node.streaming_transcription:
         return jsonify({"error": "Not a streaming transcription node"}), 404
 
-    # Find chunk files on disk
+    # Find chunk files on disk. Helper handles both .webm and .mp4
+    # recordings, chunk-vs-batch fallback, and plain-vs-encrypted preference.
     chunk_dir = AUDIO_STORAGE_ROOT / f"nodes/{node.user_id}/{node_id}"
-
-    if not chunk_dir.exists():
-        return jsonify({"error": "No audio chunks found"}), 404
-
-    # Get all audio files sorted by name (support both plain and encrypted).
-    # After batch transcription, individual chunk_*.webm files are replaced by
-    # batch_*.webm files — check for both patterns.
-    chunk_files = sorted(chunk_dir.glob("chunk_*.webm"))
-    chunk_files_enc = sorted(chunk_dir.glob("chunk_*.webm.enc"))
-    if not chunk_files and not chunk_files_enc:
-        chunk_files = sorted(chunk_dir.glob("batch_*.webm"))
-        chunk_files_enc = sorted(chunk_dir.glob("batch_*.webm.enc"))
-    # Prefer encrypted files if they exist, fall back to plain
-    if not chunk_files and chunk_files_enc:
-        chunk_files = chunk_files_enc
-    elif not chunk_files and not chunk_files_enc:
-        return jsonify({"error": "No audio chunks found"}), 404
-
+    chunk_files = list_streaming_audio_files(chunk_dir)
     if not chunk_files:
         return jsonify({"error": "No audio chunks found"}), 404
 
@@ -1309,17 +1287,7 @@ def download_audio(node_id):
         return jsonify({"error": "Not a streaming transcription node"}), 404
 
     chunk_dir = AUDIO_STORAGE_ROOT / f"nodes/{node.user_id}/{node_id}"
-    if not chunk_dir.exists():
-        return jsonify({"error": "No audio files found"}), 404
-
-    # Collect audio files — same fallback logic as get_audio_chunks
-    chunk_files = sorted(chunk_dir.glob("chunk_*.webm"))
-    chunk_files_enc = sorted(chunk_dir.glob("chunk_*.webm.enc"))
-    if not chunk_files and not chunk_files_enc:
-        chunk_files = sorted(chunk_dir.glob("batch_*.webm"))
-        chunk_files_enc = sorted(chunk_dir.glob("batch_*.webm.enc"))
-    if not chunk_files and chunk_files_enc:
-        chunk_files = chunk_files_enc
+    chunk_files = list_streaming_audio_files(chunk_dir)
     if not chunk_files:
         return jsonify({"error": "No audio files found"}), 404
 
@@ -1335,12 +1303,18 @@ def download_audio(node_id):
             else:
                 decrypted_paths.append(str(f))
 
-        merged_path = concat_audio_files(decrypted_paths)
+        # Detect source container so we ask ffmpeg for a matching output and
+        # report the right Content-Type to the browser.
+        first = chunk_files[0].name
+        if first.endswith('.mp4') or first.endswith('.mp4.enc'):
+            src_suffix, mimetype, ext = '.mp4', 'audio/mp4', 'mp4'
+        else:
+            src_suffix, mimetype, ext = '.webm', 'audio/webm', 'webm'
+
+        merged_path = concat_audio_files(decrypted_paths, output_suffix=src_suffix)
         temp_files.append(merged_path)
 
         output_path = merged_path
-        mimetype = 'audio/webm'
-        ext = 'webm'
 
         if fmt == 'mp3':
             import tempfile

--- a/backend/scripts/backfill_legacy_chunks.py
+++ b/backend/scripts/backfill_legacy_chunks.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Backfill legacy streaming-recording chunks into modern batch files.
+
+Phase-2 voice recordings (Jan-Mar 2026) were stored as one or more
+chunk_NNNN.webm[.enc] files where each chunk is a standalone Matroska
+"chained" segment with continuous cluster timestamps from the original
+recording. After the AudioContext.js WebM-offset fix (PR #119), these no
+longer replay correctly: the player treats each chunk URL as an
+independent file starting at timestamp 0, but the chunks actually
+share absolute timestamps across files.
+
+This script remuxes each affected node's chunks into a single
+batch_0000-NNNN.webm[.enc] file (the modern format the post-fix
+player expects) and renames the originals to
+chunk_NNNN.webm[.enc].legacy_backup. The endpoint at
+backend/routes/nodes.py glob-matches chunk_*.webm[.enc] and
+batch_*.webm[.enc] but not the .legacy_backup suffix, so after this
+script the endpoint falls through to the new batch_*.webm[.enc].
+
+Idempotent. Safe to rerun.
+
+Usage (from repo root, on production VM):
+
+    # Dry-run (default): inspect what would change, no writes
+    python -m backend.scripts.backfill_legacy_chunks
+
+    # Process a single node first to validate end-to-end
+    python -m backend.scripts.backfill_legacy_chunks --commit --node 5168
+
+    # Full backfill, with stronger per-file decode verification
+    python -m backend.scripts.backfill_legacy_chunks --commit --verify-decode
+
+Rollback (if needed, per node, in flask shell):
+
+    from pathlib import Path
+    d = Path('data/audio/nodes/<user_id>/<node_id>')
+    for f in d.glob('batch_*'):
+        f.unlink()
+    for f in d.glob('chunk_*.legacy_backup'):
+        f.rename(f.with_suffix(''))   # strips .legacy_backup
+"""
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+
+project_root = pathlib.Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from backend.app import create_app  # noqa: E402
+from backend.models import Node  # noqa: E402
+from backend.utils.encryption import (  # noqa: E402
+    decrypt_file, encrypt_file, is_encryption_enabled,
+)
+from backend.utils.webm_utils import concat_webm_fragments  # noqa: E402
+
+AUDIO_STORAGE_ROOT = pathlib.Path(
+    os.environ.get("AUDIO_STORAGE_PATH", "data/audio")
+).resolve()
+
+
+def ffprobe_duration(path):
+    r = subprocess.run(
+        ['ffprobe', '-v', 'error', '-show_format', '-of', 'json', path],
+        capture_output=True, text=True, timeout=60,
+    )
+    if r.returncode != 0:
+        return None
+    d = json.loads(r.stdout).get('format', {}).get('duration')
+    return float(d) if d else None
+
+
+def ffmpeg_full_decode_ok(path):
+    """Decode the entire file to /dev/null. Catches mid-file corruption
+    that ffprobe (which only reads container metadata) would miss."""
+    r = subprocess.run(
+        ['ffmpeg', '-v', 'error', '-i', path, '-f', 'null', '-'],
+        capture_output=True, text=True, timeout=600,
+    )
+    return r.returncode == 0 and not r.stderr.strip(), r.stderr.strip()[-300:]
+
+
+def list_chunks(d):
+    enc = sorted(d.glob("chunk_*.webm.enc"))
+    plain = sorted(d.glob("chunk_*.webm"))
+    return enc if enc else plain
+
+
+def list_batches(d):
+    return list(d.glob("batch_*.webm")) + list(d.glob("batch_*.webm.enc"))
+
+
+def process_node(node, dry_run, verify_decode):
+    """Returns (status, dur_seconds, info)."""
+    d = AUDIO_STORAGE_ROOT / f"nodes/{node.user_id}/{node.id}"
+    if not d.exists():
+        return ("skip_no_dir", None, None)
+
+    chunks = list_chunks(d)
+    batches = list_batches(d)
+
+    if not chunks and not batches:
+        return ("skip_empty", None, None)
+    if not chunks and batches:
+        return ("skip_already_modern", None, None)
+
+    # Partial-state recovery: prior run created the batch but didn't
+    # finish renaming the chunks. Verify the batch then complete the
+    # rename.
+    if chunks and batches:
+        batch = batches[0]
+        batch_decrypted = None
+        try:
+            if batch.name.endswith('.enc'):
+                fd, batch_decrypted = tempfile.mkstemp(suffix='.webm')
+                os.close(fd)
+                with open(batch_decrypted, 'wb') as f:
+                    f.write(decrypt_file(str(batch)))
+                batch_for_probe = batch_decrypted
+            else:
+                batch_for_probe = str(batch)
+            dur = ffprobe_duration(batch_for_probe)
+            if not dur or dur <= 0:
+                return ("partial_bad_batch", None, "existing batch has no duration")
+        finally:
+            if batch_decrypted and os.path.exists(batch_decrypted):
+                os.unlink(batch_decrypted)
+
+        if dry_run:
+            return ("partial_would_rename", dur, len(chunks))
+        for c in chunks:
+            c.rename(c.with_name(c.name + '.legacy_backup'))
+        return ("partial_completed", dur, len(chunks))
+
+    # Standard case: chunks present, no batch yet
+    encrypted = chunks[0].name.endswith('.enc')
+    n_chunks = len(chunks)
+    workdir = tempfile.mkdtemp(prefix=f'backfill_{node.id}_')
+    merged = None
+    try:
+        plain_paths = []
+        chunks_total_size = 0
+        for c in chunks:
+            base = c.name[:-4] if encrypted else c.name
+            p = os.path.join(workdir, base)
+            if encrypted:
+                with open(p, 'wb') as f:
+                    f.write(decrypt_file(str(c)))
+            else:
+                shutil.copy2(str(c), p)
+            chunks_total_size += os.path.getsize(p)
+            plain_paths.append(p)
+
+        merged = concat_webm_fragments(plain_paths)
+        merged_size = os.path.getsize(merged)
+        merged_dur = ffprobe_duration(merged)
+
+        if not merged_dur or merged_dur <= 0:
+            return ("fail_no_duration", merged_dur, merged_size)
+        if merged_size < chunks_total_size * 0.5:
+            return ("fail_size_anomaly",
+                    merged_dur,
+                    f"merged={merged_size} chunks_total={chunks_total_size}")
+
+        if verify_decode:
+            ok, err_tail = ffmpeg_full_decode_ok(merged)
+            if not ok:
+                return ("fail_decode", merged_dur, err_tail)
+
+        if dry_run:
+            return ("ok_dry_run", merged_dur, merged_size)
+
+        # Write the merged file as batch_0000-NNNN.webm[.enc] in the
+        # node's audio dir. Order: write batch first, verify, THEN
+        # rename originals — so a crash anywhere keeps the node's
+        # existing chunks intact (idempotent rerun completes the job).
+        batch_basename = f"batch_0000-{n_chunks - 1:04d}.webm"
+        batch_plain_path = d / batch_basename
+        shutil.move(merged, str(batch_plain_path))
+        merged = None  # consumed
+
+        if encrypted and is_encryption_enabled():
+            final_path = encrypt_file(str(batch_plain_path))
+        else:
+            final_path = str(batch_plain_path)
+
+        # Sanity check: final file is on disk and ffprobe agrees.
+        if final_path.endswith('.enc'):
+            fd, tmp = tempfile.mkstemp(suffix='.webm')
+            os.close(fd)
+            try:
+                with open(tmp, 'wb') as f:
+                    f.write(decrypt_file(final_path))
+                final_dur = ffprobe_duration(tmp)
+            finally:
+                os.unlink(tmp)
+        else:
+            final_dur = ffprobe_duration(final_path)
+        if not final_dur or final_dur <= 0:
+            return ("fail_post_write_verify", final_dur,
+                    f"wrote {final_path} but ffprobe failed")
+
+        for c in chunks:
+            c.rename(c.with_name(c.name + '.legacy_backup'))
+
+        return ("ok", merged_dur, merged_size)
+    except Exception as e:
+        return ("fail_exception", None,
+                f"{type(e).__name__}: {str(e)[:300]}")
+    finally:
+        if merged and os.path.exists(merged):
+            try:
+                os.unlink(merged)
+            except OSError:
+                pass
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Backfill legacy chunk_*.webm into modern batch_*.webm",
+    )
+    ap.add_argument("--commit", action="store_true",
+                    help="Actually perform the backfill (default: dry-run)")
+    ap.add_argument("--node", type=int, default=None,
+                    help="Process only this node id")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Process at most this many nodes (after sorting by id)")
+    ap.add_argument("--verify-decode", action="store_true",
+                    help="Run ffmpeg full-decode to verify each merged batch "
+                         "(slow; otherwise only ffprobe duration is checked)")
+    args = ap.parse_args()
+    dry_run = not args.commit
+
+    app = create_app()
+    with app.app_context():
+        q = Node.query.filter_by(streaming_transcription=True)
+        if args.node:
+            q = q.filter_by(id=args.node)
+        nodes = q.order_by(Node.id.asc()).all()
+        if args.limit:
+            nodes = nodes[:args.limit]
+
+        print(f"Mode:           {'DRY-RUN' if dry_run else 'COMMIT'}")
+        print(f"Verify decode:  {args.verify_decode}")
+        print(f"Storage root:   {AUDIO_STORAGE_ROOT}")
+        print(f"Nodes to scan:  {len(nodes)}")
+        print()
+
+        outcome = Counter()
+        for n in nodes:
+            status, dur, info = process_node(n, dry_run, args.verify_decode)
+            outcome[status] += 1
+            if status.startswith("ok") or status.startswith("partial"):
+                dur_s = f"{dur:.1f}s" if dur else "?"
+                print(f"  Node {n.id:>6d} (user {n.user_id:>4d}): "
+                      f"{status:<22s} dur={dur_s:>8s}  info={info}")
+            elif status.startswith("fail"):
+                print(f"  Node {n.id:>6d} (user {n.user_id:>4d}): "
+                      f"{status:<22s} info={info}")
+            # skip_* outcomes: too verbose; just count
+
+        print("\nSummary:")
+        for k, v in sorted(outcome.most_common()):
+            print(f"  {k:<22s} {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_legacy_chunks.py
+++ b/backend/scripts/backfill_legacy_chunks.py
@@ -57,7 +57,7 @@ from backend.models import Node  # noqa: E402
 from backend.utils.encryption import (  # noqa: E402
     decrypt_file, encrypt_file, is_encryption_enabled,
 )
-from backend.utils.webm_utils import concat_webm_fragments  # noqa: E402
+from backend.utils.webm_utils import concat_fragmented_media  # noqa: E402
 
 AUDIO_STORAGE_ROOT = pathlib.Path(
     os.environ.get("AUDIO_STORAGE_PATH", "data/audio")
@@ -156,7 +156,7 @@ def process_node(node, dry_run, verify_decode):
             chunks_total_size += os.path.getsize(p)
             plain_paths.append(p)
 
-        merged = concat_webm_fragments(plain_paths)
+        merged = concat_fragmented_media(plain_paths)
         merged_size = os.path.getsize(merged)
         merged_dur = ffprobe_duration(merged)
 

--- a/backend/scripts/backfill_legacy_chunks.py
+++ b/backend/scripts/backfill_legacy_chunks.py
@@ -9,13 +9,13 @@ longer replay correctly: the player treats each chunk URL as an
 independent file starting at timestamp 0, but the chunks actually
 share absolute timestamps across files.
 
-This script remuxes each affected node's chunks into a single
-batch_0000-NNNN.webm[.enc] file (the modern format the post-fix
-player expects) and renames the originals to
-chunk_NNNN.webm[.enc].legacy_backup. The endpoint at
-backend/routes/nodes.py glob-matches chunk_*.webm[.enc] and
+This script remuxes each legacy chunk individually into a modern
+batch_NNNN-NNNN.webm[.enc] file with timestamps rebased to 0 — one
+batch per input chunk, preserving the original ~5-min granularity.
+Originals are renamed to chunk_NNNN.webm[.enc].legacy_backup. The
+audio-chunks endpoint glob-matches chunk_*.webm[.enc] and
 batch_*.webm[.enc] but not the .legacy_backup suffix, so after this
-script the endpoint falls through to the new batch_*.webm[.enc].
+script the endpoint serves the new batch_*.webm[.enc].
 
 Idempotent. Safe to rerun.
 
@@ -109,113 +109,132 @@ def process_node(node, dry_run, verify_decode):
     if not chunks and batches:
         return ("skip_already_modern", None, None)
 
-    # Partial-state recovery: prior run created the batch but didn't
-    # finish renaming the chunks. Verify the batch then complete the
-    # rename.
+    # Partial-state recovery: prior run created batches but didn't
+    # finish renaming the chunks. Verify the batches have a non-zero
+    # cumulative duration, then complete the rename. (We expect one
+    # batch per chunk after this script's per-chunk remux semantics.)
     if chunks and batches:
-        batch = batches[0]
-        batch_decrypted = None
-        try:
-            if batch.name.endswith('.enc'):
-                fd, batch_decrypted = tempfile.mkstemp(suffix='.webm')
-                os.close(fd)
-                with open(batch_decrypted, 'wb') as f:
-                    f.write(decrypt_file(str(batch)))
-                batch_for_probe = batch_decrypted
-            else:
-                batch_for_probe = str(batch)
-            dur = ffprobe_duration(batch_for_probe)
-            if not dur or dur <= 0:
-                return ("partial_bad_batch", None, "existing batch has no duration")
-        finally:
-            if batch_decrypted and os.path.exists(batch_decrypted):
-                os.unlink(batch_decrypted)
+        cumulative_dur = 0.0
+        for batch in batches:
+            decrypted = None
+            try:
+                if batch.name.endswith('.enc'):
+                    fd, decrypted = tempfile.mkstemp(suffix='.webm')
+                    os.close(fd)
+                    with open(decrypted, 'wb') as f:
+                        f.write(decrypt_file(str(batch)))
+                    probe_target = decrypted
+                else:
+                    probe_target = str(batch)
+                d_dur = ffprobe_duration(probe_target) or 0
+                if d_dur <= 0:
+                    return ("partial_bad_batch", None,
+                            f"{batch.name} has no duration")
+                cumulative_dur += d_dur
+            finally:
+                if decrypted and os.path.exists(decrypted):
+                    os.unlink(decrypted)
 
         if dry_run:
-            return ("partial_would_rename", dur, len(chunks))
+            return ("partial_would_rename", cumulative_dur,
+                    f"{len(batches)} batches, {len(chunks)} chunks to rename")
         for c in chunks:
             c.rename(c.with_name(c.name + '.legacy_backup'))
-        return ("partial_completed", dur, len(chunks))
+        return ("partial_completed", cumulative_dur, len(chunks))
 
-    # Standard case: chunks present, no batch yet
+    # Standard case: chunks present, no batch yet. Per-chunk remux —
+    # each legacy chunk becomes one modern batch with timestamps
+    # rebased to 0, preserving the original ~5-min granularity (vs.
+    # collapsing the whole recording into one file, which would lose
+    # the chunk model the post-fix player expects).
     encrypted = chunks[0].name.endswith('.enc')
     n_chunks = len(chunks)
     workdir = tempfile.mkdtemp(prefix=f'backfill_{node.id}_')
-    merged = None
+    remuxed_paths = []  # parallel to chunks: workdir paths of remuxed output
     try:
-        plain_paths = []
-        chunks_total_size = 0
-        for c in chunks:
+        durations_total = 0.0
+        size_total = 0
+        for i, c in enumerate(chunks):
+            # Decrypt or copy into workdir
             base = c.name[:-4] if encrypted else c.name
-            p = os.path.join(workdir, base)
+            in_path = os.path.join(workdir, f"in_{i:04d}_{base}")
             if encrypted:
-                with open(p, 'wb') as f:
+                with open(in_path, 'wb') as f:
                     f.write(decrypt_file(str(c)))
             else:
-                shutil.copy2(str(c), p)
-            chunks_total_size += os.path.getsize(p)
-            plain_paths.append(p)
+                shutil.copy2(str(c), in_path)
 
-        merged = concat_fragmented_media(plain_paths)
-        merged_size = os.path.getsize(merged)
-        merged_dur = ffprobe_duration(merged)
+            # Remux this chunk on its own. concat_fragmented_media with
+            # a single input is functionally `ffmpeg -c copy +genpts`,
+            # which the surrounding codebase already trusts to produce
+            # an output WebM whose first cluster lands at timestamp 0
+            # regardless of the input's absolute timestamps.
+            out_path = concat_fragmented_media([in_path])
+            durations_total += ffprobe_duration(out_path) or 0.0
+            size_total += os.path.getsize(out_path)
+            remuxed_paths.append(out_path)
 
-        if not merged_dur or merged_dur <= 0:
-            return ("fail_no_duration", merged_dur, merged_size)
-        if merged_size < chunks_total_size * 0.5:
-            return ("fail_size_anomaly",
-                    merged_dur,
-                    f"merged={merged_size} chunks_total={chunks_total_size}")
+        if durations_total <= 0:
+            return ("fail_no_duration", durations_total, size_total)
 
         if verify_decode:
-            ok, err_tail = ffmpeg_full_decode_ok(merged)
-            if not ok:
-                return ("fail_decode", merged_dur, err_tail)
+            for j, p in enumerate(remuxed_paths):
+                ok, err_tail = ffmpeg_full_decode_ok(p)
+                if not ok:
+                    return ("fail_decode",
+                            durations_total,
+                            f"chunk {j}: {err_tail}")
 
         if dry_run:
-            return ("ok_dry_run", merged_dur, merged_size)
+            return ("ok_dry_run", durations_total,
+                    f"{n_chunks} batches, {size_total} bytes total")
 
-        # Write the merged file as batch_0000-NNNN.webm[.enc] in the
-        # node's audio dir. Order: write batch first, verify, THEN
-        # rename originals — so a crash anywhere keeps the node's
-        # existing chunks intact (idempotent rerun completes the job).
-        batch_basename = f"batch_0000-{n_chunks - 1:04d}.webm"
-        batch_plain_path = d / batch_basename
-        shutil.move(merged, str(batch_plain_path))
-        merged = None  # consumed
+        # Write each remuxed output as batch_NNNN-NNNN.webm[.enc] in
+        # the node's audio dir. Order: write all batches + encrypt,
+        # verify, THEN rename originals — so a crash anywhere keeps
+        # the node's existing chunks intact (idempotent rerun
+        # completes the job).
+        batch_paths = []
+        for i, src in enumerate(remuxed_paths):
+            batch_plain = d / f"batch_{i:04d}-{i:04d}.webm"
+            shutil.move(src, str(batch_plain))
+            if encrypted and is_encryption_enabled():
+                final = encrypt_file(str(batch_plain))
+            else:
+                final = str(batch_plain)
+            batch_paths.append(final)
+        remuxed_paths = []  # consumed; clear so finally{} doesn't re-unlink
 
-        if encrypted and is_encryption_enabled():
-            final_path = encrypt_file(str(batch_plain_path))
-        else:
-            final_path = str(batch_plain_path)
-
-        # Sanity check: final file is on disk and ffprobe agrees.
-        if final_path.endswith('.enc'):
-            fd, tmp = tempfile.mkstemp(suffix='.webm')
-            os.close(fd)
-            try:
-                with open(tmp, 'wb') as f:
-                    f.write(decrypt_file(final_path))
-                final_dur = ffprobe_duration(tmp)
-            finally:
-                os.unlink(tmp)
-        else:
-            final_dur = ffprobe_duration(final_path)
-        if not final_dur or final_dur <= 0:
-            return ("fail_post_write_verify", final_dur,
-                    f"wrote {final_path} but ffprobe failed")
+        # Sanity check each batch
+        for fp in batch_paths:
+            if fp.endswith('.enc'):
+                fd, tmp = tempfile.mkstemp(suffix='.webm')
+                os.close(fd)
+                try:
+                    with open(tmp, 'wb') as f:
+                        f.write(decrypt_file(fp))
+                    final_dur = ffprobe_duration(tmp)
+                finally:
+                    os.unlink(tmp)
+            else:
+                final_dur = ffprobe_duration(fp)
+            if not final_dur or final_dur <= 0:
+                return ("fail_post_write_verify", final_dur,
+                        f"wrote {fp} but ffprobe failed")
 
         for c in chunks:
             c.rename(c.with_name(c.name + '.legacy_backup'))
 
-        return ("ok", merged_dur, merged_size)
+        return ("ok", durations_total,
+                f"{n_chunks} batches, {size_total} bytes total")
     except Exception as e:
         return ("fail_exception", None,
                 f"{type(e).__name__}: {str(e)[:300]}")
     finally:
-        if merged and os.path.exists(merged):
+        for p in remuxed_paths:
             try:
-                os.unlink(merged)
+                if os.path.exists(p):
+                    os.unlink(p)
             except OSError:
                 pass
         shutil.rmtree(workdir, ignore_errors=True)

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -79,10 +79,25 @@ def export_payload(app, node_ids):
         chunks = NodeTranscriptChunk.query.filter(
             NodeTranscriptChunk.node_id.in_(node_ids)
         ).all()
+
+        # Decrypt encrypted fields on the prod side and ship plaintext.
+        # Staging has a different KMS key, so the wire format must be
+        # plaintext; the import side re-encrypts via the model setters.
+        nodes_data = []
+        for n in nodes:
+            row = serialize_row(n)
+            row["content"] = n.get_content() if n.content else ""
+            nodes_data.append(row)
+        chunks_data = []
+        for c in chunks:
+            row = serialize_row(c)
+            row["text"] = c.get_text() if c.text else ""
+            chunks_data.append(row)
+
         return {
             "users": [serialize_row(u) for u in users],
-            "nodes": [serialize_row(n) for n in nodes],
-            "chunks": [serialize_row(c) for c in chunks],
+            "nodes": nodes_data,
+            "chunks": chunks_data,
         }
 
 
@@ -116,8 +131,8 @@ payload = json.loads(sys.stdin.read())
 app = create_app()
 with app.app_context():
     counts = {"users_inserted": 0, "users_updated": 0,
-              "nodes_inserted": 0, "nodes_skipped": 0,
-              "chunks_inserted": 0, "chunks_skipped": 0}
+              "nodes_inserted": 0, "nodes_replaced": 0,
+              "chunks_inserted": 0, "chunks_replaced": 0}
 
     # Users: insert or update so they have admin/voice access
     user_ids = []
@@ -142,28 +157,44 @@ with app.app_context():
         user_ids.append(u.id)
     db.session.commit()
 
-    # Nodes: skip if already exists; null out FK chain to keep clone shallow
+    # Replace-then-insert for nodes + chunks so re-running the script fixes
+    # any prior broken clone (e.g. ciphertext shipped before this script
+    # learned to decrypt-and-reencrypt). Scoped strictly to the requested
+    # node ids — never touches unrelated staging data.
+    cloned_node_ids = [deser_row(r)["id"] for r in payload["nodes"]]
+    if cloned_node_ids:
+        # Chunks first (FK to node has no CASCADE).
+        deleted_chunks = NodeTranscriptChunk.query.filter(
+            NodeTranscriptChunk.node_id.in_(cloned_node_ids)
+        ).delete(synchronize_session=False)
+        deleted_nodes = Node.query.filter(
+            Node.id.in_(cloned_node_ids)
+        ).delete(synchronize_session=False)
+        db.session.commit()
+        counts["nodes_replaced"] = deleted_nodes
+        counts["chunks_replaced"] = deleted_chunks
+
+    # Nodes: null out FK chain to keep clone shallow. Encrypted columns
+    # arrive as plaintext — re-encrypt with staging's key.
     for raw in payload["nodes"]:
         row = deser_row(raw)
-        n = Node.query.get(row["id"])
-        if n:
-            counts["nodes_skipped"] += 1
-            continue
         row["parent_id"] = None
         row["linked_node_id"] = None
+        plain_content = row.pop("content", None)
         n = Node(**row)
+        if plain_content is not None:
+            n.set_content(plain_content)
         db.session.add(n)
         counts["nodes_inserted"] += 1
     db.session.commit()
 
-    # Chunks
+    # Chunks: same plaintext-then-re-encrypt dance for `text`.
     for raw in payload["chunks"]:
         row = deser_row(raw)
-        c = NodeTranscriptChunk.query.get(row["id"])
-        if c:
-            counts["chunks_skipped"] += 1
-            continue
+        plain_text = row.pop("text", None)
         c = NodeTranscriptChunk(**row)
+        if plain_text is not None:
+            c.set_text(plain_text)
         db.session.add(c)
         counts["chunks_inserted"] += 1
     db.session.commit()

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -360,6 +360,15 @@ def main():
                     ["docker", "cp", str(dst),
                      f"{args.staging_backend}:{dst_parent}/"], check=True,
                 )
+                # docker cp creates files as root; the container's
+                # runtime user can't then write batch_*.webm during
+                # backfill. chmod a+rwX so the backfill (running as
+                # the container's default user) can write alongside.
+                subprocess.run(
+                    ["docker", "exec", "-u", "0", args.staging_backend,
+                     "chmod", "-R", "a+rwX",
+                     f"/app/data/audio/nodes/{uid}/{nid}"], check=True,
+                )
                 print(f"  node {nid}: {n_dec} decrypted + {n_plain} plain "
                       f"-> {round(total_bytes/1024/1024, 1)} MB")
             finally:

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Clone a streaming-recording node from production to staging for testing.
+
+Lets you replay a long pre-existing recording on staging without re-recording.
+Run on the production VM (where prod DB is reachable). The script also shells
+out to `docker exec` and `docker cp` to write into the staging stack.
+
+Re-run after every staging deploy: staging DB is reset on each deploy, but
+the audio files persist in the named Docker volume — pass `--skip-files` on
+subsequent runs to skip the (already-done) file copy.
+
+Usage on the production VM, with the prod env active (DATABASE_URL set):
+
+    python -m backend.scripts.clone_node_to_staging \\
+        --node-ids 5168 5174 \\
+        --staging-backend wop-staging-backend-1
+
+Optional:
+    --skip-files               Skip docker cp of audio files (already copied)
+    --staging-backend NAME     Override the staging backend container name
+
+The script:
+  1. Reads User + Node + NodeTranscriptChunk rows from the current DB (prod)
+  2. Pipes them as JSON into a Python interpreter inside the staging backend
+     container, which writes them to the staging DB
+  3. Promotes the cloned user to is_admin=True so voice-mode access works
+  4. Mints a magic-link token for that user and prints a one-shot login URL
+     (no email send needed)
+  5. Uses `docker cp` to copy the audio chunks from prod's data/audio dir
+     into the staging backend container's /app/data/audio
+"""
+import argparse
+import json
+import os
+import pathlib
+import secrets
+import subprocess
+import sys
+from datetime import datetime, date, timedelta
+from decimal import Decimal
+
+project_root = pathlib.Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from backend.app import create_app  # noqa: E402
+from backend.models import Node, NodeTranscriptChunk, User  # noqa: E402
+
+AUDIO_STORAGE_ROOT = pathlib.Path(
+    os.environ.get("AUDIO_STORAGE_PATH", "data/audio")
+).resolve()
+
+
+def serialize_row(obj):
+    out = {}
+    for col in obj.__table__.columns:
+        v = getattr(obj, col.name)
+        if isinstance(v, (datetime, date)):
+            v = {"__datetime__": v.isoformat()}
+        elif isinstance(v, Decimal):
+            v = float(v)
+        elif isinstance(v, bytes):
+            v = {"__bytes__hex": v.hex()}
+        out[col.name] = v
+    return out
+
+
+def export_payload(app, node_ids):
+    with app.app_context():
+        nodes = Node.query.filter(Node.id.in_(node_ids)).all()
+        found = {n.id for n in nodes}
+        missing = set(node_ids) - found
+        if missing:
+            print(f"WARNING: nodes not found in prod DB: {sorted(missing)}",
+                  file=sys.stderr)
+        if not nodes:
+            sys.exit("No nodes to clone — aborting")
+        user_ids = sorted({n.user_id for n in nodes})
+        users = User.query.filter(User.id.in_(user_ids)).all()
+        chunks = NodeTranscriptChunk.query.filter(
+            NodeTranscriptChunk.node_id.in_(node_ids)
+        ).all()
+        return {
+            "users": [serialize_row(u) for u in users],
+            "nodes": [serialize_row(n) for n in nodes],
+            "chunks": [serialize_row(c) for c in chunks],
+        }
+
+
+# This script is written as a string and piped via `docker exec` into a python
+# process inside the staging backend container. Avoid f-strings / external
+# imports beyond what the staging container already has on path.
+IMPORT_SCRIPT = r'''
+import json, sys
+from datetime import datetime, timedelta
+sys.path.insert(0, "/app")
+from backend.app import create_app
+from backend.models import Node, NodeTranscriptChunk, User
+from backend.extensions import db
+from backend.utils.magic_link import generate_magic_link_token, hash_token
+
+
+def deser(v):
+    if isinstance(v, dict):
+        if "__datetime__" in v:
+            return datetime.fromisoformat(v["__datetime__"])
+        if "__bytes__hex" in v:
+            return bytes.fromhex(v["__bytes__hex"])
+    return v
+
+
+def deser_row(row):
+    return {k: deser(v) for k, v in row.items()}
+
+
+payload = json.loads(sys.stdin.read())
+app = create_app()
+with app.app_context():
+    counts = {"users_inserted": 0, "users_updated": 0,
+              "nodes_inserted": 0, "nodes_skipped": 0,
+              "chunks_inserted": 0, "chunks_skipped": 0}
+
+    # Users: insert or update so they have admin/voice access
+    user_ids = []
+    for raw in payload["users"]:
+        row = deser_row(raw)
+        u = User.query.get(row["id"])
+        if u is None:
+            u = User(**row)
+            db.session.add(u)
+            counts["users_inserted"] += 1
+        else:
+            for k, v in row.items():
+                if k != "id":
+                    setattr(u, k, v)
+            counts["users_updated"] += 1
+        # Force voice-mode access on staging
+        u.is_admin = True
+        u.approved = True
+        if not u.accepted_terms_at:
+            u.accepted_terms_at = datetime.utcnow()
+            u.accepted_terms_version = "v1"
+        user_ids.append(u.id)
+    db.session.commit()
+
+    # Nodes: skip if already exists; null out FK chain to keep clone shallow
+    for raw in payload["nodes"]:
+        row = deser_row(raw)
+        n = Node.query.get(row["id"])
+        if n:
+            counts["nodes_skipped"] += 1
+            continue
+        row["parent_id"] = None
+        row["linked_node_id"] = None
+        n = Node(**row)
+        db.session.add(n)
+        counts["nodes_inserted"] += 1
+    db.session.commit()
+
+    # Chunks
+    for raw in payload["chunks"]:
+        row = deser_row(raw)
+        c = NodeTranscriptChunk.query.get(row["id"])
+        if c:
+            counts["chunks_skipped"] += 1
+            continue
+        c = NodeTranscriptChunk(**row)
+        db.session.add(c)
+        counts["chunks_inserted"] += 1
+    db.session.commit()
+
+    # Bump sequences so future inserts on staging don't collide
+    for table, col in (("user", "id"), ("node", "id"),
+                       ("node_transcript_chunk", "id")):
+        db.session.execute(db.text(
+            f"SELECT setval(pg_get_serial_sequence('\"{table}\"', '{col}'), "
+            f"COALESCE((SELECT MAX({col}) FROM \"{table}\"), 1), true)"
+        ))
+    db.session.commit()
+
+    # Mint a magic-link login URL for each cloned user
+    login_urls = []
+    for uid in user_ids:
+        u = User.query.get(uid)
+        # Use email if set, else fabricate a placeholder so the token verifies
+        email = u.email or f"clone-{u.id}@local"
+        if not u.email:
+            u.email = email
+        token = generate_magic_link_token(email, "/")
+        u.magic_link_token_hash = hash_token(token)
+        u.magic_link_expires_at = datetime.utcnow() + timedelta(days=30)
+        db.session.commit()
+        login_urls.append((u.id, u.username, token))
+
+    print("IMPORT_RESULT", json.dumps({
+        "counts": counts,
+        "login_urls": [{"user_id": uid, "username": un, "token": tok}
+                       for (uid, un, tok) in login_urls],
+    }))
+'''
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--node-ids", nargs="+", type=int, required=True)
+    ap.add_argument("--staging-backend", default="wop-staging-backend-1")
+    ap.add_argument("--staging-url", default="https://staging.loore.org")
+    ap.add_argument("--skip-files", action="store_true",
+                    help="Skip docker cp (audio files persist across deploys)")
+    args = ap.parse_args()
+
+    print("=== Phase 1: export from prod DB ===")
+    app = create_app()
+    payload = export_payload(app, args.node_ids)
+    user_ids = sorted({n["user_id"] for n in payload["nodes"]})
+    print(f"  users: {len(payload['users'])} (ids: {user_ids})")
+    print(f"  nodes: {len(payload['nodes'])}")
+    print(f"  chunks: {len(payload['chunks'])}")
+
+    print("\n=== Phase 2: import into staging via docker exec ===")
+    proc = subprocess.run(
+        ["docker", "exec", "-i", args.staging_backend, "python", "-c",
+         IMPORT_SCRIPT],
+        input=json.dumps(payload).encode(),
+        capture_output=True,
+    )
+    out, err = proc.stdout.decode(), proc.stderr.decode()
+    if proc.returncode != 0:
+        print("IMPORT FAILED")
+        print("STDOUT:", out)
+        print("STDERR:", err)
+        sys.exit(1)
+    # Parse the IMPORT_RESULT line
+    result = None
+    for line in out.splitlines():
+        if line.startswith("IMPORT_RESULT "):
+            result = json.loads(line[len("IMPORT_RESULT "):])
+    if result is None:
+        print("Could not parse import result. Raw output:")
+        print(out)
+        sys.exit(1)
+    print("  counts:", result["counts"])
+
+    if not args.skip_files:
+        print("\n=== Phase 3: copy audio files into staging container ===")
+        for n in payload["nodes"]:
+            uid, nid = n["user_id"], n["id"]
+            src = AUDIO_STORAGE_ROOT / f"nodes/{uid}/{nid}"
+            if not src.exists():
+                print(f"  SKIP node {nid}: source dir {src} missing")
+                continue
+            dst_parent = f"/app/data/audio/nodes/{uid}"
+            subprocess.run(
+                ["docker", "exec", args.staging_backend,
+                 "mkdir", "-p", dst_parent], check=True,
+            )
+            subprocess.run(
+                ["docker", "cp", str(src),
+                 f"{args.staging_backend}:{dst_parent}/"], check=True,
+            )
+            size = sum(f.stat().st_size for f in src.rglob('*') if f.is_file())
+            print(f"  node {nid}: copied {round(size/1024/1024, 1)} MB")
+    else:
+        print("\n=== Phase 3: skipped (--skip-files) ===")
+
+    print("\n=== Login URLs (one-time use, expire in 30 days) ===")
+    for entry in result["login_urls"]:
+        url = f"{args.staging_url}/auth/magic-link/verify?token={entry['token']}"
+        print(f"  user {entry['user_id']} ({entry['username']}):")
+        print(f"    {url}")
+    print("\nDone. Open one of the URLs above to log in to staging,")
+    print("then click the speaker icon on the cloned node to test replay.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -237,7 +237,14 @@ def main():
     ap.add_argument("--staging-url", default="https://staging.loore.org")
     ap.add_argument("--skip-files", action="store_true",
                     help="Skip docker cp (audio files persist across deploys)")
+    ap.add_argument("--prod-audio-root",
+                    default=str(AUDIO_STORAGE_ROOT),
+                    help="Root path of prod audio storage. Defaults to "
+                         "AUDIO_STORAGE_PATH env var or 'data/audio' "
+                         "relative to cwd. Set this when running from a "
+                         "git worktree (e.g. /home/<user>/write-or-perish/data/audio)")
     args = ap.parse_args()
+    prod_audio_root = pathlib.Path(args.prod_audio_root).resolve()
 
     print("=== Phase 1: export from prod DB ===")
     app = create_app()
@@ -272,10 +279,11 @@ def main():
     print("  counts:", result["counts"])
 
     if not args.skip_files:
-        print("\n=== Phase 3: copy audio files into staging container ===")
+        print(f"\n=== Phase 3: copy audio files into staging container ===")
+        print(f"  prod audio root: {prod_audio_root}")
         for n in payload["nodes"]:
             uid, nid = n["user_id"], n["id"]
-            src = AUDIO_STORAGE_ROOT / f"nodes/{uid}/{nid}"
+            src = prod_audio_root / f"nodes/{uid}/{nid}"
             if not src.exists():
                 print(f"  SKIP node {nid}: source dir {src} missing")
                 continue

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -39,11 +39,15 @@ import sys
 from datetime import datetime, date, timedelta
 from decimal import Decimal
 
+import shutil
+import tempfile
+
 project_root = pathlib.Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from backend.app import create_app  # noqa: E402
 from backend.models import Node, NodeTranscriptChunk, User  # noqa: E402
+from backend.utils.encryption import decrypt_file  # noqa: E402
 
 AUDIO_STORAGE_ROOT = pathlib.Path(
     os.environ.get("AUDIO_STORAGE_PATH", "data/audio")
@@ -302,23 +306,61 @@ def main():
     if not args.skip_files:
         print(f"\n=== Phase 3: copy audio files into staging container ===")
         print(f"  prod audio root: {prod_audio_root}")
+        # Files in prod are encrypted with prod's KMS-wrapped DEK. Staging
+        # has its own (or no) KMS key and can't unwrap that DEK, so we
+        # decrypt on the prod side and ship plaintext. The /media route
+        # serves plaintext files transparently (decrypt_file is a no-op
+        # for paths without `.enc`), and the backfill script that runs
+        # next can read these plaintext chunks directly.
         for n in payload["nodes"]:
             uid, nid = n["user_id"], n["id"]
             src = prod_audio_root / f"nodes/{uid}/{nid}"
             if not src.exists():
                 print(f"  SKIP node {nid}: source dir {src} missing")
                 continue
-            dst_parent = f"/app/data/audio/nodes/{uid}"
-            subprocess.run(
-                ["docker", "exec", args.staging_backend,
-                 "mkdir", "-p", dst_parent], check=True,
-            )
-            subprocess.run(
-                ["docker", "cp", str(src),
-                 f"{args.staging_backend}:{dst_parent}/"], check=True,
-            )
-            size = sum(f.stat().st_size for f in src.rglob('*') if f.is_file())
-            print(f"  node {nid}: copied {round(size/1024/1024, 1)} MB")
+            stage = pathlib.Path(tempfile.mkdtemp(prefix=f'clone_{nid}_'))
+            try:
+                # Mirror src into stage/<nid>/, decrypting .enc files.
+                dst = stage / str(nid)
+                dst.mkdir()
+                n_dec, n_plain, total_bytes = 0, 0, 0
+                for f in src.iterdir():
+                    if not f.is_file():
+                        continue
+                    if f.name.endswith('.enc'):
+                        target = dst / f.name[:-4]
+                        plaintext = decrypt_file(str(f))
+                        target.write_bytes(plaintext)
+                        n_dec += 1
+                        total_bytes += len(plaintext)
+                    else:
+                        target = dst / f.name
+                        shutil.copy2(str(f), str(target))
+                        n_plain += 1
+                        total_bytes += target.stat().st_size
+                # Wipe any pre-existing staging data for this node so we
+                # don't end up with stale prod-encrypted .enc files
+                # alongside the new plaintext (the audio-chunks endpoint
+                # prefers plain over enc, but the backfill prefers the
+                # opposite — leaving both around would break backfill).
+                dst_dir = f"/app/data/audio/nodes/{uid}/{nid}"
+                subprocess.run(
+                    ["docker", "exec", args.staging_backend,
+                     "rm", "-rf", dst_dir], check=True,
+                )
+                dst_parent = f"/app/data/audio/nodes/{uid}"
+                subprocess.run(
+                    ["docker", "exec", args.staging_backend,
+                     "mkdir", "-p", dst_parent], check=True,
+                )
+                subprocess.run(
+                    ["docker", "cp", str(dst),
+                     f"{args.staging_backend}:{dst_parent}/"], check=True,
+                )
+                print(f"  node {nid}: {n_dec} decrypted + {n_plain} plain "
+                      f"-> {round(total_bytes/1024/1024, 1)} MB")
+            finally:
+                shutil.rmtree(str(stage), ignore_errors=True)
     else:
         print("\n=== Phase 3: skipped (--skip-files) ===")
 

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -343,14 +343,17 @@ def main():
                 # alongside the new plaintext (the audio-chunks endpoint
                 # prefers plain over enc, but the backfill prefers the
                 # opposite — leaving both around would break backfill).
+                # Run cleanup + mkdir as root because earlier docker cp
+                # copied files in as root, and the container's default
+                # user can't unlink them (Permission denied).
                 dst_dir = f"/app/data/audio/nodes/{uid}/{nid}"
                 subprocess.run(
-                    ["docker", "exec", args.staging_backend,
+                    ["docker", "exec", "-u", "0", args.staging_backend,
                      "rm", "-rf", dst_dir], check=True,
                 )
                 dst_parent = f"/app/data/audio/nodes/{uid}"
                 subprocess.run(
-                    ["docker", "exec", args.staging_backend,
+                    ["docker", "exec", "-u", "0", args.staging_backend,
                      "mkdir", "-p", dst_parent], check=True,
                 )
                 subprocess.run(

--- a/backend/scripts/clone_node_to_staging.py
+++ b/backend/scripts/clone_node_to_staging.py
@@ -132,7 +132,7 @@ app = create_app()
 with app.app_context():
     counts = {"users_inserted": 0, "users_updated": 0,
               "nodes_inserted": 0, "nodes_replaced": 0,
-              "chunks_inserted": 0, "chunks_replaced": 0}
+              "chunks_inserted": 0}
 
     # Users: insert or update so they have admin/voice access
     user_ids = []
@@ -158,21 +158,42 @@ with app.app_context():
     db.session.commit()
 
     # Replace-then-insert for nodes + chunks so re-running the script fixes
-    # any prior broken clone (e.g. ciphertext shipped before this script
-    # learned to decrypt-and-reencrypt). Scoped strictly to the requested
-    # node ids — never touches unrelated staging data.
+    # any prior broken clone. Scoped strictly to the requested node ids —
+    # never touches unrelated staging data. We sweep referencing rows in
+    # dependency order before deleting the nodes themselves; staging may
+    # have created TTSChunk / NodeVersion / Draft rows pointing at these
+    # ids during prior speaker-icon clicks, and a plain Node delete fails
+    # the FK constraints.
     cloned_node_ids = [deser_row(r)["id"] for r in payload["nodes"]]
     if cloned_node_ids:
-        # Chunks first (FK to node has no CASCADE).
-        deleted_chunks = NodeTranscriptChunk.query.filter(
-            NodeTranscriptChunk.node_id.in_(cloned_node_ids)
-        ).delete(synchronize_session=False)
+        ids_csv = ",".join(str(i) for i in cloned_node_ids)
+        # Children with no CASCADE — delete outright.
+        for table, col in (
+            ("tts_chunk", "node_id"),
+            ("node_version", "node_id"),
+            ("node_transcript_chunk", "node_id"),
+        ):
+            db.session.execute(db.text(
+                f"DELETE FROM {table} WHERE {col} IN ({ids_csv})"
+            ))
+        # Tables that should survive — null the FK instead of deleting.
+        for table, col in (
+            ("draft", "node_id"),
+            ("draft", "parent_id"),
+            ("draft", "llm_node_id"),
+            ("node", "parent_id"),
+            ("node", "linked_node_id"),
+        ):
+            db.session.execute(db.text(
+                f"UPDATE \"{table}\" SET {col} = NULL "
+                f"WHERE {col} IN ({ids_csv})"
+            ))
+        # node_context_artifact has ON DELETE CASCADE — auto-cleaned.
         deleted_nodes = Node.query.filter(
             Node.id.in_(cloned_node_ids)
         ).delete(synchronize_session=False)
         db.session.commit()
         counts["nodes_replaced"] = deleted_nodes
-        counts["chunks_replaced"] = deleted_chunks
 
     # Nodes: null out FK chain to keep clone shallow. Encrypted columns
     # arrive as plaintext — re-encrypt with staging's key.

--- a/backend/utils/audio_storage.py
+++ b/backend/utils/audio_storage.py
@@ -17,6 +17,32 @@ AUDIO_STORAGE_ROOT = pathlib.Path(
 ).resolve()
 
 
+def list_streaming_audio_files(chunk_dir: pathlib.Path) -> list:
+    """Return sorted list of streaming-recording chunk files for playback.
+
+    Searches `chunk_dir` for chunk_*.{webm,mp4}[.enc] first (recording
+    in-progress or pre-batch-transcription state), then falls back to
+    batch_*.{webm,mp4}[.enc] (the modern post-batch-transcription
+    format). Within each tier, prefers plain files over encrypted to
+    match prior endpoint behavior. Returns [] if nothing matches.
+
+    The `.legacy_backup` suffix used by `backfill_legacy_chunks.py` is
+    deliberately not matched — those files exist for rollback only and
+    must not be served to clients.
+    """
+    if not chunk_dir.exists():
+        return []
+    for prefix in ("chunk", "batch"):
+        for ext in (".webm", ".mp4"):
+            plain = sorted(chunk_dir.glob(f"{prefix}_*{ext}"))
+            if plain:
+                return plain
+            enc = sorted(chunk_dir.glob(f"{prefix}_*{ext}.enc"))
+            if enc:
+                return enc
+    return []
+
+
 def move_draft_audio_to_node_dir(
     draft_audio_dir: pathlib.Path,
     node_audio_dir: pathlib.Path,

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -399,20 +399,24 @@ def concat_fragmented_media(paths: list,
 
 def concat_audio_files(paths: list, output_suffix: str = '.webm',
                        reencode_codec: Optional[str] = None) -> str:
-    """Concatenate multiple audio files using ffmpeg concat demuxer.
+    """Concatenate multiple audio files into a single output.
 
     Args:
         paths: List of file paths to concatenate (in order).
         output_suffix: Extension for the output temp file.
-        reencode_codec: When set (e.g. 'aac'), decode + re-encode to
-            this codec instead of stream-copying. Required for MP4
-            sources because per-packet timestamps drift across
-            fragmented-MP4 batch boundaries under `-c copy`, leaving
-            most of the output muted; re-encoding rebuilds them from
-            decoded samples. WebM/Opus is robust under stream-copy.
+        reencode_codec: When set (e.g. 'aac'), use the ffmpeg concat
+            FILTER to decode each input independently, concatenate
+            decoded sample buffers, and re-encode. Required for MP4
+            sources: the concat demuxer + `-c copy` path mangles
+            per-packet timestamps across fragmented-MP4 batch
+            boundaries (output reports correct duration but most of
+            the audio reads as silence). Operating on decoded samples
+            sidesteps any demuxer-level PTS quirks. When None, uses
+            the fast concat demuxer + `-c copy` (fine for WebM/Opus,
+            whose Matroska cluster timestamps are robust).
 
     Returns:
-        Path to the merged temp file.  Caller is responsible for cleanup.
+        Path to the merged temp file. Caller is responsible for cleanup.
 
     Raises:
         RuntimeError: If ffmpeg fails.
@@ -432,6 +436,34 @@ def concat_audio_files(paths: list, output_suffix: str = '.webm',
     import subprocess
     import tempfile
 
+    if reencode_codec:
+        # concat filter path — decode + sample-level join + re-encode
+        fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
+        os.close(fd)
+        ffmpeg_inputs = []
+        for p in paths:
+            ffmpeg_inputs.extend(['-i', p])
+        n = len(paths)
+        filter_streams = ''.join(f'[{i}:a:0]' for i in range(n))
+        filter_str = f'{filter_streams}concat=n={n}:v=0:a=1[out]'
+        result = subprocess.run(
+            ['ffmpeg', '-y', *ffmpeg_inputs,
+             '-filter_complex', filter_str,
+             '-map', '[out]', '-c:a', reencode_codec, '-b:a', '128k',
+             out_path],
+            capture_output=True, text=True, timeout=900,
+        )
+        if result.returncode != 0:
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"ffmpeg concat-filter failed: {result.stderr[:500]}"
+            )
+        return out_path
+
+    # concat demuxer path — fast stream-copy, used for WebM
     concat_fd, concat_path = tempfile.mkstemp(suffix='.txt', prefix='concat_')
     try:
         with os.fdopen(concat_fd, 'w') as f:
@@ -442,13 +474,9 @@ def concat_audio_files(paths: list, output_suffix: str = '.webm',
         fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
         os.close(fd)
 
-        if reencode_codec:
-            codec_args = ['-c:a', reencode_codec, '-b:a', '128k']
-        else:
-            codec_args = ['-c', 'copy']
         result = subprocess.run(
             ['ffmpeg', '-y', '-f', 'concat', '-safe', '0',
-             '-i', concat_path, *codec_args, out_path],
+             '-i', concat_path, '-c', 'copy', out_path],
             capture_output=True, text=True, timeout=600,
         )
         if result.returncode != 0:

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -397,12 +397,19 @@ def concat_fragmented_media(paths: list,
             pass
 
 
-def concat_audio_files(paths: list, output_suffix: str = '.webm') -> str:
+def concat_audio_files(paths: list, output_suffix: str = '.webm',
+                       reencode_codec: Optional[str] = None) -> str:
     """Concatenate multiple audio files using ffmpeg concat demuxer.
 
     Args:
         paths: List of file paths to concatenate (in order).
         output_suffix: Extension for the output temp file.
+        reencode_codec: When set (e.g. 'aac'), decode + re-encode to
+            this codec instead of stream-copying. Required for MP4
+            sources because per-packet timestamps drift across
+            fragmented-MP4 batch boundaries under `-c copy`, leaving
+            most of the output muted; re-encoding rebuilds them from
+            decoded samples. WebM/Opus is robust under stream-copy.
 
     Returns:
         Path to the merged temp file.  Caller is responsible for cleanup.
@@ -414,7 +421,7 @@ def concat_audio_files(paths: list, output_suffix: str = '.webm') -> str:
     if not paths:
         raise ValueError("No audio files to concatenate")
 
-    if len(paths) == 1:
+    if len(paths) == 1 and not reencode_codec:
         # Nothing to merge — return a copy so the caller can always unlink
         import tempfile
         fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
@@ -435,10 +442,14 @@ def concat_audio_files(paths: list, output_suffix: str = '.webm') -> str:
         fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
         os.close(fd)
 
+        if reencode_codec:
+            codec_args = ['-c:a', reencode_codec, '-b:a', '128k']
+        else:
+            codec_args = ['-c', 'copy']
         result = subprocess.run(
             ['ffmpeg', '-y', '-f', 'concat', '-safe', '0',
-             '-i', concat_path, '-c', 'copy', out_path],
-            capture_output=True, text=True, timeout=120,
+             '-i', concat_path, *codec_args, out_path],
+            capture_output=True, text=True, timeout=600,
         )
         if result.returncode != 0:
             try:

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -437,31 +437,64 @@ def concat_audio_files(paths: list, output_suffix: str = '.webm',
     import tempfile
 
     if reencode_codec:
-        # concat filter path — decode + sample-level join + re-encode
-        fd, out_path = tempfile.mkstemp(suffix=output_suffix, prefix='merged_')
-        os.close(fd)
-        ffmpeg_inputs = []
-        for p in paths:
-            ffmpeg_inputs.extend(['-i', p])
-        n = len(paths)
-        filter_streams = ''.join(f'[{i}:a:0]' for i in range(n))
-        filter_str = f'{filter_streams}concat=n={n}:v=0:a=1[out]'
-        result = subprocess.run(
-            ['ffmpeg', '-y', *ffmpeg_inputs,
-             '-filter_complex', filter_str,
-             '-map', '[out]', '-c:a', reencode_codec, '-b:a', '128k',
-             out_path],
-            capture_output=True, text=True, timeout=900,
-        )
-        if result.returncode != 0:
-            try:
-                os.unlink(out_path)
-            except OSError:
-                pass
-            raise RuntimeError(
-                f"ffmpeg concat-filter failed: {result.stderr[:500]}"
+        # WAV-intermediate path. Both the concat demuxer (-c copy) and
+        # the concat filter (-filter_complex) yielded mostly-silent
+        # output for fragmented-MP4 batches from MediaRecorder, even
+        # though each batch decodes correctly on its own. The
+        # symptomatic Qavg of 2231 from a direct concat-filter pass
+        # means the encoder was eating zero/near-zero samples — the
+        # batches' codec extradata or per-frame priming gets confused
+        # when fed sequentially through libavcodec.
+        #
+        # Decoding each batch to PCM WAV separately sidesteps the
+        # whole extradata / priming dance: each batch is decoded in
+        # its own libavcodec context, samples are written verbatim,
+        # then the WAV concat-demux + AAC encode is timestamp-trivial
+        # because PCM has no codec delay.
+        wav_dir = tempfile.mkdtemp(prefix='wav_concat_')
+        try:
+            wav_paths = []
+            for i, p in enumerate(paths):
+                wav_path = os.path.join(wav_dir, f'part_{i:04d}.wav')
+                r = subprocess.run(
+                    ['ffmpeg', '-y', '-i', p,
+                     '-c:a', 'pcm_s16le', '-ar', '48000', '-ac', '1',
+                     wav_path],
+                    capture_output=True, text=True, timeout=600,
+                )
+                if r.returncode != 0:
+                    raise RuntimeError(
+                        f"ffmpeg decode-to-wav failed for {p}: "
+                        f"{r.stderr[:500]}"
+                    )
+                wav_paths.append(wav_path)
+
+            list_path = os.path.join(wav_dir, 'list.txt')
+            with open(list_path, 'w') as f:
+                for w in wav_paths:
+                    escaped = w.replace("'", "'\\''")
+                    f.write(f"file '{escaped}'\n")
+
+            fd, out_path = tempfile.mkstemp(suffix=output_suffix,
+                                            prefix='merged_')
+            os.close(fd)
+            r = subprocess.run(
+                ['ffmpeg', '-y', '-f', 'concat', '-safe', '0',
+                 '-i', list_path,
+                 '-c:a', reencode_codec, '-b:a', '128k', out_path],
+                capture_output=True, text=True, timeout=600,
             )
-        return out_path
+            if r.returncode != 0:
+                try:
+                    os.unlink(out_path)
+                except OSError:
+                    pass
+                raise RuntimeError(
+                    f"ffmpeg WAV-concat encode failed: {r.stderr[:500]}"
+                )
+            return out_path
+        finally:
+            shutil.rmtree(wav_dir, ignore_errors=True)
 
     # concat demuxer path — fast stream-copy, used for WebM
     concat_fd, concat_path = tempfile.mkstemp(suffix='.txt', prefix='concat_')

--- a/frontend/src/contexts/AudioContext.js
+++ b/frontend/src/contexts/AudioContext.js
@@ -44,9 +44,6 @@ export const AudioProvider = ({ children }) => {
   const queueMetadataRef = useRef(null);
   // Playback ID to prevent stale event handlers from updating state
   const playbackIdRef = useRef(0);
-  // For WebM files with continuous timestamps: track the starting timestamp offset of current chunk
-  // (MediaRecorder with timeslice produces chunks where timestamps continue across chunks)
-  const chunkTimestampOffsetRef = useRef(0);
 
   // Calculate cumulative time based on chunk index and current position
   const calculateCumulativeTime = useCallback((chunkIndex, timeInChunk) => {
@@ -73,10 +70,7 @@ export const AudioProvider = ({ children }) => {
         return;
       }
       if (audioRef.current && isFinite(audioRef.current.currentTime)) {
-        const rawTime = audioRef.current.currentTime;
-        // Subtract timestamp offset for WebM files with continuous timestamps
-        const timeInChunk = rawTime - chunkTimestampOffsetRef.current;
-        // Read chunk index from ref directly for most up-to-date value
+        const timeInChunk = audioRef.current.currentTime;
         const currentChunkIdx = currentChunkIndexRef.current;
         setCurrentTime(timeInChunk);
         setCumulativeTime(calculateCumulativeTime(currentChunkIdx, timeInChunk));
@@ -246,35 +240,19 @@ export const AudioProvider = ({ children }) => {
     audioRef.current = audio;
     audio.playbackRate = playbackRate;
 
-    // Detect if this is a WebM file with continuous timestamps
-    // WebM files from MediaRecorder with timeslice have timestamps that continue
-    // across chunks (chunk 0: 0-300s, chunk 1: 300-600s, etc.)
-    // MP3 and other formats start at timestamp 0 in each file
-    const isWebM = chunkUrl.toLowerCase().includes('.webm');
-
     // Track if we've already seeked (to avoid multiple seeks)
     let hasSeeked = false;
-    // Track if we've detected the timestamp offset for this chunk
-    let hasDetectedOffset = false;
 
     audio.onloadedmetadata = () => {
-      // Check if this handler is still valid
       if (playbackIdRef.current !== thisPlaybackId) return;
 
       const actualDuration = audio.duration;
-
-      if (isWebM) {
-        // WebM duration includes all prior chunks, so don't compare directly
-        // The ontimeupdate handler will detect the offset and correct durations
-      } else {
-        // For MP3 and other formats, update stored duration if significantly different
-        if (isFinite(actualDuration) && Math.abs(durations[chunkIndex] - actualDuration) > 1) {
-          const updatedDurations = [...chunkDurationsRef.current];
-          updatedDurations[chunkIndex] = actualDuration;
-          chunkDurationsRef.current = updatedDurations;
-          setChunkDurations(updatedDurations);
-          recalculateTotalDuration(updatedDurations);
-        }
+      if (isFinite(actualDuration) && Math.abs(durations[chunkIndex] - actualDuration) > 1) {
+        const updatedDurations = [...chunkDurationsRef.current];
+        updatedDurations[chunkIndex] = actualDuration;
+        chunkDurationsRef.current = updatedDurations;
+        setChunkDurations(updatedDurations);
+        recalculateTotalDuration(updatedDurations);
       }
       setDuration(actualDuration);
       setLoading(false);
@@ -283,74 +261,29 @@ export const AudioProvider = ({ children }) => {
     // Use canplay event for seeking - this fires when the browser can actually seek
     audio.oncanplay = () => {
       if (playbackIdRef.current !== thisPlaybackId) return;
-      if (hasSeeked) return; // Only seek once
+      if (hasSeeked) return;
       hasSeeked = true;
 
-      if (isWebM) {
-        // For WebM with continuous timestamps, add the expected offset
-        const expectedOffset = durations.slice(0, chunkIndex).reduce((a, b) => a + b, 0);
-        const rawSeekTime = safeTimeInChunk + expectedOffset;
-        const clampedTime = Math.max(expectedOffset, Math.min(rawSeekTime, (audio.duration || expectedOffset + 300)));
-        if (isFinite(clampedTime)) {
-          audio.currentTime = clampedTime;
-        }
-      } else {
-        // For MP3 and other formats, seek directly within the chunk
-        if (safeTimeInChunk > 0 && isFinite(safeTimeInChunk)) {
-          const clampedTime = Math.min(safeTimeInChunk, audio.duration || 300);
-          audio.currentTime = clampedTime;
-        }
+      if (safeTimeInChunk > 0 && isFinite(safeTimeInChunk)) {
+        const clampedTime = Math.min(safeTimeInChunk, audio.duration || 300);
+        audio.currentTime = clampedTime;
       }
     };
 
-    // Set the timestamp offset immediately based on format detection
-    // (don't wait for ontimeupdate which fires too late for initial seek)
-    if (isWebM) {
-      // Will be refined in ontimeupdate, but set a reasonable initial value
-      chunkTimestampOffsetRef.current = durations.slice(0, chunkIndex).reduce((a, b) => a + b, 0);
-    } else {
-      // MP3 and other formats always start at 0
-      chunkTimestampOffsetRef.current = 0;
-    }
-
     audio.ontimeupdate = () => {
-      // Check if this handler is still valid
       if (playbackIdRef.current !== thisPlaybackId) return;
 
-      const rawTime = audio.currentTime;
-
-      // Refine timestamp offset detection on first time update (WebM only)
-      if (!hasDetectedOffset) {
-        hasDetectedOffset = true;
-        if (isWebM) {
-          const expectedOffset = durations.slice(0, chunkIndex).reduce((a, b) => a + b, 0);
-          if (rawTime > expectedOffset - 5 && rawTime < expectedOffset + durations[chunkIndex] + 5) {
-            chunkTimestampOffsetRef.current = expectedOffset;
-          } else if (rawTime < 5) {
-            chunkTimestampOffsetRef.current = 0;
-          } else {
-            chunkTimestampOffsetRef.current = rawTime;
-          }
-        }
-        // For non-WebM, offset stays 0 (set above)
-      }
-
-      // Calculate time within chunk by subtracting the offset
-      const timeInCurrentChunk = rawTime - chunkTimestampOffsetRef.current;
+      const timeInCurrentChunk = audio.currentTime;
       setCurrentTime(timeInCurrentChunk);
       setCumulativeTime(calculateCumulativeTime(chunkIndex, timeInCurrentChunk));
     };
 
     audio.onended = () => {
-      // Check if this handler is still valid
       if (playbackIdRef.current !== thisPlaybackId) return;
 
-      // CRITICAL: Update this chunk's duration based on actual playback time
-      // This fixes the issue where preloaded metadata durations are incorrect
-      // (common with MediaRecorder-produced files that lack proper duration headers)
-      // Subtract the timestamp offset to get the actual duration within this chunk
-      const rawEndTime = audio.currentTime;
-      const actualDuration = rawEndTime - chunkTimestampOffsetRef.current;
+      // Correct stored duration with the actual playback length — preloaded
+      // metadata is unreliable for MediaRecorder-produced files.
+      const actualDuration = audio.currentTime;
       if (isFinite(actualDuration) && actualDuration > 0) {
         const currentDurations = chunkDurationsRef.current;
         const existingDuration = currentDurations[chunkIndex];
@@ -428,7 +361,6 @@ export const AudioProvider = ({ children }) => {
     setCumulativeTime(0);
     allChunkUrlsRef.current = [];
     audioQueueRef.current = [];
-    chunkTimestampOffsetRef.current = 0;
 
     setLoading(true);
     setCurrentAudio(audioData);
@@ -526,10 +458,9 @@ export const AudioProvider = ({ children }) => {
     setTotalChunks(urls.length);
     setCurrentChunkIndex(0);
     currentChunkIndexRef.current = 0;
-    chunkTimestampOffsetRef.current = 0;
 
     // Use server-provided durations if available (accurate via ffprobe)
-    // Otherwise fall back to browser metadata detection (unreliable for WebM with continuous timestamps)
+    // Otherwise fall back to browser metadata detection
     let durations;
     if (serverDurations && serverDurations.length === urls.length && serverDurations.every(d => d != null)) {
       durations = serverDurations;
@@ -628,7 +559,6 @@ export const AudioProvider = ({ children }) => {
       allChunkUrlsRef.current = [];
       audioQueueRef.current = [];
       queueMetadataRef.current = null;
-      chunkTimestampOffsetRef.current = 0;
       setCurrentAudio(null);
     }
   }, [stopTimeTracking]);
@@ -687,9 +617,7 @@ export const AudioProvider = ({ children }) => {
     // If same chunk, just seek within it
     if (chunkIndex === currentChunkIndexRef.current && audioRef.current) {
       const safeTime = isFinite(timeInChunk) ? timeInChunk : 0;
-      // Add timestamp offset for WebM with continuous timestamps
-      const rawSeekTime = safeTime + chunkTimestampOffsetRef.current;
-      audioRef.current.currentTime = rawSeekTime;
+      audioRef.current.currentTime = safeTime;
       setCurrentTime(safeTime);
       setCumulativeTime(clampedTime);
     } else {
@@ -716,10 +644,7 @@ export const AudioProvider = ({ children }) => {
       return;
     }
 
-    // Calculate current cumulative time and add 10 seconds
-    // Subtract the timestamp offset to get the actual position within the chunk
-    const rawTime = audioRef.current?.currentTime || 0;
-    const timeInChunk = rawTime - chunkTimestampOffsetRef.current;
+    const timeInChunk = audioRef.current?.currentTime || 0;
     const currentCumulative = calculateCumulativeTime(currentChunkIndexRef.current, timeInChunk);
     seekToCumulativeTime(currentCumulative + 10);
   }, [calculateCumulativeTime, seekToCumulativeTime]);
@@ -738,10 +663,7 @@ export const AudioProvider = ({ children }) => {
       return;
     }
 
-    // Calculate current cumulative time and subtract 10 seconds
-    // Subtract the timestamp offset to get the actual position within the chunk
-    const rawTime = audioRef.current?.currentTime || 0;
-    const timeInChunk = rawTime - chunkTimestampOffsetRef.current;
+    const timeInChunk = audioRef.current?.currentTime || 0;
     const currentCumulative = calculateCumulativeTime(currentChunkIndexRef.current, timeInChunk);
     seekToCumulativeTime(currentCumulative - 10);
   }, [calculateCumulativeTime, seekToCumulativeTime]);

--- a/frontend/src/contexts/AudioContext.js
+++ b/frontend/src/contexts/AudioContext.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useRef, useCallback } from 'react';
+import { useToast } from './ToastContext';
 
 const AudioContext = createContext();
 
@@ -10,7 +11,29 @@ export const useAudio = () => {
   return context;
 };
 
+// Map an HTMLMediaElement.error to a user-facing toast message. The
+// most common cause of code 4 (SRC_NOT_SUPPORTED) here is older iOS
+// Safari being asked to play a WebM/Opus recording made in
+// Chrome/Firefox; we surface that hypothesis since the browser doesn't
+// reveal which codec it choked on. Other codes are rare and stay
+// generic — network / decode errors mid-playback.
+const playbackErrorMessage = (audioEl) => {
+  const err = audioEl && audioEl.error;
+  if (!err) return 'Audio playback failed.';
+  if (err.code === 4) {
+    const src = (audioEl.currentSrc || '').toLowerCase();
+    if (src.includes('.webm')) {
+      return "This recording is in WebM/Opus, which this browser can't play. Try Chrome or update iOS to 17.4+.";
+    }
+    return "This audio format isn't supported by your browser.";
+  }
+  if (err.code === 2) return 'Network error loading audio. Try again.';
+  if (err.code === 3) return 'Audio decoding error. The recording may be corrupted.';
+  return 'Audio playback failed.';
+};
+
 export const AudioProvider = ({ children }) => {
+  const { addToast } = useToast();
   const [currentAudio, setCurrentAudio] = useState(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
@@ -333,7 +356,8 @@ export const AudioProvider = ({ children }) => {
 
     audio.onerror = (e) => {
       if (playbackIdRef.current !== thisPlaybackId) return;
-      console.error('Error loading audio chunk:', e);
+      console.error('Error loading audio chunk:', audio.error || e);
+      addToast(playbackErrorMessage(audio), 6000);
       setLoading(false);
       setIsPlaying(false);
       stopTimeTracking();
@@ -342,7 +366,7 @@ export const AudioProvider = ({ children }) => {
     if (shouldAutoPlay) {
       audio.play().catch(err => console.error('Error playing chunk:', err));
     }
-  }, [playbackRate, calculateCumulativeTime, startTimeTracking, stopTimeTracking, recalculateTotalDuration, cleanupAudio]);
+  }, [playbackRate, calculateCumulativeTime, startTimeTracking, stopTimeTracking, recalculateTotalDuration, cleanupAudio, addToast]);
 
   const loadAudio = useCallback(async (audioData) => {
     // If there's already audio playing, pause it first
@@ -409,7 +433,8 @@ export const AudioProvider = ({ children }) => {
     };
 
     audio.onerror = (e) => {
-      console.error('Error loading audio:', e);
+      console.error('Error loading audio:', audio.error || e);
+      addToast(playbackErrorMessage(audio), 6000);
       setLoading(false);
       setIsPlaying(false);
       stopTimeTracking();
@@ -422,7 +447,7 @@ export const AudioProvider = ({ children }) => {
       console.error('Error playing audio:', err);
       setLoading(false);
     }
-  }, [startTimeTracking, stopTimeTracking, playbackRate]);
+  }, [startTimeTracking, stopTimeTracking, playbackRate, addToast]);
 
   // Load and play a queue of audio URLs (for chunked playback)
   // serverDurations: optional array of durations from backend (accurate via ffprobe)


### PR DESCRIPTION
## Summary

This PR started as a fix for #118 (voice replay skipping middle batch on 10+ minute recordings) and grew to cover several closely-related production audio bugs surfaced during validation:

- **Fix #118** — voice messages spanning 3+ batches skipped the middle batch on replay. Caused by stale WebM-specific code in `AudioContext.js` that assumed Matroska cluster timestamps continued across batch files; modern post-#117 batches each start at timestamp 0 from ffmpeg remux. Fix: drop the WebM offset path, treat all chunks as independent files starting at 0.
- **Fix MP4 detection regression from #123** — three node-playback endpoints in `nodes.py` had hard-coded `chunk_*.webm` / `batch_*.webm` globs and didn't see iOS-recorded MP4 files, so the speaker icon silently triggered TTS instead of playback. Centralized into `list_streaming_audio_files()` helper covering both formats.
- **Fix MP4 audio-download silent output** — the download endpoint produced a mostly-silent MP4 from fragmented-MP4 batches. Both `-c copy` (PTS drift across fMP4 boundaries) and the concat filter (corrupted shared AAC decoder context) yielded broken output; switched to a WAV-intermediate path that decodes each batch in its own ffmpeg process, then concats the PCM and encodes to AAC.
- **Surface playback errors via toast** — `audio.onerror` handlers were silent. Now translates `MediaError` codes into user-facing messages, especially the iOS-Safari-can't-play-WebM/Opus case.
- **API cleanup** — `?format=webm` on `/audio-download` was misleading post-#123 (returned MP4 when source was MP4). Renamed canonical to `?format=original`; `?format=webm` is kept as a deprecated alias.

## Backfill for legacy data

A code review pointed out that voice recordings created before the ffmpeg-remux pipeline (commit `1b8c487`) might be stored as raw `chunk_*.webm` files with continuous Matroska cluster timestamps, and would regress under the new player. A production audit confirmed: **183 nodes (~2 GB)** in the 2026-01-28 → 2026-03-21 window have legacy chunks. They're concentrated in two user accounts.

`backend/scripts/backfill_legacy_chunks.py` remuxes each legacy chunk individually into a modern `batch_NNNN-NNNN.webm[.enc]` file with timestamps rebased to 0 — one batch per input chunk, preserving the original ~5-min granularity. Originals are renamed to `chunk_*.webm[.enc].legacy_backup`. Safety:
- Dry-run by default; `--commit` required for any writes
- Verifies merged duration > 0 before any rename
- Optional `--verify-decode` runs ffmpeg full-decode to catch mid-file corruption
- Idempotent; rerun completes any partial work
- Per-node rollback recipe in the script's docstring

`backend/scripts/clone_node_to_staging.py` is a sibling helper that clones a prod node (DB rows + decrypted audio files) into the staging stack via docker exec/cp, plus mints a magic-link login URL. Used during this PR's validation to test against real prod recordings without re-recording 10+ minute voice messages.

## What's been validated on staging

| Path | Status |
|---|---|
| Modern WebM multi-batch — the actual #118 bug | ✓ |
| Modern MP4 multi-chunk (iOS-recorded) | ✓ |
| Legacy WebM 1/3/5-chunk after per-chunk backfill | ✓ |
| TTS replay regression | ✓ |
| MP3 audio-download | ✓ |
| MP4 audio-download (after WAV-intermediate fix) | ✓ |
| `format=original` and deprecated `format=webm` alias | ✓ |
| WebM-on-iOS toast | manual, optional |

19/19 backend audio + webm tests pass. Frontend builds clean.

## Deployment sequence

1. Merge this PR → frontend fix ships, modern recordings (WebM and MP4) play correctly, MP4 detection regression fixed, MP4 download fixed, error toasts visible to users.
2. On the prod VM, run the legacy-chunk backfill in stages:
   ```bash
   python -m backend.scripts.backfill_legacy_chunks                          # dry-run, no writes
   python -m backend.scripts.backfill_legacy_chunks --commit --node 5168     # one small node
   # …verify replay in browser…
   python -m backend.scripts.backfill_legacy_chunks --commit --verify-decode # full
   ```
   The backfill is CPU-intensive (~hour-ish wall time at intermittent 130–150% CPU on the VM) and idempotent; safe to run during low-traffic windows.
3. After 1–2 weeks of no replay complaints, decide whether to keep `.legacy_backup` files (~2 GB) or write a separate purge script.

## Test plan

- [x] Record a voice message > 10 minutes (3+ batches), replay it, confirm all batches play sequentially with no skip
- [x] Confirm cumulative elapsed-time advances monotonically across batch boundaries
- [x] Seek into the middle of batch 2; confirm playback lands inside batch 2 content, not its end
- [x] Click speaker on an MP4-recorded node; confirm playback (not TTS generation) starts
- [x] Replay a TTS message to confirm no regression on the unified path
- [x] MP4 audio-download produces a fully-audible file (Content-Type `audio/mp4`)
- [x] MP3 audio-download produces a fully-audible file
- [ ] (manual on iPhone) WebM-on-iOS replay shows the unsupported-format toast
- [ ] After backfill on a single legacy prod node, replay that node and confirm full-length playback at correct duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
