### PR TITLE
Maeby's Feedback: Log link-to-newest, voice Send, checkboxes, expand bubbles, edit→LLM

### DIFF
--- a/backend/routes/feed.py
+++ b/backend/routes/feed.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
 from backend.models import Node, User
 from backend.extensions import db
+from backend.utils.privacy import accessible_nodes_filter
 from sqlalchemy import or_, func
 
 feed_bp = Blueprint("feed_bp", __name__)
@@ -29,6 +30,36 @@ def get_feed():
     def make_preview(text, length=200):
         return text[:length] + ("..." if len(text) > length else "")
 
+    # Map each row's root id to the most-recently-updated descendant the
+    # current user can access. Drives the "click → newest node" jump on
+    # Log cards. One recursive CTE per page (no N+1).
+    root_ids = [n.id for n in pagination.items]
+    newest_map = {}
+    if root_ids:
+        anchor = db.session.query(
+            Node.id.label("id"),
+            Node.updated_at.label("updated_at"),
+            Node.id.label("root_id"),
+        ).filter(Node.id.in_(root_ids)).cte(name="subtree", recursive=True)
+
+        child = db.aliased(Node, flat=True)
+        recursive = db.session.query(
+            child.id,
+            child.updated_at,
+            anchor.c.root_id,
+        ).join(anchor, child.parent_id == anchor.c.id).filter(
+            accessible_nodes_filter(child, current_user.id)
+        )
+        subtree = anchor.union_all(recursive)
+
+        rows = (
+            db.session.query(subtree.c.root_id, subtree.c.id)
+            .order_by(subtree.c.root_id, subtree.c.updated_at.desc())
+            .distinct(subtree.c.root_id)
+            .all()
+        )
+        newest_map = {root_id: nid for root_id, nid in rows}
+
     nodes_list = []
     for node in pagination.items:
         # If this is a system prompt root, skip to the first child
@@ -52,6 +83,7 @@ def get_feed():
 
         nodes_list.append({
             "id": display_node.id,
+            "newest_node_id": newest_map.get(node.id, display_node.id),
             "preview": make_preview(display_node.get_content()),
             "node_type": display_node.node_type,
             "child_count": len(node.children),

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -699,11 +699,13 @@ def get_node(node_id):
     while current:
         # Only include ancestor if user has access
         if can_user_access_node(current, current_user.id):
+            ancestor_content = current.get_content()
             ancestor_data = {
                 "id": current.id,
                 "username": current.user.username if current.user else "Unknown",
                 "llm_model": current.llm_model,
-                "preview": make_preview(current.get_content()),
+                "content": ancestor_content,
+                "preview": make_preview(ancestor_content),
                 "node_type": current.node_type,
                 "child_count": len(current.children),
                 "created_at": current.created_at.isoformat(),

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -10,7 +10,6 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
   const promptKey = node.prompt_key || null;
 
   const [expanded, setExpanded] = useState(false);
-  const canExpand = !!node.content;
 
   // Use full content if available; otherwise use preview.
   const text = node.content || node.preview || "";
@@ -22,6 +21,15 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
   const firstNewline = displayText.indexOf('\n');
   const title = firstNewline > 0 ? displayText.substring(0, firstNewline) : displayText;
   const body = firstNewline > 0 ? displayText.substring(firstNewline + 1).trim() : '';
+
+  // Only offer expand when there's full content AND the collapsed preview
+  // actually hides something: title past 120 chars, body past 250 chars,
+  // or body with >2 newline-separated lines (which would be line-clamped).
+  const canExpand = !!node.content && (
+    title.length > 120 ||
+    body.length > 250 ||
+    body.split('\n').length > 2
+  );
 
   // Compute children count – use node.child_count if available, else fallback to node.children.length.
   const childrenCount = typeof node.child_count !== "undefined"

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import NodeFooter from './NodeFooter';
+import MarkdownBody from './MarkdownBody';
 
 const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => {
   // Detect voice notes via backend-provided has_original_audio flag
   const isVoiceNote = !!node.has_original_audio;
   const isPinned = !!node.pinned_at;
   const promptKey = node.prompt_key || null;
+
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = !!node.content;
 
   // Use full content if available; otherwise use preview.
   const text = node.content || node.preview || "";
@@ -61,29 +66,44 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
         e.currentTarget.style.transform = 'translateY(0)';
       }}
     >
-      <div style={{
-        fontFamily: "var(--sans)",
-        fontSize: "1rem",
-        color: "var(--text-primary)",
-        marginBottom: body ? "0.6rem" : "0",
-        fontWeight: 400,
-      }}>
-        {title.length > 120 ? title.substring(0, 120) + "..." : title}
-      </div>
-      {body && (
+      {expanded ? (
         <div style={{
           fontFamily: "var(--sans)",
-          fontSize: "0.92rem",
+          fontSize: "0.95rem",
           fontWeight: 300,
           color: "var(--text-secondary)",
           lineHeight: 1.7,
-          overflow: "hidden",
-          display: "-webkit-box",
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: "vertical",
+          marginBottom: "0.6rem",
         }}>
-          {body.length > 250 ? body.substring(0, 250) + "..." : body}
+          <MarkdownBody>{node.content}</MarkdownBody>
         </div>
+      ) : (
+        <>
+          <div style={{
+            fontFamily: "var(--sans)",
+            fontSize: "1rem",
+            color: "var(--text-primary)",
+            marginBottom: body ? "0.6rem" : "0",
+            fontWeight: 400,
+          }}>
+            {title.length > 120 ? title.substring(0, 120) + "..." : title}
+          </div>
+          {body && (
+            <div style={{
+              fontFamily: "var(--sans)",
+              fontSize: "0.92rem",
+              fontWeight: 300,
+              color: "var(--text-secondary)",
+              lineHeight: 1.7,
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+            }}>
+              {body.length > 250 ? body.substring(0, 250) + "..." : body}
+            </div>
+          )}
+        </>
       )}
       {/* Footer row with optional tags + node footer */}
       <div onClick={(e) => e.stopPropagation()} style={{
@@ -125,6 +145,30 @@ const Bubble = ({ node, onClick, isHighlighted = false, leftAlign = false }) => 
               Voice Note
             </span>
           ) : null}
+          {canExpand && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded((prev) => !prev);
+              }}
+              aria-label={expanded ? "Collapse preview" : "Expand preview"}
+              style={{
+                marginLeft: "8px",
+                padding: "4px 8px",
+                background: "none",
+                border: "none",
+                color: "var(--text-muted)",
+                cursor: "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+                fontSize: "0.85rem",
+                lineHeight: 1,
+              }}
+            >
+              {expanded ? <FaChevronUp /> : <FaChevronDown />}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -58,10 +58,12 @@ function Feed() {
   }, [hasMore, loading, loadingMore, page, fetchPage]);
 
   const handleBubbleClick = (nodeId, e) => {
+    const card = feedNodes.find(n => n.id === nodeId);
+    const targetId = (card && card.newest_node_id) || nodeId;
     if (e && (e.metaKey || e.ctrlKey)) {
-      window.open(`/node/${nodeId}`, '_blank');
+      window.open(`/node/${targetId}`, '_blank');
     } else {
-      navigate(`/node/${nodeId}`);
+      navigate(`/node/${targetId}`);
     }
   };
 

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -66,47 +66,53 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
     li: ({ node, children: liChildren, ...props }) => {
       const isTask = props.className === 'task-list-item';
 
-      if (isTask && onCheckboxToggle) {
-        const itemText = extractText(liChildren).trim();
+      if (isTask) {
+        const itemText = onCheckboxToggle ? extractText(liChildren).trim() : null;
         const { children: filteredChildren } = replaceCheckboxes(
           liChildren,
-          (isChecked) => (
-            <span
-              onClick={(e) => {
+          (isChecked) => {
+            const interactive = !!onCheckboxToggle;
+            const handlers = interactive ? {
+              onClick: (e) => {
                 e.preventDefault();
                 onCheckboxToggle(itemText, isChecked);
-              }}
-              role="checkbox"
-              aria-checked={isChecked}
-              tabIndex={0}
-              onKeyDown={(e) => {
+              },
+              role: 'checkbox',
+              'aria-checked': isChecked,
+              tabIndex: 0,
+              onKeyDown: (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   onCheckboxToggle(itemText, isChecked);
                 }
-              }}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: '18px',
-                height: '18px',
-                borderRadius: '50%',
-                border: `1.5px solid ${isChecked ? 'var(--accent-dim)' : 'var(--border-hover)'}`,
-                background: isChecked ? 'var(--accent-dim)' : 'none',
-                flexShrink: 0,
-                marginRight: '8px',
-                fontSize: '0.6rem',
-                color: 'var(--bg-deep)',
-                fontWeight: 600,
-                transition: 'all 0.3s',
-                cursor: 'pointer',
-                verticalAlign: 'middle',
-              }}
-            >
-              {isChecked && '✓'}
-            </span>
-          ),
+              },
+            } : {};
+            return (
+              <span
+                {...handlers}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '18px',
+                  height: '18px',
+                  borderRadius: '50%',
+                  border: `1.5px solid ${isChecked ? 'var(--accent-dim)' : 'var(--border-hover)'}`,
+                  background: isChecked ? 'var(--accent-dim)' : 'none',
+                  flexShrink: 0,
+                  marginRight: '8px',
+                  fontSize: '0.6rem',
+                  color: 'var(--bg-deep)',
+                  fontWeight: 600,
+                  transition: 'all 0.3s',
+                  cursor: interactive ? 'pointer' : 'default',
+                  verticalAlign: 'middle',
+                }}
+              >
+                {isChecked && '✓'}
+              </span>
+            );
+          },
         );
 
         return (
@@ -131,8 +137,6 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
             whiteSpace: 'normal',
             overflowWrap: 'break-word',
             marginBottom: '2px',
-            listStyleType: isTask ? 'none' : undefined,
-            marginLeft: isTask ? '-24px' : undefined,
           }}
           {...props}
         >

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -105,7 +105,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
                   color: 'var(--bg-deep)',
                   fontWeight: 600,
                   transition: 'all 0.3s',
-                  cursor: interactive ? 'pointer' : 'default',
+                  cursor: interactive ? 'pointer' : 'inherit',
                   verticalAlign: 'middle',
                 }}
               >

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -154,7 +154,13 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
         </pre>
       ),
     a: ({ node, children, ...props }) => (
-      <a style={{ color: 'var(--accent)', textDecoration: 'underline' }} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
+      <a
+        style={{ color: 'var(--accent)', textDecoration: 'underline' }}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        {...props}
+      >{children}</a>
     ),
     table: ({ node, ...props }) => (
       <div style={{ overflowX: 'auto', margin: '8px 0' }}>

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -312,6 +312,7 @@ function NodeDetail() {
   const tryAutoGenerateFor = async (parentNodeId, chainNodes) => {
     if (!autoGenerateActive) return null;
     if (!contextAllowsAi(chainNodes)) {
+      setAutoGenerate(false);
       addToast(
         'Turning off auto-generate. AI usage on some nodes is turned off.',
         8000,

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -302,6 +302,25 @@ function NodeDetail() {
       });
   };
 
+  // Gate + fire a child LLM generation under `parentNodeId`. Returns the
+  // new pending LLM node id, or null if auto-generate is off or the
+  // ancestry blocks AI. Re-checks context at submit time (not just on
+  // mount): if ANY node in `chainNodes` has `ai_usage` outside {chat,
+  // train}, auto-generate silently skips and toasts the user. Prevents
+  // firing an LLM call that would omit parts of the thread from context
+  // and produce partial / confusing replies.
+  const tryAutoGenerateFor = async (parentNodeId, chainNodes) => {
+    if (!autoGenerateActive) return null;
+    if (!contextAllowsAi(chainNodes)) {
+      addToast(
+        'Turning off auto-generate. AI usage on some nodes is turned off.',
+        8000,
+      );
+      return null;
+    }
+    return await requestLlmFor(parentNodeId);
+  };
+
   // Called by NodeForm after it successfully POSTs /nodes/.
   // `data` is the newly-created child node from the backend.
   const handleInlineSuccess = async (data) => {
@@ -309,30 +328,46 @@ function NodeDetail() {
     if (!newNodeId) return;
     setError("");
     try {
-      // Re-check context at submit time (not just on mount): if ANY node
-      // in the current thread ancestry has `ai_usage` outside
-      // {chat, train}, auto-generate silently skips and toasts the user.
-      // Prevents firing an LLM call that would omit parts of the thread
-      // from context and produce partial / confusing replies.
       const chain = [node, ...(node.ancestors || [])];
-      const aiAllowed = contextAllowsAi(chain);
-      if (autoGenerateActive && aiAllowed) {
-        const llmNodeId = await requestLlmFor(newNodeId);
+      const llmNodeId = await tryAutoGenerateFor(newNodeId, chain);
+      if (llmNodeId) {
         // Navigate directly to the pending LLM node so the inline input
         // stays anchored below it throughout generation.
         navigate(`/node/${llmNodeId}?awaitLlm=${llmNodeId}`);
       } else {
-        if (autoGenerateActive && !aiAllowed) {
-          addToast(
-            'Turning off auto-generate. AI usage on some nodes is turned off.',
-            8000,
-          );
-        }
         navigate(`/node/${newNodeId}`);
       }
     } catch (err) {
       console.error(err);
       setError(err.response?.data?.error || err.message || "Error sending message.");
+    }
+  };
+
+  // Called after NodeForm successfully PUTs /nodes/<id>. Updates local
+  // state, closes the overlay, and — if the edited node is user-authored
+  // — fires a fresh LLM child off it. Re-running on a node that already
+  // has an LLM child produces a new sibling, i.e. a new branch off the
+  // edit. Editing an LLM node never triggers generation: nothing for it
+  // to reply to.
+  const handleEditSuccess = async (data) => {
+    const updated = data.node ? data.node : { ...node, content: data.content };
+    setNode(updated);
+    setShowEditOverlay(false);
+    const editedIsLlm = updated.node_type === "llm" || !!updated.llm_model;
+    if (editedIsLlm) return;
+    try {
+      const chain = [updated, ...(updated.ancestors || [])];
+      const llmNodeId = await tryAutoGenerateFor(updated.id, chain);
+      if (llmNodeId) navigate(`/node/${llmNodeId}?awaitLlm=${llmNodeId}`);
+    } catch (err) {
+      console.error(err);
+      const status = err?.response?.status;
+      const apiErr = err?.response?.data?.error;
+      if (status === 400 && apiErr) {
+        addToast(apiErr, 8000);
+        return;
+      }
+      setError(apiErr || err.message || "Error requesting LLM response.");
     }
   };
 
@@ -892,10 +927,7 @@ function NodeDetail() {
             initialPrivacyLevel: node.privacy_level,
             initialAiUsage: node.ai_usage,
             detachPrompt: !!node.context_artifacts?.prompt,
-            onSuccess: (data) => {
-              setNode(data.node ? data.node : { ...node, content: data.content });
-              setShowEditOverlay(false);
-            },
+            onSuccess: handleEditSuccess,
           }}
         />
       )}

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -721,12 +721,12 @@ const NodeForm = forwardRef(
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '8px' }}>
             <button
               type="submit"
-              disabled={loading || !isOnline}
+              disabled={loading || !isOnline || isStreamingRecording}
               style={{
                 borderColor: 'var(--accent)',
                 color: 'var(--accent)',
-                opacity: !isOnline ? 0.35 : 1,
-                cursor: loading || !isOnline ? 'not-allowed' : 'pointer',
+                opacity: !isOnline || isStreamingRecording ? 0.35 : 1,
+                cursor: loading || !isOnline || isStreamingRecording ? 'not-allowed' : 'pointer',
               }}
             >
               {isUploading

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -801,7 +801,7 @@ const NodeForm = forwardRef(
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
                       disabled={isStreamingRecording || aiUsage === 'none' || !isOnline}
-                      style={{ padding: '8px 16px', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'pointer', opacity: aiUsage === 'none' || !isOnline ? 0.35 : 1 }}
+                      style={{ padding: '8px 16px', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'pointer', opacity: isStreamingRecording || aiUsage === 'none' || !isOnline ? 0.35 : 1 }}
                     >
                       Upload
                     </button>

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -1,6 +1,23 @@
 import { useRef, useCallback } from 'react';
 import { useToast } from '../contexts/ToastContext';
 
+// Strip common inline markdown so a raw source line can be compared
+// against react-markdown's plain-text extraction. Without this, a line
+// like `- [ ] **bold** rest` is captured with the asterisks intact and
+// never matches the React-extracted itemText (`bold rest`), so the
+// toggle silently no-ops.
+function stripInlineMarkdown(text) {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')   // ![alt](url) → alt
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')    // [text](url) → text
+    .replace(/\*\*([^*]+?)\*\*/g, '$1')         // **bold**
+    .replace(/__([^_]+?)__/g, '$1')             // __bold__
+    .replace(/~~([^~]+?)~~/g, '$1')             // ~~strike~~
+    .replace(/`([^`]+?)`/g, '$1')               // `code`
+    .replace(/(?<![*\w])\*([^*\n]+?)\*(?!\w)/g, '$1')   // *italic*
+    .replace(/(?<![_\w])_([^_\n]+?)_(?!\w)/g, '$1');    // _italic_
+}
+
 /**
  * Toggle a checkbox in raw markdown content.
  * Finds the line matching `- [ ] itemText` or `- [x] itemText` and flips it.
@@ -9,7 +26,7 @@ export function toggleCheckbox(content, itemText, currentChecked) {
   const lines = content.split('\n');
   const newLines = lines.map(line => {
     const itemMatch = line.match(/^(\s*)- \[([ xX])\]\s+(.+)/);
-    if (itemMatch && itemMatch[3].trim() === itemText) {
+    if (itemMatch && stripInlineMarkdown(itemMatch[3]).trim() === itemText) {
       const indent = itemMatch[1];
       return currentChecked
         ? `${indent}- [ ] ${itemMatch[3]}`


### PR DESCRIPTION
## Summary

Batch of fixes and small UX improvements from a round of dogfooding.

- **Log cards link to newest node** — preview still shows the first user-authored node, but click jumps to the most-recently-updated accessible descendant in the thread.
- **Send no longer drops in-progress voice recordings** — Send is disabled while a streaming recording is active, so the textarea can't silently submit before final chunks have uploaded and transcribed.
- **Checkbox toggle works on items with inline markdown** — `toggleCheckbox` was comparing raw markdown source against react-markdown's plain-text extraction, so any list item with `**bold**` / `*italic*` / `` `code` `` / links was a silent no-op. Now strips inline markers before comparing.
- **Expand-arrow on thread bubbles** — chevron in the footer of NodeDetail's ancestor and child bubbles toggles between the 200-char preview and the full markdown content rendered inline. `/nodes/<id>` now also returns full content for ancestors so the expand UX is uniform. MarkdownBody link renderer stops propagation so link clicks inside an expanded bubble don't also navigate the bubble.
- **Auto-generate LLM on user-node edit** — when auto-generate is on, editing a user-text node fires a fresh LLM child off the edited node (same flow as creating a new node). If the node already has an LLM child, the new one becomes a sibling, effectively starting a new branch. Editing an LLM node is unchanged. Shared gating extracted into `tryAutoGenerateFor`.

## Test plan

### Log cards (newest-node link)
- [x] On `/log`, click a card on a thread with multiple replies → URL ends in the newest node id, the page shows the latest reply.
- [x] Edit an older node in a thread (so its `updated_at` is now most recent), reload `/log`, click that card → routes to the just-edited node.
- [x] Click a card on a thread with no replies → still navigates correctly (newest = the only node).
- [x] Click a card on a system-prompt-rooted thread → preview is still the first child, click goes to the newest descendant.
- [x] Cmd/Ctrl+click → newest node opens in a new tab.

### Voice recording / Send
- [x] Start a streaming voice recording, then click Send while the recording is still active → Send is disabled (no submit, recording continues).
- [ ] Stop the recording → Send becomes enabled and submits the full transcript including the final chunks.
- [x] Type a regular text node (no recording) → Send works as before.

### Checkbox toggle on inline-formatted items
- [x] Render a list item like `- [ ] Read **the docs**` and click the checkbox → toggles to `[x]`.
- [x] Try variants: `*italic*`, `` `code` ``, `[link](https://example.com)` inside the item → all toggle.
- [x] Plain `- [ ] No formatting` items still toggle (regression check).

### Expand-arrow on thread bubbles
- [x] In NodeDetail, click the chevron on an ancestor bubble → expands to full markdown in place; click again → collapses back to preview.
- [x] Same for child bubbles in the thread tree.
- [x] Click a link inside an expanded bubble → opens the link without navigating the bubble itself.
- [x] Bubble preview/footer styling unchanged when collapsed.

### Auto-generate LLM on user-node edit
- [x] With auto-generate ON: edit a user-text node that has no LLM child → a new LLM child is generated.
- [x] With auto-generate ON: edit a user-text node that already has an LLM child → a new LLM child is created as a sibling (new branch), the original LLM child is untouched.
- [x] With auto-generate ON: edit an LLM node → no new generation triggered.
- [x] With auto-generate OFF: edit a user-text node → no generation, no change in behavior.
- [x] In a context where AI is disallowed (e.g. `ai_usage=none`): edit a user-text node with auto-generate ON → disallowed-context toast appears, no generation.
