### PR TITLE
Kebab unification + soft-delete polish (recovery from missed squash)

### DIFF
--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -415,7 +415,7 @@ def _context_artifact_fields(n):
     return artifacts if artifacts else None
 
 
-def serialize_node_recursive(n, user_id=None):
+def serialize_node_recursive(n, user_id=None, parent_user_id=None):
     """Recursively serialize a node and its accessible children.
 
     Soft-deleted nodes the viewer had pre-deletion access to render as
@@ -426,6 +426,10 @@ def serialize_node_recursive(n, user_id=None):
     Args:
         n: Node to serialize
         user_id: User ID to check access for (defaults to current_user.id)
+        parent_user_id: user_id of `n`'s parent — threaded down so the
+            frontend can compute "is this LLM node mine?" without an
+            N+1 lazy-load via `n.parent.user_id`. The caller at the
+            focal-node entry point passes the focal's effective owner.
 
     Returns:
         dict: Serialized node — full content / tombstone / inaccessible —
@@ -456,8 +460,17 @@ def serialize_node_recursive(n, user_id=None):
     sorted_children = sorted(
         visible_children, key=lambda c: c._descendant_count, reverse=True,
     )
+    # Mirror the focal serializer's parent_user_id derivation (nodes.py
+    # ~line 822) so the frontend's ownedByMe check works the same way
+    # at every depth.
+    n_as_parent_user_id = (
+        n.human_owner_id if n.node_type == "llm" else n.user_id
+    )
     children_data = [
-        serialize_node_recursive(child, user_id) for child in sorted_children
+        serialize_node_recursive(
+            child, user_id, parent_user_id=n_as_parent_user_id,
+        )
+        for child in sorted_children
     ]
 
     if status is not None:
@@ -479,6 +492,8 @@ def serialize_node_recursive(n, user_id=None):
         "username": n.user.username if n.user else "Unknown",
         "llm_model": n.llm_model,
         "descendant_count": n._descendant_count,
+        "user_id": n.user_id,
+        "parent_user_id": parent_user_id,
         "children": children_data,
     }
     data.update(_system_prompt_fields(n))
@@ -759,6 +774,14 @@ def get_node(node_id):
         status = serialize_node_status(current, current_user.id)
         if status is None:  # alive + accessible
             ancestor_content = current.get_content()
+            # Mirror the focal serializer's parent_user_id derivation
+            # (nodes.py:822) so the frontend's ownedByMe check works on
+            # ancestors. The walk already has current.parent in hand, no
+            # extra query.
+            ancestor_parent_user_id = (
+                current.human_owner_id if current.node_type == "llm"
+                else (current.parent.user_id if current.parent else None)
+            )
             ancestor_data = {
                 "id": current.id,
                 "username": current.user.username if current.user else "Unknown",
@@ -768,6 +791,8 @@ def get_node(node_id):
                 "node_type": current.node_type,
                 "child_count": len(current.children),
                 "created_at": current.created_at.isoformat(),
+                "user_id": current.user_id,
+                "parent_user_id": ancestor_parent_user_id,
                 # Needed by the frontend auto-generate guard, which
                 # checks ai_usage across [node, ...ancestors] before
                 # firing an LLM reply. Without it ancestors look like
@@ -804,6 +829,12 @@ def get_node(node_id):
     sorted_children = sorted(visible_children, key=lambda child: child._descendant_count, reverse=True)
     accessible_children = visible_children  # for the child_count field below
 
+    # Compute the focal node's effective owner so first-level children
+    # carry the right parent_user_id without an N+1.
+    focal_as_parent_user_id = (
+        node.human_owner_id if node.node_type == "llm" else node.user_id
+    )
+
     # Serialize the current node (its children are now sorted descending by descendant count).
     node_data = {
         "id": node.id,
@@ -811,7 +842,12 @@ def get_node(node_id):
         "node_type": node.node_type,
         "child_count": len(accessible_children),
         "ancestors": ancestors,
-        "children": [serialize_node_recursive(child, current_user.id) for child in sorted_children],
+        "children": [
+            serialize_node_recursive(
+                child, current_user.id, parent_user_id=focal_as_parent_user_id,
+            )
+            for child in sorted_children
+        ],
         "created_at": node.created_at.isoformat(),
         "updated_at": node.updated_at.isoformat(),
         "user": {

--- a/backend/tests/test_node_detail_ownership.py
+++ b/backend/tests/test_node_detail_ownership.py
@@ -1,0 +1,235 @@
+"""Tests for the user_id / parent_user_id fields on ancestors and children.
+
+NodeDetail's per-bubble kebab needs to know which nodes the current user
+owns (Edit/Delete are gated by ownership). The focal node already exposes
+`user.id` and `parent_user_id`; these tests pin down that the same info is
+present on every ancestor and every recursively-serialized child, with the
+LLM-node derivation matching the focal serializer at nodes.py:822.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+import flask_login as _real_flask_login  # noqa: E402
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, Node  # noqa: E402
+import backend.models as _real_backend_models  # noqa: E402
+
+
+def _make_app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.nodes import nodes_bp
+    app.register_blueprint(nodes_bp, url_prefix="/nodes")
+    return app
+
+
+@pytest.fixture
+def app():
+    _affected = lambda k: (  # noqa: E731
+        k == "flask_login"
+        or k.startswith("backend.routes")
+        or k == "backend.models"
+    )
+    saved = {k: sys.modules[k] for k in list(sys.modules) if _affected(k)}
+
+    sys.modules["flask_login"] = _real_flask_login
+    sys.modules["backend.models"] = _real_backend_models
+    for _k in [k for k in list(sys.modules) if k.startswith("backend.routes")]:
+        del sys.modules[_k]
+
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+    for k in [k for k in list(sys.modules) if _affected(k)]:
+        if k not in saved:
+            del sys.modules[k]
+    for k, mod in saved.items():
+        sys.modules[k] = mod
+
+
+@pytest.fixture
+def alice(app):
+    u = User(username="alice", twitter_id="alice-twitter-id")
+    _db.session.add(u)
+    _db.session.commit()
+    return u
+
+
+@pytest.fixture
+def bob(app):
+    u = User(username="bob", twitter_id="bob-twitter-id")
+    _db.session.add(u)
+    _db.session.commit()
+    return u
+
+
+@pytest.fixture
+def llm_user(app):
+    u = User(username="claude-opus-4.6", twitter_id="claude-opus-4-6")
+    _db.session.add(u)
+    _db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as session:
+        session["_user_id"] = str(user.id)
+        session["_fresh"] = True
+
+
+def _make_node(user, parent=None, content="hi", node_type="user",
+               human_owner_id=None, privacy_level="public"):
+    n = Node(
+        user_id=user.id,
+        human_owner_id=human_owner_id if human_owner_id is not None else user.id,
+        parent_id=parent.id if parent else None,
+        node_type=node_type,
+        privacy_level=privacy_level,
+        ai_usage="chat",
+        token_count=1,
+    )
+    n.set_content(content)
+    _db.session.add(n)
+    _db.session.commit()
+    return n
+
+
+def test_ancestors_carry_user_id_and_derived_parent_user_id(app, alice, bob):
+    """Walking up: each ancestor's user_id is its author, parent_user_id is
+    one level above (or None at the root). This is what the frontend uses
+    to gate Edit/Delete on ancestor bubbles."""
+    a_root = _make_node(alice)              # parent_user_id = None
+    b_mid = _make_node(bob, parent=a_root)  # parent_user_id = alice.id
+    a_focal = _make_node(alice, parent=b_mid)
+
+    client = app.test_client()
+    _login(client, alice)
+    resp = client.get(f"/nodes/{a_focal.id}")
+    assert resp.status_code == 200
+    ancestors = resp.json["ancestors"]
+    # ancestors are ordered root-first
+    by_id = {a["id"]: a for a in ancestors}
+    assert by_id[a_root.id]["user_id"] == alice.id
+    assert by_id[a_root.id]["parent_user_id"] is None
+    assert by_id[b_mid.id]["user_id"] == bob.id
+    assert by_id[b_mid.id]["parent_user_id"] == alice.id
+
+
+def test_llm_ancestor_parent_user_id_uses_human_owner(app, alice, llm_user):
+    """LLM ancestors derive parent_user_id from human_owner_id, not from
+    parent.user_id, so the focal serializer's rule (nodes.py:822) is
+    mirrored on the way up the chain."""
+    a_root = _make_node(alice)
+    llm_mid = _make_node(
+        llm_user, parent=a_root, node_type="llm", human_owner_id=alice.id,
+    )
+    a_focal = _make_node(alice, parent=llm_mid, human_owner_id=alice.id)
+
+    client = app.test_client()
+    _login(client, alice)
+    resp = client.get(f"/nodes/{a_focal.id}")
+    assert resp.status_code == 200
+    by_id = {a["id"]: a for a in resp.json["ancestors"]}
+    assert by_id[llm_mid.id]["user_id"] == llm_user.id
+    # The LLM's "owner" for edit/delete purposes is alice — that's what
+    # parent_user_id encodes for LLM nodes.
+    assert by_id[llm_mid.id]["parent_user_id"] == alice.id
+
+
+def test_children_carry_user_id_and_parent_user_id(app, alice, bob):
+    """Direct children expose user_id and the focal node's user_id as
+    their parent_user_id."""
+    focal = _make_node(alice)
+    c_alice = _make_node(alice, parent=focal)
+    c_bob = _make_node(bob, parent=focal)
+
+    client = app.test_client()
+    _login(client, alice)
+    resp = client.get(f"/nodes/{focal.id}")
+    assert resp.status_code == 200
+    children = {c["id"]: c for c in resp.json["children"]}
+    assert children[c_alice.id]["user_id"] == alice.id
+    assert children[c_alice.id]["parent_user_id"] == alice.id
+    assert children[c_bob.id]["user_id"] == bob.id
+    assert children[c_bob.id]["parent_user_id"] == alice.id
+
+
+def test_grandchild_parent_user_id_threads_through_recursion(app, alice, bob):
+    """parent_user_id propagates correctly through serialize_node_recursive
+    so a grandchild knows its (intermediate) parent's owner without an N+1."""
+    focal = _make_node(alice)
+    mid_bob = _make_node(bob, parent=focal)
+    grand_alice = _make_node(alice, parent=mid_bob)
+
+    client = app.test_client()
+    _login(client, alice)
+    resp = client.get(f"/nodes/{focal.id}")
+    assert resp.status_code == 200
+    # children[0] = mid_bob; children[0].children[0] = grand_alice.
+    mid_payload = next(c for c in resp.json["children"] if c["id"] == mid_bob.id)
+    grand_payload = next(
+        g for g in mid_payload["children"] if g["id"] == grand_alice.id
+    )
+    assert grand_payload["user_id"] == alice.id
+    assert grand_payload["parent_user_id"] == bob.id
+
+
+def test_llm_child_parent_user_id_uses_human_owner(app, alice, llm_user):
+    """An LLM child of an alice-owned focal exposes parent_user_id=alice.id
+    (since the focal's user_id is alice). When that LLM has a human child
+    of its own, the grandchild's parent_user_id reflects the LLM's
+    human_owner_id, mirroring the focal's :822 derivation at depth."""
+    focal = _make_node(alice)
+    llm_child = _make_node(
+        llm_user, parent=focal, node_type="llm", human_owner_id=alice.id,
+    )
+    a_grand = _make_node(alice, parent=llm_child)
+
+    client = app.test_client()
+    _login(client, alice)
+    resp = client.get(f"/nodes/{focal.id}")
+    assert resp.status_code == 200
+    llm_payload = next(c for c in resp.json["children"] if c["id"] == llm_child.id)
+    assert llm_payload["user_id"] == llm_user.id
+    assert llm_payload["parent_user_id"] == alice.id  # focal owner
+    grand_payload = next(
+        g for g in llm_payload["children"] if g["id"] == a_grand.id
+    )
+    # The LLM acts as parent → parent_user_id = LLM's human_owner_id.
+    assert grand_payload["parent_user_id"] == alice.id

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -31,6 +31,26 @@ const Bubble = ({
   const [showKebab, setShowKebab] = useState(false);
   const [hovered, setHovered] = useState(false);
   const kebabRef = useRef(null);
+  const hoverHideTimerRef = useRef(null);
+
+  const cancelHoverHide = () => {
+    if (hoverHideTimerRef.current) {
+      clearTimeout(hoverHideTimerRef.current);
+      hoverHideTimerRef.current = null;
+    }
+  };
+
+  // Keep the kebab on screen for a beat after the cursor leaves so a
+  // user can still reach it across the gap between bubble and icon.
+  const scheduleHoverHide = () => {
+    cancelHoverHide();
+    hoverHideTimerRef.current = setTimeout(() => {
+      setHovered(false);
+      hoverHideTimerRef.current = null;
+    }, 3000);
+  };
+
+  useEffect(() => cancelHoverHide, []);
 
   // Outside-click handler for the kebab dropdown.
   useEffect(() => {
@@ -115,6 +135,7 @@ const Bubble = ({
       style={bubbleStyle}
       onClick={handleCardClick}
       onMouseEnter={(e) => {
+        cancelHoverHide();
         setHovered(true);
         if (!isPlaceholder) {
           e.currentTarget.style.borderColor = 'var(--border-hover)';
@@ -123,7 +144,7 @@ const Bubble = ({
         }
       }}
       onMouseLeave={(e) => {
-        setHovered(false);
+        scheduleHoverHide();
         e.currentTarget.style.borderColor = 'var(--border)';
         e.currentTarget.style.boxShadow = 'none';
         e.currentTarget.style.transform = 'translateY(0)';
@@ -135,9 +156,10 @@ const Bubble = ({
           onClick={(e) => e.stopPropagation()}
           style={{
             position: 'absolute',
-            top: '10px',
+            top: '50%',
             left: '100%',
             marginLeft: '8px',
+            transform: 'translateY(-50%)',
             opacity: kebabVisible ? 1 : 0,
             transition: 'opacity 0.15s ease',
             pointerEvents: kebabVisible ? 'auto' : 'none',
@@ -146,8 +168,8 @@ const Bubble = ({
           <button
             type="button"
             onClick={() => setShowKebab((v) => !v)}
-            onFocus={() => setHovered(true)}
-            onBlur={() => setHovered(false)}
+            onFocus={() => { cancelHoverHide(); setHovered(true); }}
+            onBlur={() => scheduleHoverHide()}
             title="More actions"
             aria-label="More actions"
             style={{

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -83,7 +83,11 @@ const Bubble = ({
     borderRadius: "10px",
     cursor: isPlaceholder ? "default" : "pointer",
     maxWidth: "1000px",
-    width: "calc(100% - 20px)",
+    // Right-side reserve covers the always-outside kebab (8px margin +
+    // ~26px icon + small buffer). On wide viewports maxWidth caps below
+    // 100%-60 so this doesn't change anything; on narrow viewports it's
+    // what keeps the kebab on screen down to ~320px portrait.
+    width: "calc(100% - 60px)",
     transition: "border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease",
     position: "relative",
   };

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -85,9 +85,9 @@ const Bubble = ({
     maxWidth: "1000px",
     // Right-side reserve covers the always-outside kebab (8px margin +
     // ~26px icon + small buffer). On wide viewports maxWidth caps below
-    // 100%-60 so this doesn't change anything; on narrow viewports it's
+    // 100%-40 so this doesn't change anything; on narrow viewports it's
     // what keeps the kebab on screen down to ~320px portrait.
-    width: "calc(100% - 60px)",
+    width: "calc(100% - 40px)",
     transition: "border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease",
     position: "relative",
   };

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { FaChevronDown, FaChevronUp, FaEllipsisV } from 'react-icons/fa';
+import { FaChevronDown, FaChevronUp } from 'react-icons/fa';
 import NodeFooter from './NodeFooter';
 import MarkdownBody from './MarkdownBody';
+import BubbleKebabMenu from './BubbleKebabMenu';
 
 const tombstoneStyle = {
   fontFamily: 'var(--sans)',
@@ -16,8 +17,7 @@ const Bubble = ({
   onClick,
   isHighlighted = false,
   leftAlign = false,
-  enableActions = false,
-  onDeleteThread = null,
+  actions = null,
 }) => {
   // Detect voice notes via backend-provided has_original_audio flag
   const isVoiceNote = !!node.has_original_audio;
@@ -28,9 +28,7 @@ const Bubble = ({
   const isPlaceholder = isTombstone || isInaccessible;
 
   const [expanded, setExpanded] = useState(false);
-  const [showKebab, setShowKebab] = useState(false);
   const [hovered, setHovered] = useState(false);
-  const kebabRef = useRef(null);
   const hoverHideTimerRef = useRef(null);
 
   const cancelHoverHide = () => {
@@ -51,18 +49,6 @@ const Bubble = ({
   };
 
   useEffect(() => cancelHoverHide, []);
-
-  // Outside-click handler for the kebab dropdown.
-  useEffect(() => {
-    if (!showKebab) return undefined;
-    const handler = (e) => {
-      if (kebabRef.current && !kebabRef.current.contains(e.target)) {
-        setShowKebab(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showKebab]);
 
   // Use full content if available; otherwise use preview.
   const text = node.content || node.preview || "";
@@ -120,10 +106,8 @@ const Bubble = ({
     window.matchMedia &&
     window.matchMedia('(hover: none)').matches
   );
-  const kebabVisible = (
-    enableActions && !isPlaceholder &&
-    (kebabAlwaysVisible || hovered || showKebab)
-  );
+  const hasActions = !isPlaceholder && Array.isArray(actions) && actions.length > 0;
+  const kebabVisible = hasActions && (kebabAlwaysVisible || hovered);
 
   const handleCardClick = (e) => {
     if (isPlaceholder) return; // Tombstones and inaccessible are non-navigable.
@@ -150,74 +134,13 @@ const Bubble = ({
         e.currentTarget.style.transform = 'translateY(0)';
       }}
     >
-      {enableActions && !isPlaceholder && (
-        <div
-          ref={kebabRef}
-          onClick={(e) => e.stopPropagation()}
-          style={{
-            position: 'absolute',
-            top: '50%',
-            left: '100%',
-            marginLeft: '8px',
-            transform: 'translateY(-50%)',
-            opacity: kebabVisible ? 1 : 0,
-            transition: 'opacity 0.15s ease',
-            pointerEvents: kebabVisible ? 'auto' : 'none',
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => setShowKebab((v) => !v)}
-            onFocus={() => { cancelHoverHide(); setHovered(true); }}
-            onBlur={() => scheduleHoverHide()}
-            title="More actions"
-            aria-label="More actions"
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'var(--text-muted)',
-              padding: '4px 6px',
-              display: 'inline-flex',
-              alignItems: 'center',
-            }}
-          >
-            <FaEllipsisV size={14} />
-          </button>
-          {showKebab && (
-            <div style={{
-              position: 'absolute',
-              top: '50%',
-              left: '100%',
-              marginLeft: '4px',
-              transform: 'translateY(-50%)',
-              background: 'var(--bg-card)',
-              border: '1px solid var(--border)',
-              borderRadius: '6px',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
-              minWidth: '160px',
-              zIndex: 5,
-              overflow: 'hidden',
-            }}>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowKebab(false);
-                  if (onDeleteThread) onDeleteThread(node);
-                }}
-                style={{
-                  display: 'block', width: '100%', textAlign: 'left',
-                  background: 'none', border: 'none', cursor: 'pointer',
-                  padding: '8px 12px',
-                  fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
-                  color: 'var(--accent)',
-                }}
-              >
-                Delete thread
-              </button>
-            </div>
-          )}
-        </div>
+      {hasActions && (
+        <BubbleKebabMenu
+          visible={kebabVisible}
+          items={actions}
+          onFocus={() => { cancelHoverHide(); setHovered(true); }}
+          onBlur={() => scheduleHoverHide()}
+        />
       )}
       {isTombstone ? (
         <div style={tombstoneStyle}>[Node deleted]</div>

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -207,7 +207,7 @@ const Bubble = ({
             llmModel={node.llm_model}
             onReplyClick={
               !isPlaceholder && Array.isArray(actions)
-                ? (actions.find((a) => a.label === 'Reply') || {}).action || null
+                ? (actions.find((a) => a.kind === 'reply') || {}).action || null
                 : null
             }
           />

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -136,7 +136,8 @@ const Bubble = ({
           style={{
             position: 'absolute',
             top: '10px',
-            right: '-12px',
+            left: '100%',
+            marginLeft: '8px',
             opacity: kebabVisible ? 1 : 0,
             transition: 'opacity 0.15s ease',
             pointerEvents: kebabVisible ? 'auto' : 'none',
@@ -150,9 +151,8 @@ const Bubble = ({
             title="More actions"
             aria-label="More actions"
             style={{
-              background: 'var(--bg-card)',
-              border: '1px solid var(--border)',
-              borderRadius: '4px',
+              background: 'none',
+              border: 'none',
               cursor: 'pointer',
               color: 'var(--text-muted)',
               padding: '4px 6px',
@@ -165,9 +165,9 @@ const Bubble = ({
           {showKebab && (
             <div style={{
               position: 'absolute',
-              top: '100%',
-              right: 0,
-              marginTop: '4px',
+              top: 0,
+              left: '100%',
+              marginLeft: '4px',
               background: 'var(--bg-card)',
               border: '1px solid var(--border)',
               borderRadius: '6px',

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -200,6 +200,11 @@ const Bubble = ({
             childrenCount={childrenCount}
             humanOwnerUsername={node.human_owner_username}
             llmModel={node.llm_model}
+            onReplyClick={
+              !isPlaceholder && Array.isArray(actions)
+                ? (actions.find((a) => a.label === 'Reply') || {}).action || null
+                : null
+            }
           />
           {!isPlaceholder && (
             <div style={{ display: "flex", alignItems: "center" }}>

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -84,10 +84,11 @@ const Bubble = ({
     cursor: isPlaceholder ? "default" : "pointer",
     maxWidth: "1000px",
     // Right-side reserve covers the always-outside kebab (8px margin +
-    // ~26px icon + small buffer). On wide viewports maxWidth caps below
-    // 100%-40 so this doesn't change anything; on narrow viewports it's
-    // what keeps the kebab on screen down to ~320px portrait.
-    width: "calc(100% - 40px)",
+    // 26px icon + 8px breathing room past the icon to match the visual
+    // gap to the bubble's left). On wide viewports maxWidth caps below
+    // 100%-30 so this doesn't change anything; on narrow viewports it
+    // keeps the kebab on screen down to ~320px portrait.
+    width: "calc(100% - 30px)",
     transition: "border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease",
     position: "relative",
   };

--- a/frontend/src/components/Bubble.js
+++ b/frontend/src/components/Bubble.js
@@ -187,9 +187,10 @@ const Bubble = ({
           {showKebab && (
             <div style={{
               position: 'absolute',
-              top: 0,
+              top: '50%',
               left: '100%',
               marginLeft: '4px',
+              transform: 'translateY(-50%)',
               background: 'var(--bg-card)',
               border: '1px solid var(--border)',
               borderRadius: '6px',

--- a/frontend/src/components/BubbleKebabMenu.js
+++ b/frontend/src/components/BubbleKebabMenu.js
@@ -1,0 +1,97 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { FaEllipsisV } from 'react-icons/fa';
+
+function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
+  const [showMenu, setShowMenu] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!showMenu) return undefined;
+    const handler = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setShowMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showMenu]);
+
+  if (!items || items.length === 0) return null;
+
+  const effectiveVisible = visible || showMenu;
+
+  return (
+    <div
+      ref={ref}
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '100%',
+        marginLeft: '8px',
+        transform: 'translateY(-50%)',
+        opacity: effectiveVisible ? 1 : 0,
+        transition: 'opacity 0.15s ease',
+        pointerEvents: effectiveVisible ? 'auto' : 'none',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setShowMenu((v) => !v)}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        title="More actions"
+        aria-label="More actions"
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: 'var(--text-muted)',
+          padding: '4px 6px',
+          display: 'inline-flex',
+          alignItems: 'center',
+        }}
+      >
+        <FaEllipsisV size={14} />
+      </button>
+      {showMenu && (
+        <div style={{
+          position: 'absolute',
+          top: '50%',
+          left: '100%',
+          marginLeft: '4px',
+          transform: 'translateY(-50%)',
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
+          minWidth: '160px',
+          zIndex: 5,
+          overflow: 'hidden',
+        }}>
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              onClick={() => {
+                setShowMenu(false);
+                item.action();
+              }}
+              style={{
+                display: 'block', width: '100%', textAlign: 'left',
+                background: 'none', border: 'none', cursor: 'pointer',
+                padding: '8px 12px',
+                fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
+                color: item.color || 'var(--text-primary)',
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default BubbleKebabMenu;

--- a/frontend/src/components/BubbleKebabMenu.js
+++ b/frontend/src/components/BubbleKebabMenu.js
@@ -7,13 +7,20 @@ function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
 
   useEffect(() => {
     if (!showMenu) return undefined;
-    const handler = (e) => {
+    const onMouseDown = (e) => {
       if (ref.current && !ref.current.contains(e.target)) {
         setShowMenu(false);
       }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') setShowMenu(false);
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
   }, [showMenu]);
 
   if (!items || items.length === 0) return null;

--- a/frontend/src/components/BubbleKebabMenu.js
+++ b/frontend/src/components/BubbleKebabMenu.js
@@ -1,9 +1,15 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect } from 'react';
 import { FaEllipsisV } from 'react-icons/fa';
 
 function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
   const [showMenu, setShowMenu] = useState(false);
+  // When the dropdown would clip the viewport's right edge (narrow
+  // screens), flip it to open leftward of the kebab instead. Reset on
+  // each open so a viewport resize while the menu is closed is picked
+  // up next time.
+  const [flipLeft, setFlipLeft] = useState(false);
   const ref = useRef(null);
+  const menuRef = useRef(null);
 
   useEffect(() => {
     if (!showMenu) return undefined;
@@ -21,6 +27,15 @@ function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
       document.removeEventListener('mousedown', onMouseDown);
       document.removeEventListener('keydown', onKeyDown);
     };
+  }, [showMenu]);
+
+  useLayoutEffect(() => {
+    if (!showMenu || !menuRef.current) {
+      setFlipLeft(false);
+      return;
+    }
+    const rect = menuRef.current.getBoundingClientRect();
+    setFlipLeft(rect.right > window.innerWidth - 8);
   }, [showMenu]);
 
   if (!items || items.length === 0) return null;
@@ -62,11 +77,13 @@ function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
         <FaEllipsisV size={14} />
       </button>
       {showMenu && (
-        <div style={{
+        <div ref={menuRef} style={{
           position: 'absolute',
           top: '50%',
-          left: '100%',
-          marginLeft: '4px',
+          left: flipLeft ? 'auto' : '100%',
+          right: flipLeft ? '100%' : 'auto',
+          marginLeft: flipLeft ? 0 : '4px',
+          marginRight: flipLeft ? '4px' : 0,
           transform: 'translateY(-50%)',
           background: 'var(--bg-card)',
           border: '1px solid var(--border)',

--- a/frontend/src/components/DeleteConfirmDialog.js
+++ b/frontend/src/components/DeleteConfirmDialog.js
@@ -1,7 +1,5 @@
 import React, { useEffect } from "react";
 
-const DEFAULT_GRACE_DAYS = 30;
-
 const overlayStyle = {
   position: "fixed",
   top: 0, left: 0, right: 0, bottom: 0,
@@ -78,7 +76,6 @@ function DeleteConfirmDialog({
   open,
   mode = "single",
   hasChildren = false,
-  graceDays = DEFAULT_GRACE_DAYS,
   onClose,
   onConfirm,
 }) {
@@ -101,9 +98,8 @@ function DeleteConfirmDialog({
     title = "Delete entire thread?";
     body = (
       <>
-        All your nodes in this thread will be deleted. Other users' replies
-        are preserved (they own them); your nodes stay as placeholders so
-        their replies remain reachable. Recoverable for {graceDays} days.
+        Your content in this thread will be removed. Your nodes remain as
+        placeholders so other users' replies stay reachable (they own them).
       </>
     );
     buttons = (
@@ -169,9 +165,7 @@ function DeleteConfirmDialog({
     title = "Delete node?";
     body = (
       <>
-        This will be permanently deleted in {graceDays} days. Support can
-        recover it during this window; after {graceDays} days, content and
-        edit history are wiped.
+        Content and edit history will be removed.
       </>
     );
     buttons = (

--- a/frontend/src/components/DeleteConfirmDialog.js
+++ b/frontend/src/components/DeleteConfirmDialog.js
@@ -102,8 +102,8 @@ function DeleteConfirmDialog({
     body = (
       <>
         All your nodes in this thread will be deleted. Other users' replies
-        are preserved (they own them) — they'll become top-level after the
-        {" "}{graceDays}-day grace period.
+        are preserved (they own them); your nodes stay as placeholders so
+        their replies remain reachable. Recoverable for {graceDays} days.
       </>
     );
     buttons = (

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -141,8 +141,11 @@ function Feed() {
               key={node.id}
               node={node}
               onClick={handleBubbleClick}
-              enableActions={true}
-              onDeleteThread={handleDeleteThread}
+              actions={[{
+                label: 'Delete thread',
+                action: () => handleDeleteThread(node),
+                color: 'var(--accent)',
+              }]}
             />
           ))}
         </div>

--- a/frontend/src/components/Feed.js
+++ b/frontend/src/components/Feed.js
@@ -86,9 +86,8 @@ function Feed() {
       .then(response => {
         const data = response.data || {};
         const n = data.scheduled || 1;
-        const days = data.grace_days || 30;
         addToast(
-          `Thread scheduled for deletion (${n} node${n === 1 ? "" : "s"}, ${days} days)`,
+          `Deleted ${n} node${n === 1 ? "" : "s"}`,
           3000,
         );
         setFeedNodes(prev => prev.filter(card => card.id !== deleteTarget.id));

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -991,6 +991,7 @@ function NodeDetail() {
           onClose={() => setReplyTarget(null)}
           nodeFormProps={{
             parentId: replyTarget.id,
+            hidePowerFeatures: !craftMode,
             onSuccess: (data) => {
               setReplyTarget(null);
               navigate(`/node/${data.id}`);

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -267,18 +267,11 @@ function NodeDetail() {
           `Deleted ${n} node${n === 1 ? "" : "s"}`,
           3000,
         );
-        // "This only" leaves the node as a tombstone with alive children.
-        // Drop into a live child so the user sees the tombstone in its
-        // breadcrumb instead of landing on the deleted-node 404.
-        if (!withDescendants && node.children) {
-          const aliveChild = node.children.find((c) => !c.deleted);
-          if (aliveChild) {
-            navigate(`/node/${aliveChild.id}`);
-            return;
-          }
-        }
-        // Otherwise walk up to the closest alive ancestor — the immediate
-        // parent may itself be a tombstone (e.g., chained "this only").
+        // Walk up to the closest alive ancestor. The immediate parent
+        // may itself be a tombstone (e.g., chained "this only"), and the
+        // ancestor's view shows the just-deleted node as a tombstoned
+        // child preview — so the tombstone stays visible without
+        // dropping the user on a 404.
         if (node.ancestors && node.ancestors.length > 0) {
           for (let i = node.ancestors.length - 1; i >= 0; i -= 1) {
             if (!node.ancestors[i].deleted) {

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -20,7 +20,7 @@ import QuotedContent from "./QuotedContent";
 import DeleteConfirmDialog from "./DeleteConfirmDialog";
 
 // Recursive component to render children nodes.
-function RenderChildTree({ nodes, onBubbleClick }) {
+function RenderChildTree({ nodes, onBubbleClick, buildActions }) {
   return (
     <div>
       {nodes.map((child, index) => {
@@ -31,9 +31,14 @@ function RenderChildTree({ nodes, onBubbleClick }) {
         return (
           <div key={child.id}>
             <div style={containerStyle}>
-              <Bubble node={child} onClick={onBubbleClick} leftAlign={true} />
+              <Bubble
+                node={child}
+                onClick={onBubbleClick}
+                leftAlign={true}
+                actions={buildActions ? buildActions(child) : null}
+              />
               {child.children && child.children.length > 0 &&
-                <RenderChildTree nodes={child.children} onBubbleClick={onBubbleClick} />
+                <RenderChildTree nodes={child.children} onBubbleClick={onBubbleClick} buildActions={buildActions} />
               }
             </div>
             {index < nodes.length - 1 && (
@@ -64,7 +69,16 @@ function NodeDetail() {
   const [voiceLoading, setVoiceLoading] = useState(false);
   const [toolActionsExpanded, setToolActionsExpanded] = useState(false);
   const [showPromptEditConfirm, setShowPromptEditConfirm] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  // Per-bubble action targets. The kebab on any rendered Bubble (focal,
+  // ancestor, child) sets exactly one of these via setExclusiveTarget.
+  const [replyTarget, setReplyTarget] = useState(null);
+  const [editTarget, setEditTarget] = useState(null);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const setExclusiveTarget = useCallback((slot, value) => {
+    setReplyTarget(slot === 'reply' ? value : null);
+    setEditTarget(slot === 'edit' ? value : null);
+    setDeleteTarget(slot === 'delete' ? value : null);
+  }, []);
   // autoGenerate is shared across the whole text-mode experience — the
   // NodeDetailWrapper uses `key={id}` which remounts NodeDetail on every
   // node navigation, so local useState would reset the toggle. Persist to
@@ -167,6 +181,19 @@ function NodeDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
+  // editTarget drives Edit's two-path branch: prompt-rooted nodes show
+  // a confirmation first; everything else opens the edit overlay
+  // directly. Both paths route through editTarget.id, so focal and
+  // non-focal edits share one code path.
+  useEffect(() => {
+    if (!editTarget) return;
+    if (editTarget.context_artifacts?.prompt) {
+      setShowPromptEditConfirm(true);
+    } else {
+      setShowEditOverlay(true);
+    }
+  }, [editTarget]);
+
   // Handle LLM completion
   useEffect(() => {
     if (llmStatus === 'completed' && llmData) {
@@ -211,6 +238,35 @@ function NodeDetail() {
     }
   };
 
+  // Mirror the focal isOwner derivation (same as NodeDetail.js:216) for
+  // any ancestor or child node, using the user_id / parent_user_id
+  // fields added in the matching backend change.
+  const ownedByMe = (n) => !!currentUser && (
+    n.user_id === currentUser.id
+    || (n.node_type === "llm" && n.parent_user_id === currentUser.id)
+  );
+
+  const buildActions = (n) => {
+    const actions = [{
+      label: 'Reply',
+      action: () => setExclusiveTarget('reply', n),
+      color: 'var(--text-primary)',
+    }];
+    if (ownedByMe(n)) {
+      actions.push({
+        label: 'Edit',
+        action: () => setExclusiveTarget('edit', n),
+        color: 'var(--text-primary)',
+      });
+      actions.push({
+        label: 'Delete',
+        action: () => setExclusiveTarget('delete', n),
+        color: 'var(--accent)',
+      });
+    }
+    return actions;
+  };
+
   // For user-typed nodes: owner must match current user
   // For LLM nodes: parent node's owner must match current user (they requested the response)
   const isOwner = node.user && currentUser && (
@@ -239,14 +295,13 @@ function NodeDetail() {
     setPinLoading(false);
   };
 
-  // Open the soft-delete confirmation dialog. The dialog branches on
-  // hasChildren to offer "this only" vs. "this + my replies".
-  const handleDelete = () => setShowDeleteDialog(true);
-
   const handleConfirmDelete = ({ withDescendants }) => {
-    setShowDeleteDialog(false);
+    if (!deleteTarget) return;
+    const targetId = deleteTarget.id;
+    const wasFocal = targetId === node.id;
+    setDeleteTarget(null);
     api
-      .delete(`/nodes/${id}`, { params: { delete_descendants: withDescendants } })
+      .delete(`/nodes/${targetId}`, { params: { delete_descendants: withDescendants } })
       .then((response) => {
         const data = response.data || {};
         const n = data.scheduled || 1;
@@ -254,11 +309,16 @@ function NodeDetail() {
           `Deleted ${n} node${n === 1 ? "" : "s"}`,
           3000,
         );
-        // Walk up to the closest alive ancestor. The immediate parent
-        // may itself be a tombstone (e.g., chained "this only"), and the
-        // ancestor's view shows the just-deleted node as a tombstoned
-        // child preview — so the tombstone stays visible without
-        // dropping the user on a 404.
+        if (!wasFocal) {
+          // Non-focal target: refetch the focal node so the just-deleted
+          // ancestor/child surfaces as a tombstone preview in place.
+          return api.get(`/nodes/${id}`).then((r) => setNode(r.data));
+        }
+        // Focal target: walk up to the closest alive ancestor. The
+        // immediate parent may itself be a tombstone (e.g., chained
+        // "this only"), and the ancestor's view shows the just-deleted
+        // node as a tombstoned child preview — so the tombstone stays
+        // visible without dropping the user on a 404.
         if (node.ancestors && node.ancestors.length > 0) {
           for (let i = node.ancestors.length - 1; i >= 0; i -= 1) {
             if (!node.ancestors[i].deleted) {
@@ -268,6 +328,7 @@ function NodeDetail() {
           }
         }
         navigate("/log");
+        return undefined;
       })
       .catch((err) => {
         console.error(err);
@@ -355,9 +416,25 @@ function NodeDetail() {
   // edit. Editing an LLM node never triggers generation: nothing for it
   // to reply to.
   const handleEditSuccess = async (data) => {
+    const wasFocal = editTarget?.id === node.id;
+    setShowEditOverlay(false);
+    setEditTarget(null);
+
+    if (!wasFocal) {
+      // Non-focal edit: refetch the focal node so the edited
+      // ancestor/child reflects new content. No auto-LLM trigger —
+      // the user is in a different conversation context.
+      try {
+        const refreshed = await api.get(`/nodes/${id}`).then((r) => r.data);
+        setNode(refreshed);
+      } catch (err) {
+        console.error(err);
+      }
+      return;
+    }
+
     const updated = data.node ? data.node : { ...node, content: data.content };
     setNode(updated);
-    setShowEditOverlay(false);
     const editedIsLlm = updated.node_type === "llm" || !!updated.llm_model;
     if (editedIsLlm) return;
     try {
@@ -403,7 +480,13 @@ function NodeDetail() {
   const ancestorsSection = node.ancestors && node.ancestors.length > 0 && (
     <div style={{ display: "flex", flexDirection: "column", marginBottom: "10px" }}>
       {node.ancestors.map((ancestor) => (
-        <Bubble key={ancestor.id} node={ancestor} onClick={handleBubbleClick} leftAlign={true} />
+        <Bubble
+          key={ancestor.id}
+          node={ancestor}
+          onClick={handleBubbleClick}
+          leftAlign={true}
+          actions={buildActions(ancestor)}
+        />
       ))}
     </div>
   );
@@ -559,18 +642,12 @@ function NodeDetail() {
             items={[
               {
                 label: 'Edit',
-                action: () => {
-                  if (node.context_artifacts?.prompt) {
-                    setShowPromptEditConfirm(true);
-                  } else {
-                    setShowEditOverlay(true);
-                  }
-                },
+                action: () => setExclusiveTarget('edit', node),
                 color: 'var(--text-primary)',
               },
               {
                 label: 'Delete',
-                action: () => handleDelete(),
+                action: () => setExclusiveTarget('delete', node),
                 color: 'var(--accent)',
               },
             ]}
@@ -790,7 +867,11 @@ function NodeDetail() {
   const childrenSection = (
     <div>
       {node.children && node.children.length > 0 && (
-        <RenderChildTree nodes={node.children} onBubbleClick={handleBubbleClick} />
+        <RenderChildTree
+          nodes={node.children}
+          onBubbleClick={handleBubbleClick}
+          buildActions={buildActions}
+        />
       )}
     </div>
   );
@@ -819,7 +900,7 @@ function NodeDetail() {
 
       {showPromptEditConfirm && (
         <div
-          onClick={() => setShowPromptEditConfirm(false)}
+          onClick={() => { setShowPromptEditConfirm(false); setEditTarget(null); }}
           style={{
             position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
             backgroundColor: 'rgba(0,0,0,0.7)',
@@ -857,7 +938,7 @@ function NodeDetail() {
             </p>
             <div style={{ display: 'flex', gap: '12px', justifyContent: 'center' }}>
               <button
-                onClick={() => setShowPromptEditConfirm(false)}
+                onClick={() => { setShowPromptEditConfirm(false); setEditTarget(null); }}
                 style={{
                   padding: '8px 20px', background: 'none',
                   border: '1px solid var(--border)', borderRadius: '6px',
@@ -882,28 +963,41 @@ function NodeDetail() {
         </div>
       )}
 
-      {showEditOverlay && (
+      {showEditOverlay && editTarget && (
         <NodeFormModal
           title="Edit Text"
-          onClose={() => setShowEditOverlay(false)}
+          onClose={() => { setShowEditOverlay(false); setEditTarget(null); }}
           nodeFormProps={{
             editMode: true,
-            nodeId: node.id,
-            initialContent: node.content,
-            initialPrivacyLevel: node.privacy_level,
-            initialAiUsage: node.ai_usage,
-            detachPrompt: !!node.context_artifacts?.prompt,
+            nodeId: editTarget.id,
+            initialContent: editTarget.content,
+            initialPrivacyLevel: editTarget.privacy_level,
+            initialAiUsage: editTarget.ai_usage,
+            detachPrompt: !!editTarget.context_artifacts?.prompt,
             onSuccess: handleEditSuccess,
           }}
         />
       )}
       <DeleteConfirmDialog
-        open={showDeleteDialog}
+        open={!!deleteTarget}
         mode="single"
-        hasChildren={!!(node && node.children && node.children.length > 0)}
-        onClose={() => setShowDeleteDialog(false)}
+        hasChildren={!!(deleteTarget && deleteTarget.children && deleteTarget.children.length > 0)}
+        onClose={() => setDeleteTarget(null)}
         onConfirm={handleConfirmDelete}
       />
+      {replyTarget && (
+        <NodeFormModal
+          title="Reply"
+          onClose={() => setReplyTarget(null)}
+          nodeFormProps={{
+            parentId: replyTarget.id,
+            onSuccess: (data) => {
+              setReplyTarget(null);
+              navigate(`/node/${data.id}`);
+            },
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -267,13 +267,27 @@ function NodeDetail() {
           `Deleted ${n} node${n === 1 ? "" : "s"}`,
           3000,
         );
-        // Navigate to parent node if it exists, otherwise go to dashboard
-        if (node.ancestors && node.ancestors.length > 0) {
-          const parentNode = node.ancestors[node.ancestors.length - 1];
-          navigate(`/node/${parentNode.id}`);
-        } else {
-          navigate("/log");
+        // "This only" leaves the node as a tombstone with alive children.
+        // Drop into a live child so the user sees the tombstone in its
+        // breadcrumb instead of landing on the deleted-node 404.
+        if (!withDescendants && node.children) {
+          const aliveChild = node.children.find((c) => !c.deleted);
+          if (aliveChild) {
+            navigate(`/node/${aliveChild.id}`);
+            return;
+          }
         }
+        // Otherwise walk up to the closest alive ancestor — the immediate
+        // parent may itself be a tombstone (e.g., chained "this only").
+        if (node.ancestors && node.ancestors.length > 0) {
+          for (let i = node.ancestors.length - 1; i >= 0; i -= 1) {
+            if (!node.ancestors[i].deleted) {
+              navigate(`/node/${node.ancestors[i].id}`);
+              return;
+            }
+          }
+        }
+        navigate("/log");
       })
       .catch((err) => {
         console.error(err);

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { FaThumbtack, FaMicrophone, FaEllipsisV } from "react-icons/fa";
+import { FaThumbtack, FaMicrophone } from "react-icons/fa";
 import NodeFooter from "./NodeFooter";
 import SpeakerIcon from "./SpeakerIcon";
 import DownloadAudioIcon from "./DownloadAudioIcon";
@@ -15,6 +15,7 @@ import { useCheckboxToggle } from "../utils/markdown";
 import { contextAllowsAi } from "../utils/aiUsage";
 import NodeFormModal from "./NodeFormModal";
 import Bubble from "./Bubble";
+import BubbleKebabMenu from "./BubbleKebabMenu";
 import QuotedContent from "./QuotedContent";
 import DeleteConfirmDialog from "./DeleteConfirmDialog";
 
@@ -79,9 +80,7 @@ function NodeDetail() {
       return resolved;
     });
   }, []);
-  const [showKebabMenu, setShowKebabMenu] = useState(false);
   const highlightedNodeRef = useRef(null);
-  const kebabMenuRef = useRef(null);
 
   // `autoGenerate` is the single source of truth. Defaults to true on
   // a fresh install (see useState initializer) and persists across
@@ -167,18 +166,6 @@ function NodeDetail() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
-
-  // Close kebab menu on outside click
-  useEffect(() => {
-    if (!showKebabMenu) return;
-    const handler = (e) => {
-      if (kebabMenuRef.current && !kebabMenuRef.current.contains(e.target)) {
-        setShowKebabMenu(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showKebabMenu]);
 
   // Handle LLM completion
   useEffect(() => {
@@ -567,66 +554,27 @@ function NodeDetail() {
       <hr style={{ borderColor: "var(--border)", margin: 0 }} />
       <div style={highlightedTextStyle}>
         {isOwner && (
-          <div ref={kebabMenuRef} style={{
-            position: 'absolute',
-            top: '10px',
-            right: '10px',
-          }}>
-            <button
-              onClick={() => setShowKebabMenu((v) => !v)}
-              title="More actions"
-              style={{
-                background: 'none', border: 'none', cursor: 'pointer',
-                color: 'var(--text-muted)', padding: '4px 6px',
-                display: 'inline-flex', alignItems: 'center',
-              }}
-            >
-              <FaEllipsisV size={14} />
-            </button>
-            {showKebabMenu && (
-              <div style={{
-                position: 'absolute',
-                top: '100%',
-                right: 0,
-                marginTop: '4px',
-                background: 'var(--bg-card)',
-                border: '1px solid var(--border)',
-                borderRadius: '6px',
-                boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
-                minWidth: '120px',
-                zIndex: 5,
-                overflow: 'hidden',
-              }}>
-                <button
-                  onClick={() => {
-                    setShowKebabMenu(false);
-                    if (node.context_artifacts?.prompt) {
-                      setShowPromptEditConfirm(true);
-                    } else {
-                      setShowEditOverlay(true);
-                    }
-                  }}
-                  style={{
-                    display: 'block', width: '100%', textAlign: 'left',
-                    background: 'none', border: 'none', cursor: 'pointer',
-                    padding: '8px 12px',
-                    fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
-                    color: 'var(--text-primary)',
-                  }}
-                >Edit</button>
-                <button
-                  onClick={() => { setShowKebabMenu(false); handleDelete(); }}
-                  style={{
-                    display: 'block', width: '100%', textAlign: 'left',
-                    background: 'none', border: 'none', cursor: 'pointer',
-                    padding: '8px 12px',
-                    fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
-                    color: 'var(--accent)',
-                  }}
-                >Delete</button>
-              </div>
-            )}
-          </div>
+          <BubbleKebabMenu
+            visible={true}
+            items={[
+              {
+                label: 'Edit',
+                action: () => {
+                  if (node.context_artifacts?.prompt) {
+                    setShowPromptEditConfirm(true);
+                  } else {
+                    setShowEditOverlay(true);
+                  }
+                },
+                color: 'var(--text-primary)',
+              },
+              {
+                label: 'Delete',
+                action: () => handleDelete(),
+                color: 'var(--accent)',
+              },
+            ]}
+          />
         )}
         {node.is_system_prompt && node.prompt_title && (
           <div style={{

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -263,11 +263,8 @@ function NodeDetail() {
       .then((response) => {
         const data = response.data || {};
         const n = data.scheduled || 1;
-        const days = data.grace_days || 30;
         addToast(
-          n === 1
-            ? `Node scheduled for deletion in ${days} days`
-            : `${n} nodes scheduled for deletion in ${days} days`,
+          `Deleted ${n} node${n === 1 ? "" : "s"}`,
           3000,
         );
         // Navigate to parent node if it exists, otherwise go to dashboard

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -500,9 +500,11 @@ function NodeDetail() {
     border: "1px solid var(--border)",
     borderLeft: "3px solid var(--accent)",
     borderRadius: "10px",
-    // Reserve right-side space for the always-outside kebab so it
-    // stays on screen down to ~320px portrait viewports.
-    width: "calc(95% - 40px)",
+    // Reserve right-side space for the always-outside kebab so the
+    // visible gap to the right of the icon matches the gap between
+    // bubble and icon (~14px). Drops the 95% scaling — maxWidth still
+    // caps the bubble on wide viewports.
+    width: "calc(100% - 50px)",
     maxWidth: "1500px",
     marginLeft: "20px",
     position: "relative",

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -981,7 +981,10 @@ function NodeDetail() {
       <DeleteConfirmDialog
         open={!!deleteTarget}
         mode="single"
-        hasChildren={!!(deleteTarget && deleteTarget.children && deleteTarget.children.length > 0)}
+        hasChildren={!!(deleteTarget && (
+          deleteTarget.child_count > 0
+          || (deleteTarget.children && deleteTarget.children.length > 0)
+        ))}
         onClose={() => setDeleteTarget(null)}
         onConfirm={handleConfirmDelete}
       />

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -500,7 +500,9 @@ function NodeDetail() {
     border: "1px solid var(--border)",
     borderLeft: "3px solid var(--accent)",
     borderRadius: "10px",
-    width: "95%",
+    // Reserve right-side space for the always-outside kebab so it
+    // stays on screen down to ~320px portrait viewports.
+    width: "calc(95% - 60px)",
     maxWidth: "1500px",
     marginLeft: "20px",
     position: "relative",

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -247,7 +247,11 @@ function NodeDetail() {
   );
 
   const buildActions = (n) => {
+    // `kind` is the stable identifier — Bubble pulls the reply action
+    // out of this list to wire the comment-icon click. The label is
+    // free to change without breaking that coupling.
     const actions = [{
+      kind: 'reply',
       label: 'Reply',
       action: () => setExclusiveTarget('reply', n),
       color: 'var(--text-primary)',

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -502,7 +502,7 @@ function NodeDetail() {
     borderRadius: "10px",
     // Reserve right-side space for the always-outside kebab so it
     // stays on screen down to ~320px portrait viewports.
-    width: "calc(95% - 60px)",
+    width: "calc(95% - 40px)",
     maxWidth: "1500px",
     marginLeft: "20px",
     position: "relative",

--- a/frontend/src/components/NodeFooter.js
+++ b/frontend/src/components/NodeFooter.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FaRegCommentDots } from 'react-icons/fa';
 import { useUser } from '../contexts/UserContext';
 
-const NodeFooter = ({ username, createdAt, childrenCount, humanOwnerUsername, llmModel, children }) => {
+const NodeFooter = ({ username, createdAt, childrenCount, humanOwnerUsername, llmModel, onReplyClick, children }) => {
   const { user } = useUser();
 
   // "via" display: show "humanOwner via model" for LLM nodes,
@@ -17,6 +17,13 @@ const NodeFooter = ({ username, createdAt, childrenCount, humanOwnerUsername, ll
   const linkUrl = user && user.username === linkUsername ? '/dashboard' : `/dashboard/${linkUsername}`;
   const formattedDateTime = createdAt ? new Date(createdAt).toLocaleString() : "";
 
+  const replyIcon = (
+    <>
+      <FaRegCommentDots />
+      {childrenCount > 0 && <span>{childrenCount}</span>}
+    </>
+  );
+
   return (
     <div style={footerStyle}>
       <Link to={linkUrl} style={{ color: "var(--text-muted)", textDecoration: "none", transition: "color 0.3s ease" }}>
@@ -24,12 +31,22 @@ const NodeFooter = ({ username, createdAt, childrenCount, humanOwnerUsername, ll
       </Link>
       <span style={{ color: "var(--border)" }}>&middot;</span>
       <span>{formattedDateTime}</span>
-      {childrenCount > 0 && (
-        <>
-          <span style={{ color: "var(--border)" }}>&middot;</span>
-          <FaRegCommentDots />
-          <span>{childrenCount}</span>
-        </>
+      <span style={{ color: "var(--border)" }}>&middot;</span>
+      {onReplyClick ? (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onReplyClick(); }}
+          title="Reply"
+          style={{
+            background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+            color: 'inherit', font: 'inherit',
+            display: 'flex', alignItems: 'center', gap: '4px',
+          }}
+        >
+          {replyIcon}
+        </button>
+      ) : (
+        replyIcon
       )}
       {children && (
         <>


### PR DESCRIPTION
## Why this PR exists

PR #121 was squash-merged into main on 2026-05-06, but the squash captured the feature branch only at `69b8226` (`Walk feed CTE through tombstones to find live descendants`). 21 commits authored after that — covering the kebab unification, the Reply-from-non-focal-bubble feature, and a string of polish/bugfix follow-ups — never made it onto `origin/feat/soft-delete-nodes` and were therefore left out of the squash.

This PR is a clean recovery: cherry-picked the 21 missing commits onto a fresh branch off current `main`. No conflicts (the squash captured `69b8226`'s tree exactly, so each commit applied as authored).

## Summary

- **Bubble kebab unification** — extracted `BubbleKebabMenu`, generalized `Bubble.actions` prop, migrated the focal-node kebab so every bubble in the app uses the same component (Log card, focal, ancestor, child).
- **Reply / Edit / Delete from any non-focal bubble** in NodeDetail — previously you had to navigate to a node before replying. Hover any ancestor or child, click the kebab (or the comment icon), pick the action; on Send the view jumps to the new reply.
- **Backend**: `serialize_node_recursive` now threads `parent_user_id` down to avoid an N+1 for the frontend's ownership check; ancestors expose the same `user_id` + derived `parent_user_id` fields. New `test_node_detail_ownership.py` (5 tests) pins both LLM and human derivations across ancestors, direct children, and recursed grandchildren.
- **Polish** found on staging: kebab outside-right with vertical centering and a 3 s post-hover hold, dropdown flips leftward when it would clip the viewport, kebab stays reachable on narrow viewports, Escape closes the dropdown, simpler delete copy, smarter post-delete navigation (always lands on the closest alive ancestor), Reply-icon trigger keyed on `action.kind === 'reply'` rather than the label string.

## Race-correctness story

No new race surface vs. #121. The `with_for_update()` locking on parent + the descendant-walk locks added in #121 cover the create paths exercised here (Reply on a non-focal bubble goes through the same `create_node` path, which already has `assert_parent_alive`). The Race A inspection rationale in `backend/utils/node_deletion.py:1-16` carries forward unchanged.

## Test plan

- [x] Backend: 320 tests pass (5 new in `test_node_detail_ownership.py`; rest unchanged from main)
- [x] Backend lint: 0 syntax/undefined-name errors
- [x] Frontend: production build succeeds
- [x] Manual on staging: hover an ancestor → kebab appears outside-right and centered; click Reply → modal opens → Send → URL navigates to the new reply with the hovered ancestor as `parent_id`
- [x] Manual on staging: hover a child → kebab → Edit → submit → page stays put, child shows updated content
- [x] Manual on staging: hover a child → kebab → Delete → confirm → page stays put, child surfaces as `[Node deleted]` tombstone
- [x] Mobile pass: kebabs visible without hover on touch devices, dropdown doesn't clip on narrow viewports
- [x] Focal kebab on `/node/<x>` is outside-right, vertically centered, always visible (no hover gate); Edit and Delete still work
- [x] Log card kebab still opens "Delete thread" correctly after the actions-prop refactor

The single-user manual items above were exercised iteratively during the kebab-unification staging deploys — the polish commits in this branch (`Equalize visible gap on each side of the kebab`, `Tighten kebab right-edge reserve`, `Reserve right-edge space for the kebab on narrow viewports`, `Flip kebab dropdown leftward when it would clip the viewport`) were each driven by an issue spotted on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
