### PR TITLE
Voice mode: MP4/AAC fallback for non-WebM browsers

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -303,6 +303,12 @@ class Draft(db.Model):
     streaming_status = db.Column(db.String(20), nullable=True)  # recording, finalizing, completed, failed
     streaming_total_chunks = db.Column(db.Integer, nullable=True)  # Total chunks expected (set on finalize)
     streaming_completed_chunks = db.Column(db.Integer, default=0)  # Chunks transcribed so far
+    # Family-only audio MIME ('audio/webm' or 'audio/mp4') chosen by the
+    # frontend MediaRecorder negotiation. Set on chunk 0 after the init
+    # segment is successfully parsed; chunks 1+ are rejected if their mime
+    # family disagrees. Default 'audio/webm' keeps in-flight pre-deploy
+    # sessions on their existing path.
+    streaming_mime_type = db.Column(db.String(64), nullable=True, default='audio/webm')
     # Workflow label: 'Reflect', 'Orient', etc. Set on init for recovery UI.
     label = db.Column(db.String(20), nullable=True)
     # Privacy settings for when this draft becomes a node

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -20,6 +20,17 @@ AUDIO_STORAGE_ROOT = pathlib.Path(
 ).resolve()
 
 
+def _mime_family(m: str) -> str:
+    """Return the MIME family prefix (substring before `;`) lowercased.
+
+    Browsers disagree on whether `mediaRecorder.mimeType` retains codec
+    params after construction (Safari may report 'audio/mp4', Chrome
+    'audio/mp4;codecs=mp4a.40.2'). We persist and compare on the family
+    only so chunk-N mime checks can't be defeated by codec-string drift.
+    """
+    return (m or '').split(';', 1)[0].strip().lower()
+
+
 @drafts_bp.route("/", methods=["GET"])
 @login_required
 def get_draft():
@@ -200,6 +211,7 @@ def get_interrupted_drafts():
             "content": draft.get_content(),
             "chunk_count": chunk_count,
             "has_stored_chunks": stored_count > 0,
+            "streaming_mime_type": draft.streaming_mime_type,
             "created_at": draft.created_at.isoformat() + "Z",
             "updated_at": draft.updated_at.isoformat() + "Z",
         }
@@ -493,6 +505,9 @@ def upload_streaming_chunk(session_id):
     Expects multipart/form-data with:
     - chunk: audio file blob
     - chunk_index: integer (0-based)
+    - mime_type: optional, family-only or codec-qualified MIME of the
+      chunk (e.g. 'audio/webm', 'audio/mp4;codecs=mp4a.40.2'). Defaults
+      to 'audio/webm' for backward compatibility with pre-MP4 frontends.
 
     Returns: { "chunk_index": 0, "task_id": "celery-task-id" }
     """
@@ -523,18 +538,45 @@ def upload_streaming_chunk(session_id):
     except ValueError:
         return jsonify({"error": "Invalid chunk_index"}), 400
 
+    # Normalize the chunk's mime to a family prefix; older frontends
+    # without the field send WebM by definition.
+    form_mime_family = _mime_family(
+        request.form.get("mime_type", "audio/webm")
+    )
+    if form_mime_family not in ("audio/webm", "audio/mp4"):
+        return jsonify({
+            "error": f"Unsupported audio mime: {form_mime_family}",
+        }), 400
+
+    # On chunks past 0, the session mime is locked in by chunk 0. Reject
+    # any chunk that disagrees — closes the resume-on-different-device
+    # class of bug where a user could try to append fMP4 fragments to a
+    # WebM session (or vice versa).
+    if (chunk_index > 0
+            and draft.streaming_mime_type
+            and form_mime_family != draft.streaming_mime_type):
+        return jsonify({
+            "error": (
+                f"Chunk mime {form_mime_family!r} does not match "
+                f"session mime {draft.streaming_mime_type!r}"
+            ),
+            "code": "mime_mismatch",
+        }), 400
+
+    ext = ".mp4" if form_mime_family == "audio/mp4" else ".webm"
+
     # Save chunk to disk
     chunk_dir = AUDIO_STORAGE_ROOT / f"drafts/{current_user.id}/{session_id}"
     if not chunk_dir.exists():
         return jsonify({"error": "Streaming session directory not found"}), 404
 
-    chunk_filename = f"chunk_{chunk_index:04d}.webm"
+    chunk_filename = f"chunk_{chunk_index:04d}{ext}"
     chunk_path = chunk_dir / chunk_filename
     chunk_file.save(chunk_path)
 
-    # Chunk 0 carries the EBML/Segment/Tracks init segment — the bytes that
-    # every later batch needs as a prefix to remain a valid WebM (chunks 1+
-    # are raw cluster fragments with no header). Extract and persist it now,
+    # Chunk 0 carries the format's init segment — the bytes that every
+    # later batch needs as a prefix to remain a valid file (WebM:
+    # EBML/Segment/Tracks; fMP4: ftyp+moov). Extract and persist it now,
     # before encrypt_file() deletes the plaintext chunk.
     #
     # Reject the upload if extraction fails: batch 1 (chunks 0..19) would
@@ -544,11 +586,12 @@ def upload_streaming_chunk(session_id):
     # later audio.
     if chunk_index == 0:
         # Narrow to the failure modes that actually signal "bad browser
-        # output": ValueError from the EBML walker and OSError from the
-        # file write. Anything else (e.g. KMS outage in encrypt_file) is
-        # not the client's fault and should propagate as a 500 by the
-        # usual Flask error path rather than getting misattributed to a
-        # parse failure the user can't do anything about.
+        # output": ValueError from the EBML/ISOBMFF walker and OSError
+        # from the file write. Anything else (e.g. KMS outage in
+        # encrypt_file) is not the client's fault and should propagate as
+        # a 500 by the usual Flask error path rather than getting
+        # misattributed to a parse failure the user can't do anything
+        # about.
         try:
             persist_init_segment(chunk_path, chunk_dir)
         except (ValueError, OSError) as exc:
@@ -564,10 +607,14 @@ def upload_streaming_chunk(session_id):
             # parse. Not a server failure, so it shouldn't count in the
             # 5xx alert dashboards.
             return jsonify({
-                "error": "Could not parse WebM header from first chunk",
+                "error": "Could not parse init segment from first chunk",
                 "detail": str(exc),
-                "code": "webm_header_parse_failed",
+                "code": "init_parse_failed",
             }), 400
+        # Only persist the family mime AFTER successful init extraction —
+        # if persist_init_segment raised, we don't want a half-committed
+        # mime that'd survive a future early-commit refactor.
+        draft.streaming_mime_type = form_mime_family
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))
@@ -836,6 +883,7 @@ def get_streaming_status(session_id):
         "session_id": session_id,
         "draft_id": draft.id,
         "streaming_status": draft.streaming_status,
+        "streaming_mime_type": draft.streaming_mime_type,
         "total_chunks": draft.streaming_total_chunks,
         "completed_chunks": completed_count,
         "failed_chunks": failed_count,

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -18,7 +18,7 @@ from backend.models import Node, NodeTranscriptChunk, Draft, APICostLog
 from backend.extensions import db
 from backend.utils.audio_processing import compress_audio_if_needed, get_audio_duration
 from backend.utils.audio_storage import move_draft_audio_to_node_dir
-from backend.utils.webm_utils import concat_webm_fragments
+from backend.utils.webm_utils import concat_fragmented_media
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import decrypt_file_to_temp
 from backend.utils.cost import calculate_audio_cost_microdollars
@@ -530,12 +530,13 @@ class BatchTranscriptionTask(Task):
 @celery.task(base=BatchTranscriptionTask, bind=True)
 def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
     """
-    Transcribe a batch of audio chunks by merging them and sending to Whisper.
+    Transcribe a batch of audio chunks by merging them and sending to
+    OpenAI's gpt-4o-transcribe.
 
     Instead of transcribing each 15s chunk individually, this task:
     1. Decrypts all chunk files in the batch
-    2. Merges MediaRecorder fragments into one valid WebM
-    3. Sends merged audio to Whisper (gpt-4o-transcribe)
+    2. Merges MediaRecorder fragments into one valid file (WebM or fMP4)
+    3. Sends merged audio to gpt-4o-transcribe
     4. Stores transcript, marks all chunks as completed
     5. Reassembles draft.content from all completed chunks
     6. Encrypts the merged audio and deletes individual chunk files
@@ -554,6 +555,15 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
         if not draft:
             raise ValueError(f"Draft not found for session {session_id}")
 
+        # Family-only mime drives the on-disk extension. Defensive None
+        # handling in case a row was inserted before the default backfill;
+        # falling back to .webm preserves the pre-MP4 behavior.
+        ext = (
+            ".mp4"
+            if (draft.streaming_mime_type or "").startswith("audio/mp4")
+            else ".webm"
+        )
+
         chunk_dir = audio_storage_root / f"drafts/{draft.user_id}/{session_id}"
 
         # Collect and decrypt chunk files
@@ -562,7 +572,7 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
 
         try:
             for idx in sorted(chunk_indices):
-                chunk_filename = f"chunk_{idx:04d}.webm"
+                chunk_filename = f"chunk_{idx:04d}{ext}"
                 chunk_path = chunk_dir / chunk_filename
                 enc_path = chunk_dir / f"{chunk_filename}.enc"
 
@@ -585,15 +595,16 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 )
 
             # If this batch doesn't include chunk 0, decrypt the cached
-            # init segment so concat_webm_fragments can prepend it — only
-            # chunk 0 carries the EBML/Segment/Tracks header, so later
-            # batches would otherwise be header-less cluster data that
-            # ffmpeg can't remux.
+            # init segment so concat_fragmented_media can prepend it —
+            # only chunk 0 carries the format-specific header (WebM:
+            # EBML/Segment/Tracks; fMP4: ftyp+moov), so later batches
+            # would otherwise be header-less fragment data that ffmpeg
+            # can't remux.
             first_chunk = min(chunk_indices) if chunk_indices else 0
             init_segment_path = None
             if first_chunk > 0:
-                init_enc = chunk_dir / "init.webm.enc"
-                init_plain = chunk_dir / "init.webm"
+                init_enc = chunk_dir / f"init{ext}.enc"
+                init_plain = chunk_dir / f"init{ext}"
                 if init_enc.exists():
                     init_segment_path = decrypt_file_to_temp(str(init_enc))
                     temp_files.append(init_segment_path)
@@ -606,15 +617,18 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                         "concat will likely fail"
                     )
 
-            # Merge MediaRecorder fragments into a single valid WebM.
+            # Merge MediaRecorder fragments into a single valid file.
             # Binary-append the fragments and remux — see
-            # concat_webm_fragments for the full rationale.
-            merged_path = concat_webm_fragments(
-                decrypted_paths, init_segment_path=init_segment_path,
+            # concat_fragmented_media for the full rationale. Same code
+            # path handles both Matroska/WebM and fMP4.
+            merged_path = concat_fragmented_media(
+                decrypted_paths,
+                init_segment_path=init_segment_path,
+                output_suffix=ext,
             )
             merge_input = merged_path
 
-            # Compress if needed (webm -> mp3)
+            # Compress if needed (no-op for already-compressed WebM/MP4)
             merge_input_path = pathlib.Path(merge_input)
             processed_path = compress_audio_if_needed(merge_input_path, logger)
 
@@ -622,7 +636,7 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
             batch_duration_sec = get_audio_duration(processed_path, logger)
 
             try:
-                # Transcribe via Whisper
+                # Transcribe via gpt-4o-transcribe
                 api_key = get_openai_chat_key(flask_app.config)
                 if not api_key:
                     raise ValueError(
@@ -631,9 +645,12 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
 
                 client = OpenAI(api_key=api_key)
                 with open(processed_path, "rb") as audio_file:
+                    # Pass an explicit (name, file) tuple so the API
+                    # infers the format from `ext` rather than from the
+                    # tempfile's auto-generated suffix.
                     resp = client.audio.transcriptions.create(
                         model="gpt-4o-transcribe",
-                        file=audio_file,
+                        file=(f"audio{ext}", audio_file),
                         response_format="text"
                     )
 
@@ -693,7 +710,7 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
             if merged_path and os.path.exists(merged_path):
                 batch_filename = (
                     f"batch_{min(chunk_indices):04d}-"
-                    f"{max(chunk_indices):04d}.webm"
+                    f"{max(chunk_indices):04d}{ext}"
                 )
                 batch_dest = chunk_dir / batch_filename
                 shutil.move(merged_path, str(batch_dest))
@@ -702,11 +719,11 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
 
                 # Delete individual encrypted chunk files in the batch
                 for idx in chunk_indices:
-                    for ext in [
-                        f"chunk_{idx:04d}.webm.enc",
-                        f"chunk_{idx:04d}.webm"
+                    for chunk_name in [
+                        f"chunk_{idx:04d}{ext}.enc",
+                        f"chunk_{idx:04d}{ext}",
                     ]:
-                        p = chunk_dir / ext
+                        p = chunk_dir / chunk_name
                         if p.exists():
                             try:
                                 p.unlink()

--- a/backend/tests/test_webm_utils.py
+++ b/backend/tests/test_webm_utils.py
@@ -16,7 +16,7 @@ import subprocess
 import pytest
 
 from backend.utils.webm_utils import (
-    concat_webm_fragments,
+    concat_fragmented_media,
     extract_webm_init_segment,
     find_all_cluster_offsets,
     find_first_cluster_offset,
@@ -179,7 +179,7 @@ def test_raises_on_segment_with_no_cluster():
         find_first_cluster_offset(buf)
 
 
-# --- integration tests for concat_webm_fragments -----------------------------
+# --- integration tests for concat_fragmented_media -----------------------------
 # These exercise the full binary-append + ffmpeg remux pipeline and require
 # ffmpeg on PATH; skipped locally if absent. CI installs ffmpeg (see ci.yml).
 
@@ -233,7 +233,7 @@ def test_concat_single_fragment_including_init(tmp_path, webm_fixture):
     chunk_0 = tmp_path / "chunk_0000.webm"
     chunk_0.write_bytes(webm_fixture)
 
-    out = concat_webm_fragments([str(chunk_0)])
+    out = concat_fragmented_media([str(chunk_0)])
 
     assert _ffprobe_duration(out) == pytest.approx(5.0, abs=0.3)
 
@@ -261,7 +261,7 @@ def test_concat_multi_cluster_batch_with_init_segment(tmp_path, webm_fixture):
         fpath.write_bytes(webm_fixture[boundaries[i]:boundaries[i + 1]])
         fragment_paths.append(str(fpath))
 
-    out = concat_webm_fragments(
+    out = concat_fragmented_media(
         fragment_paths, init_segment_path=str(init_path),
     )
 
@@ -327,4 +327,4 @@ def test_concat_without_init_on_body_only_input_fails(
     body_path.write_bytes(webm_fixture[split:])
 
     with pytest.raises(RuntimeError, match="ffmpeg"):
-        concat_webm_fragments([str(body_path)])
+        concat_fragmented_media([str(body_path)])

--- a/backend/utils/audio_storage.py
+++ b/backend/utils/audio_storage.py
@@ -25,11 +25,11 @@ def move_draft_audio_to_node_dir(
     """Move every audio file from a streaming-session draft dir into the
     node's permanent audio dir, then remove the emptied draft dir.
 
-    Skips `init.webm` (and `init.webm.enc`) — that file is the extracted
-    EBML/Segment/Tracks prefix cached on chunk-0 upload so later batches
-    can remux into valid WebM, and has no purpose in node storage.
-    Callers pass their own logger so the messages land with the right
-    request/task context.
+    Skips `init.{webm,mp4}` (and their `.enc` variants) — those files
+    are the format-specific init segments cached on chunk-0 upload so
+    later batches can remux into valid output, and have no purpose in
+    node storage. Callers pass their own logger so the messages land
+    with the right request/task context.
 
     Best-effort: exceptions are logged at warning level rather than
     raised, since by the time this is called the DB record has already
@@ -40,7 +40,10 @@ def move_draft_audio_to_node_dir(
     try:
         node_audio_dir.mkdir(parents=True, exist_ok=True)
         for fp in draft_audio_dir.iterdir():
-            if fp.name.startswith("init.webm"):
+            # Match init.webm, init.webm.enc, init.mp4, init.mp4.enc.
+            # The dir is server-controlled, never holds user-uploaded
+            # files, so a permissive prefix match is safe here.
+            if fp.name.startswith("init."):
                 fp.unlink()
                 continue
             shutil.move(str(fp), str(node_audio_dir / fp.name))

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -1,25 +1,27 @@
 """
-Utility functions for WebM audio file handling.
+Utility functions for fragmented-media (Matroska/WebM and fMP4) audio
+file handling.
 
 Covers:
 - Probing duration via ffprobe (`get_webm_duration`).
-- Extracting a MediaRecorder session's init segment (EBML header +
-  Segment header + Info + Tracks, everything before the first Cluster)
-  via a proper EBML element walk (`extract_webm_init_segment`,
-  `find_first_cluster_offset`, `find_all_cluster_offsets`).
+- Extracting a MediaRecorder session's init segment via a proper EBML
+  element walk for WebM (`extract_webm_init_segment`,
+  `find_first_cluster_offset`, `find_all_cluster_offsets`) or a flat
+  ISOBMFF box walk for fMP4 (`extract_mp4_init_segment`).
 - Persisting that init segment alongside a streaming session so later
-  batches that don't include chunk 0 can still be remuxed into valid
-  WebM (`persist_init_segment`).
-- Concatenating MediaRecorder fragments into a single valid WebM via
-  binary append + a single ffmpeg remux (`concat_webm_fragments`), and
-  concatenating multiple standalone WebM files via the ffmpeg concat
-  demuxer (`concat_audio_files`).
+  batches that don't include chunk 0 can still be remuxed into a valid
+  file (`persist_init_segment` — format-aware, dispatches on file suffix).
+- Concatenating MediaRecorder fragments (Matroska or fMP4) into a single
+  valid file via binary append + a single ffmpeg remux
+  (`concat_fragmented_media`), and concatenating multiple standalone
+  audio files via the ffmpeg concat demuxer (`concat_audio_files`).
 """
 
 import logging
 import os
 import pathlib
 import shutil
+import struct
 import subprocess
 import tempfile
 from typing import Optional
@@ -115,32 +117,41 @@ def persist_init_segment(
     chunk_path: pathlib.Path, chunk_dir: pathlib.Path,
 ) -> None:
     """Extract the init segment from a chunk-0 file on disk and persist it
-    at `chunk_dir/init.webm.enc` (or `init.webm` if encryption is disabled).
+    at `chunk_dir/init{ext}.enc` (or `init{ext}` if encryption is disabled),
+    where `ext` matches the chunk's file extension (`.webm` or `.mp4`).
 
-    Raises ValueError if the chunk's WebM bytes can't be parsed or are
-    missing a Tracks element. The caller is responsible for deleting the
-    offending chunk and surfacing an error — retaining a chunk 0 we can't
-    extract the init from would let batch 1 succeed and batch 2 fail
+    Dispatches on the chunk's suffix: WebM goes through the EBML walker,
+    MP4 through the ISOBMFF box walker. Both raise ValueError on malformed
+    input, OSError on disk failure. The caller is responsible for deleting
+    the offending chunk and surfacing an error — retaining a chunk 0 we
+    can't extract the init from would let batch 1 succeed and batch 2 fail
     silently for want of an init segment.
     """
     # Local import avoids circular imports; encryption depends on this
     # module's sibling files.
     from backend.utils.encryption import encrypt_file
 
+    ext = chunk_path.suffix.lower()
     with open(chunk_path, 'rb') as f:
-        init_bytes = extract_webm_init_segment(f.read())
+        raw = f.read()
+    if ext == '.mp4':
+        init_bytes = extract_mp4_init_segment(raw)
+    elif ext == '.webm':
+        init_bytes = extract_webm_init_segment(raw)
+    else:
+        raise ValueError(f"Unsupported chunk extension: {ext}")
 
-    init_path = chunk_dir / "init.webm"
+    init_path = chunk_dir / ("init" + ext)
     with open(init_path, 'wb') as f:
         f.write(init_bytes)
     try:
         # encrypt_file is a no-op returning the original path when
         # encryption is disabled; no return value to track. On success it
-        # removes the plaintext init.webm and writes init.webm.enc.
+        # removes the plaintext init file and writes init{ext}.enc.
         encrypt_file(str(init_path))
     except Exception:
         # KMS outage or any other encrypt failure — don't leave a
-        # plaintext init.webm on disk for a subsequent batch to pick up
+        # plaintext init file on disk for a subsequent batch to pick up
         # and mistakenly treat as its own (unencrypted) init segment.
         try:
             init_path.unlink(missing_ok=True)
@@ -260,24 +271,87 @@ def extract_webm_init_segment(data: bytes) -> bytes:
     return data[:cluster_offset]
 
 
-def concat_webm_fragments(paths: list,
-                          init_segment_path: Optional[str] = None,
-                          output_suffix: str = '.webm') -> str:
-    """Concatenate MediaRecorder timeslice fragments into one valid WebM.
+def extract_mp4_init_segment(data: bytes) -> bytes:
+    """Return the init segment of a Safari/WebKit MediaRecorder fMP4 blob.
 
-    MediaRecorder with a timeslice emits Matroska *fragments* of a single
-    continuous stream — only the first blob carries the EBML/Segment/Tracks
-    header; subsequent blobs are header-less cluster data with timestamps
-    absolute to the original recording. Per the MSE byte-stream format, those
+    MediaRecorder on Safari with `audio/mp4` and a timeslice emits
+    fragmented MP4: the first blob carries `ftyp` + `moov` (the init
+    segment, ~652 bytes for typical AAC) followed by the first
+    `moof`+`mdat` fragment; later blobs are bare `moof`+`mdat` fragments
+    with timestamps absolute to the original recording. Like WebM, the
+    init bytes never change over the lifetime of a single MediaRecorder
+    recording, so we persist them once and prepend to future batches that
+    don't start at chunk 0.
+
+    Hardened to raise ValueError (never struct.error) on every parse
+    failure, so the route handler at drafts.py upload_streaming_chunk
+    catches and returns a clean 400 + `init_parse_failed`. Validates that
+    a `moov` box was seen before the first `moof`/`mdat` (parallel to the
+    WebM Tracks check) so a malformed chunk where the first box is `moof`
+    can't yield an empty init segment that would silently corrupt batch 2.
+    Rejects pathological box sizes (< 8, or < 16 for largesize) that would
+    otherwise misalign subsequent reads.
+    """
+    off = 0
+    saw_moov = False
+    while off + 8 <= len(data):
+        try:
+            size = struct.unpack('>I', data[off:off+4])[0]
+        except struct.error as e:
+            raise ValueError(f"Truncated MP4 box header at offset {off}") from e
+        box = data[off+4:off+8]
+        if box in (b'moof', b'mdat'):
+            if not saw_moov:
+                raise ValueError(
+                    "Init segment is missing a moov element — "
+                    "chunk 0 is structurally malformed"
+                )
+            return data[:off]
+        if box == b'moov':
+            saw_moov = True
+        if size == 1:  # 64-bit largesize
+            if off + 16 > len(data):
+                raise ValueError(f"Truncated 64-bit largesize at offset {off}")
+            try:
+                size = struct.unpack('>Q', data[off+8:off+16])[0]
+            except struct.error as e:
+                raise ValueError(f"Bad largesize at offset {off}") from e
+            if size < 16:
+                raise ValueError(f"Invalid largesize {size} at offset {off}")
+        elif size < 8:
+            raise ValueError(f"Invalid box size {size} at offset {off}")
+        if size == 0:
+            break
+        off += size
+    raise ValueError("No moof/mdat element found — chunk 0 is structurally malformed")
+
+
+def concat_fragmented_media(paths: list,
+                            init_segment_path: Optional[str] = None,
+                            output_suffix: str = '.webm') -> str:
+    """Concatenate MediaRecorder timeslice fragments into one valid file.
+
+    Handles both Matroska/WebM and fragmented MP4 (fMP4) — they share the
+    same architectural property: with a timeslice, MediaRecorder emits a
+    sequence of byte-concatenable fragments of a single continuous stream.
+    Only the first blob carries the init prefix (EBML/Segment/Tracks for
+    WebM; ftyp+moov for fMP4); subsequent blobs are header-less fragment
+    bodies (Matroska Clusters / MP4 moof+mdat) with timestamps absolute to
+    the original recording. Per the respective byte-stream formats, those
     fragments concatenated in order as raw bytes form exactly one valid
-    Matroska file. This function does that append, then runs a single ffmpeg
-    remux pass to rewrite the container's Duration/Cues so the output is
+    file. This function does that append, then runs a single ffmpeg remux
+    pass to rewrite the container's duration metadata so the output is
     seekable and reports the correct length.
 
     For batches that don't include the first fragment of the recording,
-    pass `init_segment_path` pointing at a previously-extracted init segment
-    (see `extract_webm_init_segment`). Its bytes are binary-prepended so the
-    resulting file has a valid EBML/Segment/Tracks prefix.
+    pass `init_segment_path` pointing at a previously-extracted init
+    segment (see `extract_webm_init_segment` / `extract_mp4_init_segment`).
+    Its bytes are binary-prepended.
+
+    `output_suffix` should be `.webm` for Matroska inputs and `.mp4` for
+    fMP4. The function body is format-agnostic — `+genpts` and `-c copy`
+    don't care about container — but the suffix tells ffmpeg which muxer
+    to use for the output.
 
     Returns the path to the merged output file. Caller is responsible for
     cleaning it up (parity with `concat_audio_files`).

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -1,5 +1,20 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 
+// Preference-ordered MIME list. WebM/Opus first (existing browsers stay
+// on the optimized raw-byte-concat path), then MP4/AAC for iOS Safari
+// and other WebKit-based browsers that don't ship WebM in MediaRecorder.
+// Order matters: the first supported entry wins.
+const PREFERRED_MIMES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4;codecs=mp4a.40.2',
+  'audio/mp4',
+];
+
+// Return 'audio/webm' or 'audio/mp4' (family prefix only) given any MIME
+// string — matches the backend's `_mime_family` so resume passes round-trip.
+const mimeFamily = (m) => (m || '').split(';', 1)[0].trim().toLowerCase();
+
 /**
  * useStreamingMediaRecorder hook for recording audio with real-time chunk emission.
  *
@@ -29,6 +44,7 @@ export function useStreamingMediaRecorder({
   const dataAvailableFiredRef = useRef(false); // Track if ondataavailable ran during stop
   const pausedAtRef = useRef(null); // Timestamp when paused
   const totalPausedMsRef = useRef(0); // Accumulated paused duration
+  const mimeTypeRef = useRef(null); // Active recorder's mimeType (so non-state callbacks like getPartialBlob can read it)
 
   // Clean up on unmount
   useEffect(() => {
@@ -64,6 +80,7 @@ export function useStreamingMediaRecorder({
     chunkIndexRef.current = 0;
     pausedAtRef.current = null;
     totalPausedMsRef.current = 0;
+    mimeTypeRef.current = null;
     setMediaBlob(null);
     setMediaUrl('');
     setDuration(0);
@@ -74,7 +91,14 @@ export function useStreamingMediaRecorder({
 
   // startingChunkIndex: offset for chunk numbering when resuming an interrupted session
   // durationOffset: seconds of audio already recorded before this session
-  const startRecording = useCallback(async ({ startingChunkIndex = 0, durationOffset = 0 } = {}) => {
+  // forceMimeFamily: 'audio/webm' or 'audio/mp4' — required for resume; the
+  //   recorder must match the family chunk 0 was uploaded with, otherwise
+  //   the server rejects subsequent chunks with mime_mismatch.
+  const startRecording = useCallback(async ({
+    startingChunkIndex = 0,
+    durationOffset = 0,
+    forceMimeFamily = null,
+  } = {}) => {
     resetRecording();
 
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
@@ -90,50 +114,71 @@ export function useStreamingMediaRecorder({
       throw err;
     }
 
-    // The server requires WebM (EBML init-segment parser, .webm-suffixed
-    // storage). If the browser doesn't support audio/webm at the MediaRecorder
-    // level (e.g. older iOS Safari, where MediaRecorder shipped MP4-only), we
-    // can't proceed — fail fast with an actionable message rather than letting
-    // `new MediaRecorder({mimeType:'audio/webm'})` throw a generic
-    // NotSupportedError. The console log captures the codec capability matrix
-    // and UA for any future diagnostic.
+    // Capture the codec capability matrix + UA for diagnostics — same log
+    // that confirmed user 50's iOS-18.0-Safari case in the field.
     const codecSupport = {
       webm: MediaRecorder.isTypeSupported('audio/webm'),
       webmOpus: MediaRecorder.isTypeSupported('audio/webm;codecs=opus'),
       mp4: MediaRecorder.isTypeSupported('audio/mp4'),
       mp4Aac: MediaRecorder.isTypeSupported('audio/mp4;codecs=mp4a.40.2'),
     };
-    console.log('[StreamingRecorder] Codec support:', codecSupport, 'UA:', navigator.userAgent);
 
-    if (!codecSupport.webm && !codecSupport.webmOpus) {
-      const err = new Error(
-        `This browser cannot record in WebM, which the server requires. ` +
-        `Please try a recent version of Chrome on this device, or update your ` +
-        `operating system. (Detected codecs: ${JSON.stringify(codecSupport)})`
-      );
-      err.name = 'NotSupportedError';
-      setError(err.message);
-      throw err;
+    let chosenMime;
+    if (forceMimeFamily) {
+      // Resume path: the session's family is fixed by chunk 0. Refuse if
+      // this browser can't record it — same behavior as a fresh start
+      // hitting an unsupported environment.
+      if (!MediaRecorder.isTypeSupported(forceMimeFamily)) {
+        console.log('[StreamingRecorder] Codec support:', codecSupport, 'forceMimeFamily:', forceMimeFamily, 'UA:', navigator.userAgent);
+        const err = new Error(
+          `Resumed session uses ${forceMimeFamily}, which this browser cannot record. (Detected codecs: ${JSON.stringify(codecSupport)})`
+        );
+        err.name = 'NotSupportedError';
+        setError(err.message);
+        throw err;
+      }
+      // Prefer a codec-qualified entry that shares the family for explicit
+      // codec selection; fall back to family-only if none qualified.
+      chosenMime =
+        PREFERRED_MIMES.find(
+          (m) => m.startsWith(forceMimeFamily + ';') && MediaRecorder.isTypeSupported(m),
+        ) || forceMimeFamily;
+    } else {
+      chosenMime = PREFERRED_MIMES.find((m) => MediaRecorder.isTypeSupported(m));
+      if (!chosenMime) {
+        console.log('[StreamingRecorder] Codec support:', codecSupport, 'UA:', navigator.userAgent);
+        const err = new Error(
+          `This browser cannot record in any supported audio format. (Detected codecs: ${JSON.stringify(codecSupport)})`
+        );
+        err.name = 'NotSupportedError';
+        setError(err.message);
+        throw err;
+      }
     }
+
+    console.log('[StreamingRecorder] Codec support:', codecSupport, 'chosen:', chosenMime, 'UA:', navigator.userAgent);
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
-      const options = { mimeType: 'audio/webm' };
+      const options = { mimeType: chosenMime };
       const mediaRecorder = new MediaRecorder(stream, options);
-      console.log('[StreamingRecorder] MediaRecorder constructed:', { requested: 'audio/webm', actual: mediaRecorder.mimeType });
+      console.log('[StreamingRecorder] MediaRecorder constructed:', { requested: chosenMime, actual: mediaRecorder.mimeType, family: mimeFamily(mediaRecorder.mimeType) });
       recorderRef.current = mediaRecorder;
+      mimeTypeRef.current = mediaRecorder.mimeType;
       chunksRef.current = [];
       chunkIndexRef.current = startingChunkIndex;
 
-      // MediaRecorder with a timeslice emits Matroska *fragments* of one
-      // continuous stream — only chunk 0 has an EBML header; chunks 1+ are
-      // header-less cluster data whose timestamps are absolute to the
-      // original recording. These fragments, concatenated in order as raw
-      // bytes on the server, form exactly one valid WebM. So we upload each
-      // blob verbatim and let the backend do the binary concat + a single
-      // remux pass to rewrite duration metadata.
+      // MediaRecorder with a timeslice emits format-specific fragments
+      // of one continuous stream — only chunk 0 has the init prefix
+      // (Matroska EBML/Segment/Tracks for WebM, ftyp+moov for fMP4);
+      // chunks 1+ are header-less fragment bodies whose timestamps are
+      // absolute to the original recording. Per the respective byte-stream
+      // formats, those fragments concatenated in order as raw bytes form
+      // exactly one valid file. So we upload each blob verbatim and let
+      // the backend do the binary concat + a single remux pass to rewrite
+      // duration metadata.
       mediaRecorder.ondataavailable = (e) => {
         const recorderState = recorderRef.current?.state || 'unknown';
         console.log(`[StreamingRecorder] ondataavailable fired: size=${e.data?.size || 0}, recorderState=${recorderState}, timeSinceStart=${Date.now() - startTimeRef.current}ms`);
@@ -281,7 +326,7 @@ export function useStreamingMediaRecorder({
   // Get a partial blob from chunks recorded so far (for download during recording)
   const getPartialBlob = useCallback(() => {
     if (chunksRef.current.length === 0) return null;
-    return new Blob(chunksRef.current, { type: 'audio/webm' });
+    return new Blob(chunksRef.current, { type: mimeTypeRef.current || 'audio/webm' });
   }, []);
 
   return {

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -123,13 +123,23 @@ export function useStreamingMediaRecorder({
       mp4Aac: MediaRecorder.isTypeSupported('audio/mp4;codecs=mp4a.40.2'),
     };
 
+    // Permanent debug knob: ?force_mime=mp4 or ?force_mime=webm constrains
+    // the negotiation to a single family. Useful for asking any user to
+    // reproduce a specific codec path without code changes (e.g. exercising
+    // the MP4 path on a WebM-supporting browser to validate the server-side
+    // pipeline). No effect unless the param is present, so it can't be
+    // triggered by accident in production. Resume paths (forceMimeFamily
+    // branch below) ignore this since the session's family is already
+    // locked by chunk 0.
+    const forced = new URLSearchParams(window.location.search).get('force_mime');
+
     let chosenMime;
     if (forceMimeFamily) {
       // Resume path: the session's family is fixed by chunk 0. Refuse if
       // this browser can't record it — same behavior as a fresh start
       // hitting an unsupported environment.
       if (!MediaRecorder.isTypeSupported(forceMimeFamily)) {
-        console.log('[StreamingRecorder] Codec support:', codecSupport, 'forceMimeFamily:', forceMimeFamily, 'UA:', navigator.userAgent);
+        console.log('[StreamingRecorder] Codec support:', codecSupport, 'forceMimeFamily:', forceMimeFamily, 'forced:', forced, 'UA:', navigator.userAgent);
         const err = new Error(
           `Resumed session uses ${forceMimeFamily}, which this browser cannot record. (Detected codecs: ${JSON.stringify(codecSupport)})`
         );
@@ -144,11 +154,19 @@ export function useStreamingMediaRecorder({
           (m) => m.startsWith(forceMimeFamily + ';') && MediaRecorder.isTypeSupported(m),
         ) || forceMimeFamily;
     } else {
-      chosenMime = PREFERRED_MIMES.find((m) => MediaRecorder.isTypeSupported(m));
+      let preferred = PREFERRED_MIMES;
+      if (forced === 'mp4') {
+        preferred = PREFERRED_MIMES.filter((m) => m.startsWith('audio/mp4'));
+      } else if (forced === 'webm') {
+        preferred = PREFERRED_MIMES.filter((m) => m.startsWith('audio/webm'));
+      }
+      chosenMime = preferred.find((m) => MediaRecorder.isTypeSupported(m));
       if (!chosenMime) {
-        console.log('[StreamingRecorder] Codec support:', codecSupport, 'UA:', navigator.userAgent);
+        console.log('[StreamingRecorder] Codec support:', codecSupport, 'forced:', forced, 'UA:', navigator.userAgent);
         const err = new Error(
-          `This browser cannot record in any supported audio format. (Detected codecs: ${JSON.stringify(codecSupport)})`
+          forced
+            ? `Forced mime '${forced}' is not supported by this browser. (Detected codecs: ${JSON.stringify(codecSupport)})`
+            : `This browser cannot record in any supported audio format. (Detected codecs: ${JSON.stringify(codecSupport)})`
         );
         err.name = 'NotSupportedError';
         setError(err.message);
@@ -156,7 +174,7 @@ export function useStreamingMediaRecorder({
       }
     }
 
-    console.log('[StreamingRecorder] Codec support:', codecSupport, 'chosen:', chosenMime, 'UA:', navigator.userAgent);
+    console.log('[StreamingRecorder] Codec support:', codecSupport, 'chosen:', chosenMime, 'forced:', forced, 'UA:', navigator.userAgent);
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -99,39 +99,49 @@ export function useStreamingTranscription(options = {}) {
    * Upload a single chunk with exponential backoff retry.
    * Returns { success: true } on success, or { success: false, fatalError?: string }
    * on failure. `fatalError` is set when the server returned a deterministic
-   * error (e.g. chunk 0's WebM header didn't parse) where retrying wouldn't
+   * error (e.g. chunk 0's init segment didn't parse) where retrying wouldn't
    * help — retries are skipped and the caller surfaces a distinct message.
    */
   const uploadChunkWithRetry = useCallback(async (blob, chunkIndex, sessionId) => {
     const maxRetries = 4;
     const baseDelay = 2000; // 2 seconds
 
+    // The blob's `type` is set from the MediaRecorder's mimeType (which
+    // may include codec params like ';codecs=opus'). Derive the on-disk
+    // extension from the family so the backend can store + look up
+    // chunks correctly. Default to webm for safety.
+    const blobType = blob.type || 'audio/webm';
+    const family = blobType.split(';')[0].trim().toLowerCase();
+    const ext = family === 'audio/mp4' ? '.mp4' : '.webm';
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const formData = new FormData();
-        formData.append('chunk', blob, `chunk_${chunkIndex}.webm`);
+        formData.append('chunk', blob, `chunk_${chunkIndex}${ext}`);
         formData.append('chunk_index', chunkIndex.toString());
+        formData.append('mime_type', blobType);
 
         await api.post(`/drafts/streaming/${sessionId}/audio-chunk`, formData, {
           headers: { 'Content-Type': 'multipart/form-data' },
           timeout: 600000,
         });
 
-        console.log(`[StreamingTranscription] Upload complete: chunk=${chunkIndex}` + (attempt > 0 ? ` (after ${attempt} retries)` : ''));
+        console.log(`[StreamingTranscription] Upload complete: chunk=${chunkIndex} mime=${blobType}` + (attempt > 0 ? ` (after ${attempt} retries)` : ''));
         return { success: true };
       } catch (err) {
-        // Server rejected chunk 0 because it couldn't parse the WebM header
-        // (MediaRecorder on this browser produced bytes we don't recognize).
-        // Retrying will yield the exact same bytes, so short-circuit with a
-        // fatal-error message the caller can surface distinctly from
-        // ordinary network flakiness. Key only on the stable code field so
-        // the status code can change without regressing this check.
-        if (err.response?.data?.code === 'webm_header_parse_failed') {
+        // Server rejected chunk 0 because it couldn't parse the format's
+        // init segment. Retrying will yield the exact same bytes, so
+        // short-circuit with a fatal-error message the caller can surface
+        // distinctly from ordinary network flakiness. After the MP4
+        // fallback fix, this path means corruption in transit (or a
+        // browser producing genuinely malformed output across both
+        // formats), not a browser-incompatibility issue.
+        if (err.response?.data?.code === 'init_parse_failed') {
           const detail = err.response?.data?.detail || 'unknown parse error';
-          console.error(`[StreamingTranscription] Fatal: server could not parse chunk ${chunkIndex}'s WebM header (${detail}); not retrying`);
+          console.error(`[StreamingTranscription] Fatal: server could not parse chunk ${chunkIndex}'s init segment (${detail}); not retrying`);
           return {
             success: false,
-            fatalError: `Your browser produced an audio format we can't process. Please try a different browser or device. (${detail})`,
+            fatalError: `Your audio recording could not be processed. Please try recording again. (${detail})`,
           };
         }
 
@@ -460,7 +470,13 @@ export function useStreamingTranscription(options = {}) {
 
   // Resume an existing interrupted session (continue recording).
   // New chunks start after existingChunkCount, duration continues from estimated offset.
-  const resumeStreaming = useCallback(async (existingSessionId, existingDraftId, existingChunkCount) => {
+  // existingMimeType: family-only mime ('audio/webm' or 'audio/mp4') from the
+  //   /drafts/interrupted payload. The recorder must record in the same family
+  //   chunk 0 was uploaded with, otherwise the server rejects subsequent chunks
+  //   with mime_mismatch. If this browser can't record that family, the
+  //   recorder hook throws NotSupportedError and we surface that via onError.
+  const resumeStreaming = useCallback(async (existingSessionId, existingDraftId, existingChunkCount, existingMimeType) => {
+    let initSucceeded = false;
     try {
       setSessionState('initializing');
       setErrorMessage(null);
@@ -470,19 +486,27 @@ export function useStreamingTranscription(options = {}) {
       draftIdRef.current = existingDraftId;
       sessionIdRef.current = existingSessionId;
       totalChunksRef.current = existingChunkCount || 0;
+      initSucceeded = true;
 
       const durationOffset = (existingChunkCount || 0) * (chunkIntervalMs / 1000);
       await startMediaRecorder({
         startingChunkIndex: existingChunkCount || 0,
         durationOffset,
+        forceMimeFamily: existingMimeType || null,
       });
       setSessionState('recording');
     } catch (err) {
       console.error('Failed to resume streaming:', err);
       setSessionState('error');
       setErrorMessage(err.message);
+      // Mirror startStreaming's onError plumbing so the parent sees the
+      // resume-incompatible-browser case and can reset the UI.
+      if (initSucceeded && onError) {
+        try { err.startup = true; } catch (_) { /* DOMException may be sealed */ }
+        onError(err);
+      }
     }
-  }, [startMediaRecorder, chunkIntervalMs]);
+  }, [startMediaRecorder, chunkIntervalMs, onError]);
 
   // Stop streaming and finalize
   // extraParams: optional { parent_id, model } for server-side LLM chain

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -193,10 +193,18 @@ export function useStreamingTranscription(options = {}) {
         }
         playErrorSound();
         if (onError) {
-          onError(new Error(
+          const uploadErr = new Error(
             result.fatalError
             || `Failed to upload chunk ${chunkIndex} after retries`
-          ));
+          );
+          // Tag fatal errors so the parent can distinguish them from
+          // recoverable transient failures and surface a toast +
+          // reset phase. Non-fatal uploads (transient network) keep the
+          // existing behavior of just queueing for retry without UI.
+          if (result.fatalError) {
+            try { uploadErr.fatal = true; } catch (_) { /* sealed */ }
+          }
+          onError(uploadErr);
         }
       }
     })();

--- a/frontend/src/hooks/useVoiceSession.js
+++ b/frontend/src/hooks/useVoiceSession.js
@@ -426,8 +426,12 @@ export function useVoiceSession({ apiEndpoint, ttsTitle = 'Audio', onLLMComplete
     streaming.cancelStreaming();
   }, [audio, ttsSSE, streaming, stopSilentAudio]);
 
-  // Resume an interrupted session (continue recording from where it left off)
-  const handleResumeSession = useCallback(({ sessionId, draftId, chunkCount, parentId: draftParentId }) => {
+  // Resume an interrupted session (continue recording from where it left off).
+  // mimeType is the family-only mime ('audio/webm' or 'audio/mp4') from the
+  // /drafts/interrupted payload — required so the recorder records in the
+  // same family chunk 0 was uploaded with (otherwise the server rejects with
+  // mime_mismatch).
+  const handleResumeSession = useCallback(({ sessionId, draftId, chunkCount, parentId: draftParentId, mimeType }) => {
     // Restore thread context so finalization uses the correct parent
     if (draftParentId != null) {
       threadParentIdRef.current = draftParentId;
@@ -440,7 +444,7 @@ export function useVoiceSession({ apiEndpoint, ttsTitle = 'Audio', onLLMComplete
     setPhase('recording');
     setHasError(false);
     startSilentAudio();
-    streaming.resumeStreaming(sessionId, draftId, chunkCount);
+    streaming.resumeStreaming(sessionId, draftId, chunkCount, mimeType);
   }, [streaming, startSilentAudio]);
 
   const handlePauseRecording = useCallback(() => {

--- a/frontend/src/hooks/useVoiceSession.js
+++ b/frontend/src/hooks/useVoiceSession.js
@@ -138,15 +138,19 @@ export function useVoiceSession({ apiEndpoint, ttsTitle = 'Audio', onLLMComplete
       transcriptRef.current = text;
     },
     onError: (err) => {
-      // Only act on recording-startup failures (getUserMedia rejection,
-      // MediaRecorder construction error). Runtime errors like chunk-upload
-      // failures also flow through onError but should not interrupt an
-      // in-progress recording — preserve prior behavior for those.
-      if (!err?.startup) return;
+      // Surface (1) startup failures (getUserMedia/MediaRecorder ctor) and
+      // (2) fatal upload failures (server rejected chunk 0 with
+      // init_parse_failed — recorder was reset, session is dead).
+      // Non-fatal upload failures (transient network) preserve prior silent
+      // retry-queue behavior so they don't interrupt an in-progress recording.
+      if (!err?.startup && !err?.fatal) return;
 
       const name = err?.name || err?.error?.name;
       let message;
-      if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
+      if (err?.fatal) {
+        // Use the fatal-error message verbatim — it's already user-facing.
+        message = err.message;
+      } else if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
         message = "Microphone access was denied. Allow microphone access for this site in your browser and OS settings, then try again.";
       } else if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
         message = "No microphone was found on this device.";

--- a/frontend/src/pages/VoicePage.js
+++ b/frontend/src/pages/VoicePage.js
@@ -334,9 +334,15 @@ export default function VoicePage() {
         <RecoveryBanner
           draft={interruptedDraft}
           onContinue={() => {
-            const { session_id, id, chunk_count, parent_id } = interruptedDraft;
+            const { session_id, id, chunk_count, parent_id, streaming_mime_type } = interruptedDraft;
             clearInterrupted();
-            handleResumeSession({ sessionId: session_id, draftId: id, chunkCount: chunk_count, parentId: parent_id });
+            handleResumeSession({
+              sessionId: session_id,
+              draftId: id,
+              chunkCount: chunk_count,
+              parentId: parent_id,
+              mimeType: streaming_mime_type,
+            });
           }}
           onDiscard={() => {
             if (phase === 'playback') {


### PR DESCRIPTION
## Summary

- Adds a parallel MP4/AAC streaming path so voice mode works on iOS Safari and any other browser that ships MediaRecorder without WebM. Confirmed broken in prod for users 50 + 42 — they recorded with zero chunks reaching the server, silent failure.
- Empirically confirmed Safari MediaRecorder emits fragmented MP4 (chunk 0 = `ftyp`+`moov`, chunks 1+ = bare `moof`+`mdat`), structurally identical to the WebM Matroska fragments we already handle. Existing `concat_webm_fragments` (raw byte concat + ffmpeg remux) works unchanged for both formats — renamed to `concat_fragmented_media` to reflect the dual use, body unchanged.
- New `extract_mp4_init_segment` (~10 lines, ISOBMFF box walker, hardened to raise `ValueError` on every parse failure). Existing chunk-0 reject path catches malformed MP4 the same way it catches malformed WebM, with a unified `init_parse_failed` error code.
- `Draft.streaming_mime_type` column + family-only normalization (`audio/webm` or `audio/mp4`) so chunk-N mime checks aren't fooled by browser-to-browser codec-string drift. Mid-session reject + frontend resume guard close the resume-on-different-device class of bug.
- `?force_mime=mp4|webm` URL-param debug knob — permanent, no-op without the param, lets a WebM-supporting browser exercise the MP4 path for pre-merge validation and future user-reported debugging.
- Fatal chunk-upload failures (`init_parse_failed`) now surface as a toast (tagged `err.fatal=true`, picked up by the same `useVoiceSession.onError` filter that handles startup errors). Previously dropped on the floor by the startup-only filter, leaving users staring at a reset timer with no explanation.

## Test plan

- [x] **Local fMP4 fixture verification** against real Safari recording (`chunk_000{0,1,2}.mp4`):
  - `extract_mp4_init_segment(chunk_0)` returns exactly the 652-byte prefix up to first `moof`
  - All 5 error paths raise `ValueError` (truncated, garbage, size<8, moof-before-moov, empty)
  - `concat_fragmented_media([chunk_1, chunk_2], init_segment_path=…, output_suffix='.mp4')` produces a 30.02s decode-clean MP4 (`ffmpeg -v error -i out -f null -` returns no stderr)
- [x] **Backend regression**: full pytest suite (320 passed). Existing 14 WebM tests pass under the rename.
- [x] **CI-blocking flake8** (`E9,F63,F7,F82`): 0 errors
- [x] **Frontend build**: `npm run build` clean, no warnings
- [x] **macOS Safari capability matrix** confirmed via `MediaRecorder.isTypeSupported`: all four `PREFERRED` MIMEs supported (`audio/webm;codecs=opus`, `audio/webm`, `audio/mp4;codecs=mp4a.40.2`, `audio/mp4`). Validates that the URL-param test exercises the same code path as iOS Safari.
- [x] **macOS Safari + `?force_mime=mp4`, 25s recording** on staging — chunk-0 init parse, transcription, final node all clean. Same WebKit family as iOS Safari, so this validates the user-50 path with high confidence.
- [x] **macOS Safari + `?force_mime=webm`, 25s recording** on staging — existing path unchanged.
- [x] **macOS Chrome, no param, 25s recording** on staging — MIME negotiation correctly picks `audio/webm;codecs=opus`, behavior identical to pre-PR.
- [x] **Long-form recording (>7 min) on macOS Safari with `?force_mime=mp4`** on staging — full path through batch transcription (`transcribe_chunk_batch` → `concat_fragmented_media` on 30+ fMP4 fragments → `gpt-4o-transcribe`), final node has the full transcript. This is the actual production usage pattern (voice mode is 30–60 min by default).
- [ ] **Post-deploy smoke test on user 50** (iOS 18.0 Safari, no param needed): timer increments past 0:00, audio-chunk POSTs return 202, `Draft.streaming_mime_type='audio/mp4'` for her sessions, final node has non-empty content.
- [ ] **Auto-migration sanity**: inspect the `[skip ci]` migration commit after deploy — should be a single `op.add_column('draft', sa.Column('streaming_mime_type', sa.String(64), nullable=True))`. Anything more invasive (table recreate, default backfill SQL) needs a second look.

## Known issue (out of scope, follow-up)

⚠️ **Recovery-flow merge corruption** — when a user refreshes mid-recording and clicks "Continue", the resumed `MediaRecorder` produces stream-incompatible chunks (its own `ftyp`+`moov` for MP4, or fresh EBML+Segment+Tracks for WebM) that don't byte-concat correctly with the original session's chunks. Result: final transcript contains only the post-resume audio. **Pre-existing — affects WebM resume the same way**, just less visible in practice; not introduced by this PR. Tracked in #124 with a fix sketch (per-chunk init detection + sub-batch partitioning at subsession boundaries). User 50 won't hit this on her first reproduction since she's exercising the basic record→stop→transcribe path, which this PR validates end-to-end.

## Notes on the URL-param debug knob

`?force_mime=mp4` filters the negotiation to MP4-only entries; `?force_mime=webm` filters to WebM-only. The param is read fresh on each `startRecording` call (not at hook construction), so it must be on the URL when the user clicks "record" — the existing `[StreamingRecorder] Codec support:` console log now includes the `forced` value for visibility. Resume paths ignore the param since the session's family is locked by chunk 0. Production safety: no effect unless the param is explicitly added.

Note: the URL-param test is **only meaningful on Safari**, not Chrome. Chrome's MP4 muxer produces a different fragment structure than Safari's and may fail this PR's parser. That's not a production concern — Chrome users naturally negotiate `audio/webm;codecs=opus` and never touch the MP4 path. The param is a Safari-targeted debug tool.

## Notes on the format-handling architecture

`concat_audio_files` (the ffmpeg concat demuxer path) does **not** work for fMP4 — the demuxer bails on chunks 1+ with "no tfhd was found". An earlier fixture test that suggested otherwise was misleading because it used `ffmpeg -ss -c copy` to split a complete file, producing standalone MP4s rather than the bare fragments Safari actually emits. The `concat_fragmented_media` (binary append) path is the right utility for both formats.

Plan + design history: `~/.claude/plans/rosy-snuggling-alpaca.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
