### PR TITLE
Light mode foundation: data-theme + warm parchment palette

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,17 +6,38 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet" />
+    <script>
+      // Theme bootstrap — runs synchronously before paint to set data-theme on <html>
+      // so the var-driven critical CSS below boots in the user's chosen theme.
+      // Honors localStorage 'loore_theme' (set by ThemeContext.setTheme), falling
+      // back to OS-level prefers-color-scheme. Wrapped in try/catch so localStorage
+      // failures (private browsing, etc.) don't break the page.
+      (function() {
+        try {
+          var t = localStorage.getItem('loore_theme');
+          if (t === 'light' || t === 'dark') {
+            document.documentElement.setAttribute('data-theme', t);
+          } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+            document.documentElement.setAttribute('data-theme', 'light');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <style>
-      /* Critical dark theme — prevents white flash before JS bundle loads */
+      /* Critical theme — prevents flash before JS bundle loads. Uses CSS vars
+         so the data-theme attribute set above resolves to the right colors. */
+      html { --boot-bg: #0e0d0b; --boot-fg: #ede8dd; }
+      html[data-theme="light"] { --boot-bg: #f5efe4; --boot-fg: #1f1c17; }
       html, body, #root {
         margin: 0; padding: 0; height: 100%; width: 100%;
-        background-color: #0e0d0b; color: #ede8dd;
+        background-color: var(--boot-bg); color: var(--boot-fg);
       }
     </style>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#0e0d0b" />
+    <meta name="theme-color" content="#0e0d0b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f5efe4" media="(prefers-color-scheme: light)" />
     <meta
       name="description"
       content="Uncover your lore. Unleash your hidden potential."

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -92,7 +92,7 @@ function AdminPanel() {
       <h1>Admin Panel</h1>
 
       {/* Whitelist New User Section */}
-      <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid #333" }}>
+      <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
         <h2>Whitelist a New User</h2>
         <input
           type="text"
@@ -102,31 +102,31 @@ function AdminPanel() {
           style={{ padding: "8px", marginRight: "10px" }}
         />
         <button onClick={handleWhitelistUser}>Whitelist User</button>
-        {newHandleError && <div style={{ color: "red" }}>{newHandleError}</div>}
+        {newHandleError && <div style={{ color: "var(--error)" }}>{newHandleError}</div>}
       </div>
 
-      {error && <div style={{ color: "red" }}>{error}</div>}
-      <table style={{ width: "100%", borderCollapse: "collapse", color: "#e0e0e0" }}>
+      {error && <div style={{ color: "var(--error)" }}>{error}</div>}
+      <table style={{ width: "100%", borderCollapse: "collapse", color: "var(--text-primary)" }}>
         <thead>
           <tr>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>ID</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Username</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Approved</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Plan</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Email</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Spent</th>
-            <th style={{ border: "1px solid #333", padding: "8px" }}>Actions</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>ID</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Username</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Approved</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Plan</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Email</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Spent</th>
+            <th style={{ border: "1px solid var(--border)", padding: "8px" }}>Actions</th>
           </tr>
         </thead>
         <tbody>
           {users.map((u) => (
             <tr key={u.id}>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>{u.id}</td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>{u.username}</td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>{u.id}</td>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>{u.username}</td>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>
                 {u.approved ? "Active" : "Inactive"}
               </td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>
                 <select
                   value={u.plan || "free"}
                   onChange={(e) => updatePlan(u.id, e.target.value)}
@@ -136,13 +136,13 @@ function AdminPanel() {
                   ))}
                 </select>
               </td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>
                 {u.email || "None"}
               </td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>
                 ${(u.total_spending_usd || 0).toFixed(2)}
               </td>
-              <td style={{ border: "1px solid #333", padding: "8px" }}>
+              <td style={{ border: "1px solid var(--border)", padding: "8px" }}>
                 {!u.approved && u.email ? (
                   <>
                     <button onClick={() => activateAndWelcome(u.id)}>

--- a/frontend/src/components/InlineQuoteBubble.js
+++ b/frontend/src/components/InlineQuoteBubble.js
@@ -56,9 +56,9 @@ const bubbleStyle = {
   display: 'block',
   padding: '12px',
   margin: '10px 0',
-  background: '#252525',
-  border: '1px solid #444',
-  borderLeft: '3px solid #61dafb',
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderLeft: '3px solid var(--accent)',
   borderRadius: '6px',
   cursor: 'pointer',
   whiteSpace: 'pre-wrap',
@@ -68,7 +68,7 @@ const bubbleStyle = {
 
 const quoteHeaderStyle = {
   fontSize: '0.85em',
-  color: '#888',
+  color: 'var(--text-muted)',
   marginBottom: '6px',
   fontStyle: 'italic',
 };
@@ -83,10 +83,10 @@ const notAccessibleStyle = {
   display: 'inline-block',
   padding: '4px 8px',
   margin: '4px 0',
-  background: '#333',
-  border: '1px solid #555',
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-hover)',
   borderRadius: '4px',
-  color: '#888',
+  color: 'var(--text-muted)',
   fontStyle: 'italic',
   fontSize: '0.9em',
 };

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -45,18 +45,6 @@ const styles = {
     }
 
     .loore-landing {
-      --bg-deep: #0e0d0b;
-      --bg-surface: #151412;
-      --bg-card: #1a1917;
-      --text-primary: #e8e2d6;
-      --text-secondary: #9e9688;
-      --text-muted: #6b655b;
-      --accent: #c4956a;
-      --accent-glow: #c4956a33;
-      --accent-subtle: #c4956a18;
-      --serif: 'Cormorant Garamond', Georgia, serif;
-      --sans: 'Outfit', system-ui, sans-serif;
-
       background: var(--bg-deep);
       color: var(--text-primary);
       font-family: var(--sans);
@@ -70,8 +58,8 @@ const styles = {
       position: fixed;
       inset: 0;
       background:
-        radial-gradient(ellipse 80% 60% at 50% 0%, #1a150f 0%, transparent 70%),
-        radial-gradient(ellipse 50% 40% at 80% 20%, #1a130d08 0%, transparent 60%);
+        radial-gradient(ellipse 80% 60% at 50% 0%, var(--gradient-overlay-1) 0%, transparent 70%),
+        radial-gradient(ellipse 50% 40% at 80% 20%, var(--gradient-overlay-2) 0%, transparent 60%);
       pointer-events: none;
       z-index: 0;
     }
@@ -233,7 +221,7 @@ const styles = {
 
     .loore-mockup {
       background: var(--bg-card);
-      border: 1px solid #252320;
+      border: 1px solid var(--border);
       border-radius: 12px;
       overflow: hidden;
       box-shadow: 0 20px 80px rgba(0,0,0,0.4);
@@ -244,15 +232,15 @@ const styles = {
       align-items: center;
       gap: 6px;
       padding: 14px 18px;
-      background: #1e1d1a;
-      border-bottom: 1px solid #252320;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border);
     }
 
     .loore-mockup-dot {
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: #2a2825;
+      background: var(--bg-card-hover);
     }
 
     .loore-mockup-content {
@@ -272,12 +260,12 @@ const styles = {
       font-family: var(--serif);
       font-size: 1.25rem;
       line-height: 1.75;
-      color: #b5aea2;
+      color: var(--text-secondary);
       font-style: normal;
       font-weight: 400;
       margin-bottom: 1.8rem;
       padding-bottom: 1.8rem;
-      border-bottom: 1px solid #252320;
+      border-bottom: 1px solid var(--border);
     }
 
     .loore-mockup-reflection-label {
@@ -327,7 +315,7 @@ const styles = {
       font-family: var(--sans);
       font-size: 0.8rem;
       color: var(--text-muted);
-      border-top: 1px solid #1e1d1a;
+      border-top: 1px solid var(--border);
       position: relative;
       z-index: 1;
     }

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -27,8 +27,8 @@ const loginStyles = `
     position: fixed;
     inset: 0;
     background:
-      radial-gradient(ellipse 80% 60% at 50% 0%, #1a150f 0%, transparent 70%),
-      radial-gradient(ellipse 50% 40% at 80% 20%, #1a130d08 0%, transparent 60%);
+      radial-gradient(ellipse 80% 60% at 50% 0%, var(--gradient-overlay-1) 0%, transparent 70%),
+      radial-gradient(ellipse 50% 40% at 80% 20%, var(--gradient-overlay-2) 0%, transparent 60%);
     pointer-events: none;
     z-index: 0;
   }
@@ -114,7 +114,7 @@ const loginStyles = `
 
   .loore-login-btn-x:hover {
     border-color: var(--border-hover);
-    background: rgba(255,255,255,0.03);
+    background: var(--accent-subtle);
     transform: translateY(-1px);
     box-shadow: 0 4px 16px rgba(0,0,0,0.2);
   }
@@ -128,7 +128,7 @@ const loginStyles = `
 
   .loore-login-btn-email:hover {
     border-color: var(--border-hover);
-    background: rgba(255,255,255,0.03);
+    background: var(--accent-subtle);
     color: var(--text-primary);
     transform: translateY(-1px);
     box-shadow: 0 4px 16px rgba(0,0,0,0.2);
@@ -142,8 +142,8 @@ const loginStyles = `
   }
 
   .loore-login-btn-submit:hover {
-    background: rgba(196, 149, 106, 0.1);
-    box-shadow: 0 0 20px rgba(196, 149, 106, 0.15);
+    background: var(--accent-subtle);
+    box-shadow: 0 0 20px var(--accent-glow);
   }
 
   .loore-login-btn-submit:disabled {

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useUser } from "../contexts/UserContext";
+import { useTheme } from "../contexts/ThemeContext";
 import GlobalAudioPlayer from "./GlobalAudioPlayer";
 import api from "../api";
 
@@ -10,6 +11,7 @@ const aboutPaths = ["/why-loore", "/vision", "/how-to"];
 
 function NavBar({ onNewEntryClick }) {
   const { user, setUser } = useUser();
+  const { theme, toggleTheme } = useTheme();
   const location = useLocation();
   const navigate = useNavigate();
   const [aboutOpen, setAboutOpen] = useState(false);
@@ -376,6 +378,46 @@ function NavBar({ onNewEntryClick }) {
                           position: "absolute",
                           top: "2px",
                           left: craftMode ? "16px" : "2px",
+                          transition: "left 0.2s ease",
+                        }} />
+                      </div>
+                    </button>
+
+                    {/* Theme toggle */}
+                    <button
+                      onClick={toggleTheme}
+                      style={{ ...dropdownItemStyle, display: "flex", justifyContent: "space-between", alignItems: "center" }}
+                      title={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
+                    >
+                      <span style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                        {theme === "light" ? (
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <circle cx="12" cy="12" r="4" />
+                            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+                          </svg>
+                        ) : (
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                          </svg>
+                        )}
+                        <span>Light mode</span>
+                      </span>
+                      <div style={{
+                        width: "32px",
+                        height: "18px",
+                        borderRadius: "9px",
+                        background: theme === "light" ? "var(--accent)" : "var(--border)",
+                        position: "relative",
+                        transition: "background 0.2s ease",
+                      }}>
+                        <div style={{
+                          width: "14px",
+                          height: "14px",
+                          borderRadius: "50%",
+                          background: "var(--text-primary)",
+                          position: "absolute",
+                          top: "2px",
+                          left: theme === "light" ? "16px" : "2px",
                           transition: "left 0.2s ease",
                         }} />
                       </div>

--- a/frontend/src/components/ProposalInline.js
+++ b/frontend/src/components/ProposalInline.js
@@ -200,7 +200,7 @@ function sizeStyles(size) {
       display: 'flex', alignItems: 'flex-start',
       gap: roomy ? '12px' : '10px',
       padding: roomy ? '12px 0' : '8px 0',
-      borderBottom: roomy ? '1px solid #1e1d1a' : '1px solid var(--border)',
+      borderBottom: roomy ? '1px solid var(--bg-surface)' : '1px solid var(--border)',
     },
     circleBase: {
       width: roomy ? '18px' : '16px',
@@ -548,7 +548,7 @@ export default function ProposalInline({
             </StatusTag>
           )}
           {applyStatus === 'completed' && (
-            <StatusTag style={{ ...styles.statusText, color: '#4ade80' }}>
+            <StatusTag style={{ ...styles.statusText, color: 'var(--success)' }}>
               Todo updated
             </StatusTag>
           )}
@@ -589,13 +589,13 @@ export default function ProposalInline({
               </StatusTag>
             )}
             {issueApplyStatus === 'completed' && (
-              <StatusTag style={{ ...styles.statusText, color: '#4ade80' }}>
+              <StatusTag style={{ ...styles.statusText, color: 'var(--success)' }}>
                 Issue created{issueResult?.issue_url && (
                   <> — <a
                     href={issueResult.issue_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style={{ color: '#4ade80', textDecoration: 'underline' }}
+                    style={{ color: 'var(--success)', textDecoration: 'underline' }}
                   >#{issueResult.issue_number}</a></>
                 )}
               </StatusTag>
@@ -612,7 +612,7 @@ export default function ProposalInline({
       {hasPrefsUpdate && (
         <p style={{
           fontFamily: 'var(--sans)', fontSize: '0.75rem', fontWeight: 300,
-          color: '#4ade80',
+          color: 'var(--success)',
           textAlign: styles.roomy ? 'center' : 'left',
           marginTop: '16px',
         }}>

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -294,7 +294,7 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage }) => {
     <button onClick={handleClick} title={noAiAccess ? 'TTS disabled — No AI access' : isActive ? 'Generating audio...' : 'Play audio'}
         disabled={noAiAccess}
         style={{ background: 'none', border: 'none', cursor: noAiAccess ? 'not-allowed' : 'pointer', padding: 0, marginLeft: '8px', opacity: noAiAccess ? 0.35 : 1 }}>
-      {isActive ? <FaSpinner className="spin" /> : <FaVolumeUp color={isCurrentlyPlaying ? '#61dafb' : 'inherit'} />}
+      {isActive ? <FaSpinner className="spin" /> : <FaVolumeUp color={isCurrentlyPlaying ? 'var(--accent)' : 'inherit'} />}
     </button>
   );
 };

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -237,7 +237,7 @@ const MicIcon = () => (
 );
 
 const StopIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="#dc3545">
+  <svg width="16" height="16" viewBox="0 0 24 24" style={{ fill: 'var(--error)' }}>
     <rect x="6" y="6" width="12" height="12" />
   </svg>
 );
@@ -251,7 +251,7 @@ const LoadingIcon = () => (
 );
 
 const ErrorIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="#dc3545">
+  <svg width="16" height="16" viewBox="0 0 24 24" style={{ fill: 'var(--error)' }}>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
   </svg>
 );

--- a/frontend/src/contexts/ThemeContext.js
+++ b/frontend/src/contexts/ThemeContext.js
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const ThemeContext = createContext(null);
+
+const STORAGE_KEY = 'loore_theme';
+
+function readInitialTheme() {
+  // The bootstrap script in public/index.html has already set this attribute
+  // synchronously before paint, honoring localStorage and prefers-color-scheme.
+  if (typeof document !== 'undefined') {
+    const attr = document.documentElement.getAttribute('data-theme');
+    if (attr === 'light' || attr === 'dark') return attr;
+  }
+  return 'dark';
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(readInitialTheme);
+
+  const setTheme = useCallback((next) => {
+    if (next !== 'light' && next !== 'dark') return;
+    setThemeState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch (e) {}
+    document.documentElement.setAttribute('data-theme', next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  }, [theme, setTheme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,7 @@
   box-sizing: border-box;
 }
 
-/* Design System Tokens */
+/* Design System Tokens — dark mode (default) */
 :root {
   /* Backgrounds */
   --bg-deep: #0e0d0b;
@@ -30,9 +30,49 @@
   --border: #302c27;
   --border-hover: #433e36;
 
+  /* Status */
+  --success: #4ade80;
+  --error: #e74c3c;
+  --warning: #ffc107;
+  --info: #61dafb;
+
+  /* Gradient overlays (LoginPage / LandingPage radial backgrounds) */
+  --gradient-overlay-1: #1a150f;
+  --gradient-overlay-2: #1a130d08;
+
   /* Fonts */
   --serif: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
   --sans: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+/* Light mode — warm parchment palette */
+[data-theme="light"] {
+  --bg-deep: #f5efe4;
+  --bg-surface: #ebe4d6;
+  --bg-card: #e0d8c7;
+  --bg-card-hover: #d6cdb9;
+  --bg-input: #fbf7ee;
+
+  --text-primary: #1f1c17;
+  --text-secondary: #5d564a;
+  --text-muted: #857c6c;
+
+  --accent: #a87547;
+  --accent-hover: #8a5d36;
+  --accent-dim: #bb8c66;
+  --accent-glow: #a8754740;
+  --accent-subtle: #a8754718;
+
+  --border: #cdc4b1;
+  --border-hover: #b3a98f;
+
+  --success: #1f8a4d;
+  --error: #c0392b;
+  --warning: #b88600;
+  --info: #0b6e9a;
+
+  --gradient-overlay-1: #e8dfca;
+  --gradient-overlay-2: #d4c8aa20;
 }
 
 html, body, #root {
@@ -45,6 +85,11 @@ html, body, #root {
   font-family: var(--sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Theme-flip transition — narrowly scoped to chromatic properties */
+html, body, button, input, textarea, a {
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 /* Spinner animation for loading icons */
@@ -117,12 +162,12 @@ button {
 
 /* Change button appearance on hover/active */
 button:hover {
-  background-color: rgba(196, 149, 106, 0.08);
+  background-color: var(--accent-subtle);
   border-color: var(--border-hover);
   color: var(--text-primary);
 }
 button:active {
-  background-color: rgba(196, 149, 106, 0.12);
+  background-color: var(--accent-glow);
 }
 
 /* Search highlight */

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,17 +5,20 @@ import "./index.css";
 import App from "./App";
 import { UserProvider } from "./contexts/UserContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 const container = document.getElementById("root");
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <UserProvider>
-        <ToastProvider>
-          <App />
-        </ToastProvider>
-      </UserProvider>
+      <ThemeProvider>
+        <UserProvider>
+          <ToastProvider>
+            <App />
+          </ToastProvider>
+        </UserProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/AiPreferencesPage.js
+++ b/frontend/src/pages/AiPreferencesPage.js
@@ -127,7 +127,7 @@ export default function AiPreferencesPage() {
             >
               <span style={{
                 width: '6px', height: '6px', borderRadius: '50%',
-                background: '#4ade80', display: 'inline-block',
+                background: 'var(--success)', display: 'inline-block',
               }} />
               v{prefs.version_number} &middot; {formatDate(prefs.created_at)}
             </button>

--- a/frontend/src/pages/ConversePage.js
+++ b/frontend/src/pages/ConversePage.js
@@ -198,7 +198,7 @@ export default function ConversePage() {
             width: '40px',
             height: '40px',
             borderRadius: '50%',
-            border: isVoiceRecording ? '2px solid #dc3545' : '1px solid var(--border)',
+            border: isVoiceRecording ? '2px solid var(--error)' : '1px solid var(--border)',
             background: isVoiceRecording ? 'rgba(220,53,69,0.1)' : 'transparent',
             cursor: 'pointer',
             display: 'flex',
@@ -208,7 +208,7 @@ export default function ConversePage() {
           }}
         >
           {isVoiceRecording ? (
-            <svg width="16" height="16" viewBox="0 0 20 20" fill="#dc3545">
+            <svg width="16" height="16" viewBox="0 0 20 20" style={{ fill: 'var(--error)' }}>
               <rect x="4" y="4" width="12" height="12" rx="2" />
             </svg>
           ) : (

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -45,9 +45,9 @@ const cards = [
     icon: (
       <svg width="42" height="42" viewBox="0 0 42 42" fill="none">
         <path d="M8 12 C8 9.8 9.8 8 12 8 L30 8 C32.2 8 34 9.8 34 12 L34 24 C34 26.2 32.2 28 30 28 L16 28 L10 33 L10 28 L12 28 C9.8 28 8 26.2 8 24 Z"
-              stroke="#c4956a" strokeWidth="1.4" fill="none"/>
-        <line x1="14" y1="15" x2="28" y2="15" stroke="#c4956a" strokeWidth="1.4" strokeLinecap="round"/>
-        <line x1="14" y1="20" x2="23" y2="20" stroke="#c4956a" strokeWidth="1.4" strokeLinecap="round"/>
+              stroke="var(--accent)" strokeWidth="1.4" fill="none"/>
+        <line x1="14" y1="15" x2="28" y2="15" stroke="var(--accent)" strokeWidth="1.4" strokeLinecap="round"/>
+        <line x1="14" y1="20" x2="23" y2="20" stroke="var(--accent)" strokeWidth="1.4" strokeLinecap="round"/>
       </svg>
     ),
   },

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -188,7 +188,7 @@ export default function ProfilePage() {
             >
               <span style={{
                 width: '6px', height: '6px', borderRadius: '50%',
-                background: '#4ade80', display: 'inline-block',
+                background: 'var(--success)', display: 'inline-block',
               }} />
               v{versionNumber} &middot; {formatDate(profile.created_at)}
             </button>

--- a/frontend/src/pages/PromptDetailPage.js
+++ b/frontend/src/pages/PromptDetailPage.js
@@ -201,7 +201,7 @@ export default function PromptDetailPage() {
           >
             <span style={{
               width: '6px', height: '6px', borderRadius: '50%',
-              background: '#4ade80', display: 'inline-block',
+              background: 'var(--success)', display: 'inline-block',
             }} />
             v{prompt.version_number} &middot; {formatDate(prompt.created_at)}
           </button>

--- a/frontend/src/pages/PromptsPage.js
+++ b/frontend/src/pages/PromptsPage.js
@@ -97,7 +97,7 @@ export default function PromptsPage() {
                       width: '6px',
                       height: '6px',
                       borderRadius: '50%',
-                      background: 'var(--accent, #4ade80)',
+                      background: 'var(--accent)',
                       display: 'inline-block',
                       flexShrink: 0,
                     }}

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -107,7 +107,7 @@ function TodoItem({ item, onToggle, depth = 0 }) {
           alignItems: 'flex-start',
           gap: '12px',
           padding: '12px 0',
-          borderBottom: '1px solid #1e1d1a',
+          borderBottom: '1px solid var(--bg-surface)',
           paddingLeft: depth * 24,
         }}
       >
@@ -333,7 +333,7 @@ export default function TodoPage() {
             >
               <span style={{
                 width: '6px', height: '6px', borderRadius: '50%',
-                background: '#4ade80', display: 'inline-block',
+                background: 'var(--success)', display: 'inline-block',
               }} />
               v{todo.version_number} &middot; {formatDate(todo.created_at)}
             </button>

--- a/frontend/src/pages/VoicePage.js
+++ b/frontend/src/pages/VoicePage.js
@@ -92,7 +92,7 @@ function EcgAnimation({ active = true, showScanline = true, dim = false }) {
       <svg width="100%" height="100%" viewBox="0 0 280 168" fill="none">
         <path
           d={ECG_PATH}
-          stroke="#c4956a"
+          stroke="var(--accent)"
           strokeWidth="8"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -109,7 +109,7 @@ function EcgAnimation({ active = true, showScanline = true, dim = false }) {
         />
         <path
           d={ECG_PATH}
-          stroke="#c4956a"
+          stroke="var(--accent)"
           strokeWidth="3"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -123,7 +123,7 @@ function EcgAnimation({ active = true, showScanline = true, dim = false }) {
         />
         <path
           d={ECG_PULSE_PATH}
-          stroke="#c4956a"
+          stroke="var(--accent)"
           strokeWidth="5"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -399,7 +399,7 @@ export default function VoicePage() {
 
         {hasError && phase === 'ready' && (
           <div style={{ marginBottom: '16px' }}>
-            <PulsingDot color="var(--error, #e74c3c)" />
+            <PulsingDot color="var(--error)" />
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Adds a toggleable light mode without duplicating components — one set of tokens, two value sets, swapped via `[data-theme="light"]` on `<html>`. Includes the user-facing NavBar toggle.

- New `[data-theme="light"]` override block in `frontend/src/index.css` with a warm-parchment palette (`#f5efe4` bg, `#a87547` accent — chosen after side-by-side mockup review).
- New semantic tokens (`--success`, `--error`, `--warning`, `--info`, `--gradient-overlay-1/2`) so previously-hardcoded greens/reds/cyans/gradients participate in the theme flip.
- FOUC-safe bootstrap script in `frontend/public/index.html` that reads `localStorage['loore_theme']` and falls back to `prefers-color-scheme` synchronously before paint. Plus dual media-conditioned `theme-color` metas.
- New `ThemeContext` (`frontend/src/contexts/ThemeContext.js`) wired into `index.js`. Exposes `useTheme()` with `theme`, `setTheme`, `toggleTheme`. localStorage-only persistence (no backend column).
- Var-ifies hardcoded colors across `AdminPanel`, `ProposalInline`, `InlineQuoteBubble`, `LoginPage`, page-level success dots, error indicators, SVG accent strokes — without these, the theme flip would only partially propagate.
- **Load-bearing**: removes the local token redeclaration at `LandingPage.js:47-58` that was shadowing `:root`. Without this, `data-theme` could not reach `/landing`.
- **NavBar toggle UI**: row in the overflow menu with a sun/moon icon and the same slider visual as the Craft mode toggle. Visible only when logged in.

## What's NOT in this PR

- `StreamingAudioPlayer.js` — verified to be dead code (never imported anywhere), candidate for outright deletion in a separate cleanup.
- Backend `User.theme_preference` column — localStorage only for v1.
- Lighthouse AA contrast audit — deferred (revisit if real users report contrast issues).
- Mobile `theme-color` meta on Android browser chrome — covered by dual media-conditioned metas; not validated on a physical device.

## Test plan

Local + automated end-to-end on `staging.loore.org` via Chrome MCP, plus manual sweep by author.

**Build / config**
- [x] `cd frontend && npm run build` clean (no errors)

**Bootstrap behavior (FOUC + persistence)**
- [x] Default boot, no localStorage, dark macOS → boots dark, no FOUC, `data-theme` not set
- [x] Default boot, no localStorage, **light macOS → boots light, no FOUC, `data-theme="light"`** (verified end-to-end with macOS toggled to Light Appearance)
- [x] `localStorage['loore_theme']='light'` + reload → boots light directly, no FOUC

**Token cascade**
- [x] Manual `data-theme="light"` flip themes home, profile, log, landing, admin
- [x] LandingPage `getComputedStyle(.loore-landing).backgroundColor` resolves to `rgb(245,239,228)` in light mode — load-bearing fix verified end-to-end (without the local-token-redeclaration removal it would still resolve to `#0e0d0b`)
- [x] All semantic tokens (`--success`, `--error`, `--accent`, etc.) resolve to the right values per active theme

**NavBar toggle (UI)**
- [x] Toggle visible in the overflow menu only when logged in
- [x] Sun icon renders in light mode, moon icon in dark mode (swaps with state)
- [x] Click flips the entire UI; slider activates with accent color
- [x] **Round-trip via UI**: dark → light → dark via successive clicks, localStorage updated each time, all tokens flipped correctly
- [x] Theme persists across in-app navigation (`/` → `/profile`) with no flash
- [x] No console errors on staging

**Author manual sweep (in light mode)**
- [x] `/login` (logged out, gradient overlays + accent button hover)
- [x] `/admin` (table borders, status colors)
- [x] Bubble / Feed / InlineQuoteBubble with real entries
- [x] Modals (Search, NodeForm, DeleteConfirm)
- [x] Forms / inputs / autofill
- [x] Hover states across buttons, links, NavBar items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
