### PR TITLE
Strip nginx Server header to avoid version/OS info leak (#142)

### DIFF
--- a/configs/nginx-staging.txt
+++ b/configs/nginx-staging.txt
@@ -5,6 +5,9 @@
 server {
    server_name staging.loore.org;
 
+   # Don't leak the nginx version/OS in the Server response header (#142).
+   server_tokens off;
+
    # Allow large file uploads (200MB) - server-wide setting
    client_max_body_size 200M;
 

--- a/configs/nginx.txt
+++ b/configs/nginx.txt
@@ -4,6 +4,9 @@ server {
    root /home/hrosspet/write-or-perish/frontend/build;
    index index.html index.htm;
 
+   # Don't leak the nginx version/OS in the Server response header (#142).
+   server_tokens off;
+
    # Allow large file uploads (200MB) - server-wide setting
    client_max_body_size 200M;
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Don't leak the nginx version in the Server response header (#142).
+    server_tokens off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
Closes #142.

Adds `server_tokens off;` to the frontend container nginx (`frontend/nginx.conf`) and to the edge reverse-proxy reference configs (`configs/nginx.txt`, `configs/nginx-staging.txt`) so the `Server` response header no longer leaks the nginx version/OS.

**Note:** the externally-visible header is set by the **edge nginx on the VM**, which the deploy does not touch. That was applied manually (`server_tokens off;` in the VM's `nginx.conf` http block + `nginx -t` + reload).

**Verified (prod + staging):** `curl -sI https://loore.org` and `https://staging.loore.org` now return `Server: nginx` (version/OS stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
