### PR TITLE
Add tooltips explaining why record/upload buttons are disabled (#62)

### DIFF
--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -810,15 +810,22 @@ const NodeForm = forwardRef(
                       onChange={handleFileSelect}
                       style={{ display: 'none' }}
                     />
-                    <button
-                      type="button"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isStreamingRecording || aiUsage === 'none' || !isOnline}
-                      title={audioDisabledReason || undefined}
-                      style={{ padding: '8px 16px', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'pointer', opacity: isStreamingRecording || aiUsage === 'none' || !isOnline ? 0.35 : 1 }}
+                    {/* Tooltip on the wrapper span, not the disabled button —
+                        disabled elements don't fire hover, so a title on the
+                        button itself never shows (#62). */}
+                    <span
+                      title={(isStreamingRecording || aiUsage === 'none' || !isOnline) ? (audioDisabledReason || undefined) : undefined}
+                      style={{ display: 'inline-flex', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'default' }}
                     >
-                      Upload
-                    </button>
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={isStreamingRecording || aiUsage === 'none' || !isOnline}
+                        style={{ padding: '8px 16px', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'pointer', opacity: isStreamingRecording || aiUsage === 'none' || !isOnline ? 0.35 : 1, pointerEvents: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'none' : 'auto' }}
+                      >
+                        Upload
+                      </button>
+                    </span>
                   </>
                 )}
               </>

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -443,6 +443,18 @@ const NodeForm = forwardRef(
       isDirty: () => content.trim().length > 0 || uploadedFile,
     }));
 
+    // Explain why the record/upload buttons are disabled (#62). The most
+    // common cause is "No AI Access" — audio needs transcription, which
+    // requires AI access. Surfaced as a tooltip on both buttons.
+    const audioDisabledReason =
+      aiUsage === 'none'
+        ? "Set AI Usage to Chat or Train to record or upload audio — transcription needs AI access."
+        : !isOnline
+        ? "You're offline — reconnect to record or upload audio."
+        : isStreamingRecording
+        ? "Finish the current recording first."
+        : "";
+
     // Format time ago for last saved indicator
     const formatTimeAgo = (date) => {
       if (!date) return '';
@@ -755,6 +767,7 @@ const NodeForm = forwardRef(
                   parentId={parentId}
                   privacyLevel={privacyLevel}
                   aiUsage={aiUsage}
+                  disabledReason={audioDisabledReason}
                   onRecordingStart={() => {
                     // Capture content before streaming starts so we can append to it
                     preStreamingContentRef.current = content;
@@ -801,6 +814,7 @@ const NodeForm = forwardRef(
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
                       disabled={isStreamingRecording || aiUsage === 'none' || !isOnline}
+                      title={audioDisabledReason || undefined}
                       style={{ padding: '8px 16px', cursor: isStreamingRecording || aiUsage === 'none' || !isOnline ? 'not-allowed' : 'pointer', opacity: isStreamingRecording || aiUsage === 'none' || !isOnline ? 0.35 : 1 }}
                     >
                       Upload

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -27,6 +27,7 @@ export default function StreamingMicButton({
   onComplete = null,
   onError = null,
   disabled = false,
+  disabledReason = '',
 }) {
   const {
     sessionState,
@@ -194,6 +195,13 @@ export default function StreamingMicButton({
           type="button"
           onClick={handleClick}
           disabled={disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing'}
+          title={
+            disabled && disabledReason
+              ? disabledReason
+              : isIdleOffline
+              ? "You're offline — reconnect to record audio."
+              : undefined
+          }
           style={{
             display: 'flex',
             alignItems: 'center',

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -191,28 +191,42 @@ export default function StreamingMicButton({
         </div>
       )}
       <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-        <button
-          type="button"
-          onClick={handleClick}
-          disabled={disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing'}
+        {/* The tooltip lives on this wrapper span, NOT the button: browsers
+            suppress pointer events (and thus the native title tooltip) on
+            disabled elements, so a title on the disabled button never shows.
+            The span isn't disabled, so it receives hover and shows it (#62). */}
+        <span
           title={
-            disabled && disabledReason
+            (disabled && disabledReason)
               ? disabledReason
               : isIdleOffline
               ? "You're offline — reconnect to record audio."
               : undefined
           }
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '6px',
-            padding: '8px 16px',
-            cursor: disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing' ? 'not-allowed' : 'pointer',
-            opacity: disabled || isIdleOffline ? 0.35 : 1,
+            display: 'inline-flex',
+            cursor: disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing' ? 'not-allowed' : 'default',
           }}
         >
-          {getButtonContent()}
-        </button>
+          <button
+            type="button"
+            onClick={handleClick}
+            disabled={disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing'}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '8px 16px',
+              cursor: disabled || isIdleOffline || sessionState === 'initializing' || sessionState === 'finalizing' ? 'not-allowed' : 'pointer',
+              opacity: disabled || isIdleOffline ? 0.35 : 1,
+              // Let hover events reach the wrapper span when disabled so the
+              // tooltip can show.
+              pointerEvents: disabled || isIdleOffline ? 'none' : 'auto',
+            }}
+          >
+            {getButtonContent()}
+          </button>
+        </span>
         {showDownload && (
           <button
             type="button"


### PR DESCRIPTION
Closes #62.

Explains why the Record/Upload buttons in the Write dialog are disabled (most commonly "No AI Access" — audio needs transcription, which needs AI access).

The first attempt put `title` directly on the disabled buttons, but browsers suppress hover/tooltips on `disabled` elements, so nothing showed. Fixed by moving the tooltip to a non-disabled wrapper `<span>` (with `pointer-events:none` on the inner button) so the tooltip appears on hover.

**Verified on staging** (manual): hovering the disabled Record/Upload buttons under "No AI Access" now shows the explanatory tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
