### PR TITLE
Respect auto-generate preference on first text-mode turn (#134)

### DIFF
--- a/frontend/src/pages/WritePage.js
+++ b/frontend/src/pages/WritePage.js
@@ -28,8 +28,16 @@ export default function WritePage() {
       });
       return { id: res.data.id };
     }
+    // Respect the user's auto-generate preference from the very first
+    // turn (#134). Shares the `loore_auto_generate` key with NodeDetail's
+    // inline toggle and NodeForm's craft-mode toggle, so there's one
+    // "auto-generate after submit" preference across the app. Default
+    // true on a fresh install (matches the backend default). When off,
+    // /textmode/start creates the thread without firing an LLM reply.
+    const stored = localStorage.getItem('loore_auto_generate');
+    const autoGenerate = stored === null ? true : stored === 'true';
     const res = await api.post('/textmode/start', {
-      content, privacy_level, ai_usage,
+      content, privacy_level, ai_usage, auto_generate: autoGenerate,
     });
     return res.data;
   };
@@ -40,6 +48,10 @@ export default function WritePage() {
       // Land directly on the pending LLM node so NodeDetail anchors the
       // inline input below it and flips to the response in place.
       navigate(`/node/${llmNodeId}?awaitLlm=${llmNodeId}`);
+    } else if (data?.user_node_id) {
+      // Auto-generate off (#134): no LLM reply was created — land on the
+      // user's own entry. /textmode/start returns user_node_id (not id).
+      navigate(`/node/${data.user_node_id}`);
     } else if (data?.id) {
       // Fallback path (ai_usage not chat/train) — navigate to the plain
       // entry without the awaitLlm query param.


### PR DESCRIPTION
Closes #134.

Text mode (WritePage → `/textmode/start`) always fired an automatic first LLM reply because the request omitted `auto_generate`, so the backend applied its default of `True` — even when the user had auto-generate off. Now reads the shared `loore_auto_generate` preference and passes it through; also handles the no-LLM response shape (`user_node_id`) in `handleSuccess`.

**Verified end-to-end on staging (live API):** `auto_generate:false` → 202 with no `llm_node_id` (no AI reply); `auto_generate:true` → returns `llm_node_id` + `task_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
