### PR TITLE
Keep landing scroll cue visible + scroll-gated narrative fade-in (#98)

### DIFF
--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -81,7 +81,11 @@ const styles = {
       align-items: center;
       justify-content: flex-start;
       position: relative;
-      padding: 16vh 2rem 1.25rem;
+      /* Top padding clears the fixed 56px navbar and places the title in
+         the upper area, but stays small enough that title + CTA + the
+         bottom-pinned line all fit within one viewport (so the line is
+         inside the fold). padding-top was overshooting at 16vh. */
+      padding: clamp(4.5rem, 11vh, 10rem) 2rem 1.25rem;
       text-align: center;
     }
 

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -81,7 +81,7 @@ const styles = {
       align-items: center;
       justify-content: flex-start;
       position: relative;
-      padding: 16vh 2rem 3rem;
+      padding: 16vh 2rem 1.25rem;
       text-align: center;
     }
 

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -65,27 +65,21 @@ const styles = {
     }
 
     .loore-hero {
-      /* Full-height for a clean, undisturbed first view. vh -> svh -> dvh
-         cascade so mobile uses the actually-visible (toolbar-collapsed)
-         height. Content sits in the upper area (flex-start + padding-top)
-         and the scroll line is pinned to the bottom via margin-top:auto
-         on .loore-scroll-hint — in-flow (no iOS absolute-positioning bug)
-         yet at the hero bottom, so the first narrative section follows the
-         hero directly and "pops up" right away on scroll instead of after
-         a large empty band. (#98) */
-      min-height: 100vh;
-      min-height: 100svh;
-      min-height: 100dvh;
+      /* Content-sized hero (NOT forced to full viewport). The scroll line
+         sits a fixed ~40px below the CTA as part of this block — always
+         visible and close to the content on every screen — and the first
+         narrative section follows directly, so there's no dead band and
+         it "pops up" right away on scroll. Earlier full-height + either
+         absolute-bottom or margin-top:auto pinning put the line at the
+         screen edge (detached / below the fold across vh/svh/dvh). The
+         clamped top padding clears the fixed 56px navbar and keeps the
+         title in the upper area. (#98) */
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: flex-start;
       position: relative;
-      /* Top padding clears the fixed 56px navbar and places the title in
-         the upper area, but stays small enough that title + CTA + the
-         bottom-pinned line all fit within one viewport (so the line is
-         inside the fold). padding-top was overshooting at 16vh. */
-      padding: clamp(4.5rem, 11vh, 10rem) 2rem 1.25rem;
+      padding: clamp(5rem, 18vh, 14rem) 2rem clamp(3rem, 8vh, 6rem);
       text-align: center;
     }
 
@@ -140,14 +134,11 @@ const styles = {
     }
 
     .loore-scroll-hint {
-      /* In normal flow (NOT absolute — that kept landing the line at the
-         screen edge / below the fold across vh/svh/dvh). margin-top:auto
-         pushes it to the bottom of the full-height hero, so it's reliably
-         visible near the fold and the next section follows the hero
-         directly. min 2.5rem keeps clearance from the CTA on short
-         viewports where auto collapses. (#98) */
-      margin-top: auto;
-      padding-top: 2.5rem;
+      /* In normal flow, a fixed ~40px below the CTA (it follows the CTA in
+         the JSX). Not absolute and not margin-top:auto — both put the line
+         at the screen edge on tall viewports. Tied to the content, it's
+         reliably visible and close to the CTA on every screen. (#98) */
+      margin: 2.5rem auto 0;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -346,9 +337,9 @@ const styles = {
       .loore-preview { padding: 3rem 1rem 5rem; }
       .loore-mockup-content { padding: 1.5rem 1.2rem; }
 
-      /* Mobile hero: a touch tighter top than the base rule; line stays
-         bottom-pinned (margin-top:auto, base rule). Logo margin trimmed
-         so the title sits in the upper third. (#98) */
+      /* Mobile hero: a touch tighter top than the base rule. Logo margin
+         trimmed so the title sits in the upper third. The line stays
+         ~40px below the CTA (base rule). (#98) */
       .loore-hero {
         padding-top: 12vh;
         padding-bottom: 2rem;

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -65,21 +65,23 @@ const styles = {
     }
 
     .loore-hero {
-      /* Use dvh (dynamic viewport height) so the hero is exactly the
-         currently-visible area on mobile — with the browser toolbars
-         showing. 100vh (and even svh on some iOS builds) resolves taller
-         than what's visible, which pushed the centered content down (big
-         gap above the title) AND dropped the bottom-anchored scroll hint
-         below the fold. Fallback chain: vh -> svh -> dvh. (#98) */
+      /* Full-height for a clean, undisturbed first view. vh -> svh -> dvh
+         cascade so mobile uses the actually-visible (toolbar-collapsed)
+         height. Content sits in the upper area (flex-start + padding-top)
+         and the scroll line is pinned to the bottom via margin-top:auto
+         on .loore-scroll-hint — in-flow (no iOS absolute-positioning bug)
+         yet at the hero bottom, so the first narrative section follows the
+         hero directly and "pops up" right away on scroll instead of after
+         a large empty band. (#98) */
       min-height: 100vh;
       min-height: 100svh;
       min-height: 100dvh;
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       position: relative;
-      padding: 2rem;
+      padding: 16vh 2rem 3rem;
       text-align: center;
     }
 
@@ -134,12 +136,14 @@ const styles = {
     }
 
     .loore-scroll-hint {
-      /* In normal flow, just below the CTA (it follows the CTA in the
-         JSX). Earlier absolute/viewport-bottom anchoring kept landing the
-         line at the screen edge — cut off on desktop and below the fold on
-         mobile (across vh/svh/dvh). In-flow, it's tied to visible content
-         and is reliably visible on every viewport. (#98) */
-      margin: 2.5rem auto 0;
+      /* In normal flow (NOT absolute — that kept landing the line at the
+         screen edge / below the fold across vh/svh/dvh). margin-top:auto
+         pushes it to the bottom of the full-height hero, so it's reliably
+         visible near the fold and the next section follows the hero
+         directly. min 2.5rem keeps clearance from the CTA on short
+         viewports where auto collapses. (#98) */
+      margin-top: auto;
+      padding-top: 2.5rem;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -338,21 +342,14 @@ const styles = {
       .loore-preview { padding: 3rem 1rem 5rem; }
       .loore-mockup-content { padding: 1.5rem 1.2rem; }
 
-      /* Mobile hero: size to its content instead of forcing a full
-         viewport. With the content packed at the top and the scroll line
-         right after the CTA, a 100dvh hero left ~25% dead space between
-         the line and the first narrative section. Dropping the min-height
-         removes that gap so the narrative follows the line with the same
-         spacing as the other sections; padding-top keeps the title in the
-         upper third. (#98) */
+      /* Mobile hero: a touch tighter top than the base rule; line stays
+         bottom-pinned (margin-top:auto, base rule). Logo margin trimmed
+         so the title sits in the upper third. (#98) */
       .loore-hero {
-        min-height: auto;
-        justify-content: flex-start;
-        padding-top: 14vh;
-        padding-bottom: 1rem;
+        padding-top: 12vh;
+        padding-bottom: 2rem;
       }
       .loore-logo-mark { margin-bottom: 1.5rem; }
-      /* Scroll hint is in normal flow (base rule); no mobile override needed. */
     }
   `,
 };

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -150,17 +150,11 @@ const styles = {
     }
 
     .loore-scroll-line {
-      width: 1px;
-      height: 36px;
-      /* Brighter top stop so the cue reads clearly (was fading from the
-         very dim --text-muted); still tapers to transparent. */
-      background: linear-gradient(to bottom, var(--text-secondary), transparent);
-      animation: loore-pulse 2s ease-in-out infinite;
-    }
-
-    .loore-scroll-chevron {
-      color: var(--text-secondary);
-      margin-top: -0.2rem;
+      width: 2px;
+      height: 40px;
+      /* Brighter, more opaque gradient so the cue reads clearly (was
+         fading from the very dim --text-muted); still tapers off. */
+      background: linear-gradient(to bottom, var(--text-secondary), rgba(255,255,255,0.05));
       animation: loore-pulse 2s ease-in-out infinite;
     }
 
@@ -375,17 +369,6 @@ function LandingPage() {
           </div>
           <div className="loore-scroll-hint" aria-hidden="true">
             <div className="loore-scroll-line" />
-            <svg
-              className="loore-scroll-chevron"
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            >
-              <path d="M6 9l6 6 6-6" />
-            </svg>
           </div>
         </section>
 

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -1,30 +1,57 @@
 import React, { useState, useEffect, useRef } from "react";
 import CtaButton from "./CtaButton";
 
-function useOnScreen(ref, threshold = 0.15, rootMargin = "0px") {
+function useOnScreen(ref, threshold = 0.15) {
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => { if (entry.isIntersecting) setVisible(true); },
-      { threshold, rootMargin }
+      { threshold }
     );
     const el = ref.current;
     if (el) observer.observe(el);
     return () => { if (el) observer.unobserve(el); };
-  }, [ref, threshold, rootMargin]);
+  }, [ref, threshold]);
   return visible;
+}
+
+// True once the user has scrolled the page at all. On tall desktop
+// screens the whole first narrative section can fit within the initial
+// viewport, so an in-view check alone fades it in before any scroll. We
+// additionally gate on this so narrative sections only reveal after the
+// user initiates scrolling. Starts true if the page is already scrolled
+// (e.g. restored position / deep link). (#98)
+function useHasScrolled() {
+  const [scrolled, setScrolled] = useState(() =>
+    typeof window !== "undefined" && window.scrollY > 0
+  );
+  useEffect(() => {
+    if (scrolled) return undefined;
+    const onScroll = () => {
+      if (window.scrollY > 0) setScrolled(true);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    // Sync in case a scroll happened between render and effect.
+    if (window.scrollY > 0) setScrolled(true);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [scrolled]);
+  return scrolled;
 }
 
 function FadeSection({ children, delay = 0, className = "", style = {} }) {
   const ref = useRef(null);
-  // Negative bottom rootMargin shrinks the observer viewport from the
-  // bottom, so a section only fades in once it's scrolled ~15% of the way
-  // up into view — not while it's merely peeking at the very bottom edge.
-  // On desktop the content-sized hero lets the first section peek in on
-  // load, which previously triggered the fade before any scroll; this
-  // gates it on actual scrolling. Mobile (section fully below the fold)
-  // is unaffected. (#98)
-  const visible = useOnScreen(ref, 0.1, "0px 0px -15% 0px");
+  const inView = useOnScreen(ref, 0.1);
+  const hasScrolled = useHasScrolled();
+  // Reveal only when the section is in view AND the user has scrolled, so
+  // a section that already fits in the initial viewport (tall desktop)
+  // doesn't appear until scrolling begins. The reveal latches on (stays
+  // visible thereafter). Mobile is unaffected — its sections sit below
+  // the fold and only enter view after scrolling anyway. (#98)
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    if (inView && hasScrolled) setRevealed(true);
+  }, [inView, hasScrolled]);
+  const visible = revealed;
   return (
     <div
       ref={ref}

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -1,23 +1,30 @@
 import React, { useState, useEffect, useRef } from "react";
 import CtaButton from "./CtaButton";
 
-function useOnScreen(ref, threshold = 0.15) {
+function useOnScreen(ref, threshold = 0.15, rootMargin = "0px") {
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => { if (entry.isIntersecting) setVisible(true); },
-      { threshold }
+      { threshold, rootMargin }
     );
     const el = ref.current;
     if (el) observer.observe(el);
     return () => { if (el) observer.unobserve(el); };
-  }, [ref, threshold]);
+  }, [ref, threshold, rootMargin]);
   return visible;
 }
 
 function FadeSection({ children, delay = 0, className = "", style = {} }) {
   const ref = useRef(null);
-  const visible = useOnScreen(ref, 0.1);
+  // Negative bottom rootMargin shrinks the observer viewport from the
+  // bottom, so a section only fades in once it's scrolled ~15% of the way
+  // up into view — not while it's merely peeking at the very bottom edge.
+  // On desktop the content-sized hero lets the first section peek in on
+  // load, which previously triggered the fade before any scroll; this
+  // gates it on actual scrolling. Mobile (section fully below the fold)
+  // is unaffected. (#98)
+  const visible = useOnScreen(ref, 0.1, "0px 0px -15% 0px");
   return (
     <div
       ref={ref}

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -65,7 +65,10 @@ const styles = {
     }
 
     .loore-hero {
-      min-height: 100vh;
+      /* svh tracks the *small* (mobile browser-chrome-collapsed) viewport
+         so the absolutely-positioned scroll hint isn't pushed off-screen
+         on phones, where 100vh overestimates the visible height (#98). */
+      min-height: 100svh;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -73,6 +76,10 @@ const styles = {
       position: relative;
       padding: 2rem;
       text-align: center;
+    }
+
+    @supports not (height: 100svh) {
+      .loore-hero { min-height: 100vh; }
     }
 
     .loore-hero-grain {
@@ -127,21 +134,33 @@ const styles = {
 
     .loore-scroll-hint {
       position: absolute;
-      bottom: 2.5rem;
+      /* Clamp to the bottom but never closer than the device safe-area
+         inset (home indicator), and keep it on-screen on short viewports
+         (#98). */
+      bottom: max(1.25rem, env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.35rem;
       opacity: 0;
       animation: loore-fade-down 1s ease 1.5s forwards;
+      cursor: default;
     }
 
     .loore-scroll-line {
       width: 1px;
-      height: 40px;
-      background: linear-gradient(to bottom, var(--text-muted), transparent);
+      height: 36px;
+      /* Brighter top stop so the cue reads clearly (was fading from the
+         very dim --text-muted); still tapers to transparent. */
+      background: linear-gradient(to bottom, var(--text-secondary), transparent);
+      animation: loore-pulse 2s ease-in-out infinite;
+    }
+
+    .loore-scroll-chevron {
+      color: var(--text-secondary);
+      margin-top: -0.2rem;
       animation: loore-pulse 2s ease-in-out infinite;
     }
 
@@ -151,8 +170,8 @@ const styles = {
     }
 
     @keyframes loore-pulse {
-      0%, 100% { opacity: 0.3; }
-      50% { opacity: 0.8; }
+      0%, 100% { opacity: 0.5; }
+      50% { opacity: 1; }
     }
 
     /* Narrative sections */
@@ -354,8 +373,19 @@ function LandingPage() {
           }}>
             <CtaButton href="/login?returnUrl=%2F">Join the Alpha</CtaButton>
           </div>
-          <div className="loore-scroll-hint">
+          <div className="loore-scroll-hint" aria-hidden="true">
             <div className="loore-scroll-line" />
+            <svg
+              className="loore-scroll-chevron"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
           </div>
         </section>
 

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -65,10 +65,15 @@ const styles = {
     }
 
     .loore-hero {
-      /* svh tracks the *small* (mobile browser-chrome-collapsed) viewport
-         so the absolutely-positioned scroll hint isn't pushed off-screen
-         on phones, where 100vh overestimates the visible height (#98). */
+      /* Use dvh (dynamic viewport height) so the hero is exactly the
+         currently-visible area on mobile — with the browser toolbars
+         showing. 100vh (and even svh on some iOS builds) resolves taller
+         than what's visible, which pushed the centered content down (big
+         gap above the title) AND dropped the bottom-anchored scroll hint
+         below the fold. Fallback chain: vh -> svh -> dvh. (#98) */
+      min-height: 100vh;
       min-height: 100svh;
+      min-height: 100dvh;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -76,10 +81,6 @@ const styles = {
       position: relative;
       padding: 2rem;
       text-align: center;
-    }
-
-    @supports not (height: 100svh) {
-      .loore-hero { min-height: 100vh; }
     }
 
     .loore-hero-grain {
@@ -337,6 +338,16 @@ const styles = {
       .loore-section { padding: 4rem 0; }
       .loore-preview { padding: 3rem 1rem 5rem; }
       .loore-mockup-content { padding: 1.5rem 1.2rem; }
+
+      /* Mobile hero: tighten the top so the title sits higher (less dead
+         space above it) and leave clear room at the bottom for the scroll
+         hint to be visible above the fold. (#98) */
+      .loore-hero {
+        justify-content: flex-start;
+        padding-top: 18vh;
+        padding-bottom: 5rem;
+      }
+      .loore-logo-mark { margin-bottom: 1.5rem; }
     }
   `,
 };

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -340,14 +340,25 @@ const styles = {
       .loore-mockup-content { padding: 1.5rem 1.2rem; }
 
       /* Mobile hero: tighten the top so the title sits higher (less dead
-         space above it) and leave clear room at the bottom for the scroll
-         hint to be visible above the fold. (#98) */
+         space above it). (#98) */
       .loore-hero {
         justify-content: flex-start;
-        padding-top: 18vh;
-        padding-bottom: 5rem;
+        padding-top: 14vh;
+        padding-bottom: 3rem;
       }
       .loore-logo-mark { margin-bottom: 1.5rem; }
+
+      /* Mobile scroll hint: take it OUT of absolute/viewport-bottom
+         anchoring (which kept landing below the fold whenever iOS resolved
+         the hero taller than the visible area, across vh/svh/dvh alike) and
+         let it flow right after the CTA. Tied to visible content, it can't
+         fall off-screen, and still signals "more below". (#98) */
+      .loore-scroll-hint {
+        position: static;
+        transform: none;
+        bottom: auto;
+        margin: 2.5rem auto 0;
+      }
     }
   `,
 };

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -134,13 +134,12 @@ const styles = {
     }
 
     .loore-scroll-hint {
-      position: absolute;
-      /* Clamp to the bottom but never closer than the device safe-area
-         inset (home indicator), and keep it on-screen on short viewports
-         (#98). */
-      bottom: max(1.25rem, env(safe-area-inset-bottom));
-      left: 50%;
-      transform: translateX(-50%);
+      /* In normal flow, just below the CTA (it follows the CTA in the
+         JSX). Earlier absolute/viewport-bottom anchoring kept landing the
+         line at the screen edge — cut off on desktop and below the fold on
+         mobile (across vh/svh/dvh). In-flow, it's tied to visible content
+         and is reliably visible on every viewport. (#98) */
+      margin: 2.5rem auto 0;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -339,26 +338,21 @@ const styles = {
       .loore-preview { padding: 3rem 1rem 5rem; }
       .loore-mockup-content { padding: 1.5rem 1.2rem; }
 
-      /* Mobile hero: tighten the top so the title sits higher (less dead
-         space above it). (#98) */
+      /* Mobile hero: size to its content instead of forcing a full
+         viewport. With the content packed at the top and the scroll line
+         right after the CTA, a 100dvh hero left ~25% dead space between
+         the line and the first narrative section. Dropping the min-height
+         removes that gap so the narrative follows the line with the same
+         spacing as the other sections; padding-top keeps the title in the
+         upper third. (#98) */
       .loore-hero {
+        min-height: auto;
         justify-content: flex-start;
         padding-top: 14vh;
-        padding-bottom: 3rem;
+        padding-bottom: 1rem;
       }
       .loore-logo-mark { margin-bottom: 1.5rem; }
-
-      /* Mobile scroll hint: take it OUT of absolute/viewport-bottom
-         anchoring (which kept landing below the fold whenever iOS resolved
-         the hero taller than the visible area, across vh/svh/dvh alike) and
-         let it flow right after the CTA. Tied to visible content, it can't
-         fall off-screen, and still signals "more below". (#98) */
-      .loore-scroll-hint {
-        position: static;
-        transform: none;
-        bottom: auto;
-        margin: 2.5rem auto 0;
-      }
+      /* Scroll hint is in normal flow (base rule); no mobile override needed. */
     }
   `,
 };


### PR DESCRIPTION
Closes #98.

The landing-page scroll cue (the pulsing vertical line) was faint and, more importantly, kept landing off-screen / below the fold across mobile and desktop, and the first narrative section appeared before the user scrolled.

Changes:
- Higher-contrast scroll line (no chevron, per feedback).
- Content-sized hero with the scroll line a fixed ~40px below the CTA on **all** viewports — reliably visible and close to the content (earlier absolute-bottom / `margin-top:auto` / full-height approaches put it at the screen edge or below the fold across vh/svh/dvh).
- Narrative sections now reveal only after the user **initiates scrolling** (`useHasScrolled()` gate), fixing the desktop case where the whole first section fits in the initial viewport and previously faded in before any scroll. Reveal latches on; mobile unaffected.

**Verified on staging (logged-out), desktop + mobile:** line visible ~40px below CTA in the first view; narrative hidden at scrollY=0, fades in after scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
