### PR TITLE
Claude import: client-side extraction + import progress indicator (#137, #135)

### DIFF
--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -491,11 +491,15 @@ def analyze_twitter_import():
 @login_required
 def analyze_claude_import():
     """
-    Analyze a Claude data export zip file.
+    Analyze a Claude conversations.json file.
+
+    The client extracts conversations.json from the Claude export zip
+    in the browser and uploads only that file, so the full (potentially
+    large) export never has to traverse the network.
 
     Expects:
-        - multipart/form-data with 'zip_file' field containing a Claude
-          data export (contains conversations.json)
+        - multipart/form-data with 'conversations_file' field containing
+          the conversations.json extracted from a Claude data export
 
     Returns:
         {
@@ -520,33 +524,22 @@ def analyze_claude_import():
             "total_size": N
         }
     """
-    if 'zip_file' not in request.files:
-        return jsonify({"error": "No zip_file provided"}), 400
+    if 'conversations_file' not in request.files:
+        return jsonify({"error": "No conversations_file provided"}), 400
 
-    zip_file = request.files['zip_file']
+    conv_file = request.files['conversations_file']
 
-    if zip_file.filename == '':
+    if conv_file.filename == '':
         return jsonify({"error": "No file selected"}), 400
 
-    if not zip_file.filename.lower().endswith('.zip'):
-        return jsonify({"error": "File must be a .zip file"}), 400
-
     try:
-        zip_bytes = io.BytesIO(zip_file.read())
-
-        conversations_json = None
-
-        with zipfile.ZipFile(zip_bytes, 'r') as zip_ref:
-            for name in zip_ref.namelist():
-                if name.endswith('conversations.json'):
-                    conversations_json = zip_ref.read(name).decode('utf-8')
-                    break
-
-        if conversations_json is None:
-            return jsonify({
-                "error": "Could not find conversations.json in the zip "
-                         "archive. Please upload a Claude data export."
-            }), 400
+        conversations_bytes = conv_file.read()
+        current_app.logger.info(
+            "Claude import: size_bytes=%d user_id=%s",
+            len(conversations_bytes),
+            getattr(current_user, 'id', None),
+        )
+        conversations_json = conversations_bytes.decode('utf-8')
 
         raw_conversations = json.loads(conversations_json)
 
@@ -607,8 +600,11 @@ def analyze_claude_import():
             "total_size": total_size
         }), 200
 
-    except zipfile.BadZipFile:
-        return jsonify({"error": "Invalid zip file"}), 400
+    except UnicodeDecodeError as e:
+        return jsonify({
+            "error": "conversations.json is not valid UTF-8",
+            "details": str(e)
+        }), 400
     except json.JSONDecodeError as e:
         return jsonify({
             "error": "Failed to parse conversations JSON",

--- a/backend/tests/test_claude_import.py
+++ b/backend/tests/test_claude_import.py
@@ -1,0 +1,302 @@
+"""Tests for the Claude import analyze endpoint.
+
+The client extracts conversations.json from the Claude export zip in the
+browser and uploads only that file, so the analyze endpoint now reads the
+JSON field directly (no zip handling).
+
+Covers POST /api/import/claude/analyze:
+- request shape validation (missing field, empty filename)
+- JSON parse errors
+- empty-conversations case
+- happy path (single + multiple conversations)
+- login required
+"""
+
+import io
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+import flask_login as _real_flask_login          # noqa: E402
+from backend.extensions import db as _db         # noqa: E402
+from backend.models import User                  # noqa: E402
+import backend.models as _real_backend_models    # noqa: E402
+
+
+def _make_app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+
+    _db.init_app(app)
+
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.import_data import import_bp
+    app.register_blueprint(import_bp, url_prefix="/api")
+
+    return app
+
+
+@pytest.fixture
+def app():
+    _affected = lambda k: (  # noqa: E731
+        k == "flask_login"
+        or k.startswith("backend.routes")
+        or k == "backend.models"
+    )
+    saved = {k: sys.modules[k] for k in list(sys.modules) if _affected(k)}
+
+    sys.modules["flask_login"] = _real_flask_login
+    sys.modules["backend.models"] = _real_backend_models
+    for _k in [k for k in list(sys.modules) if k.startswith("backend.routes")]:
+        del sys.modules[_k]
+
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+    for k in [k for k in list(sys.modules) if _affected(k)]:
+        if k not in saved:
+            del sys.modules[k]
+    for k, mod in saved.items():
+        sys.modules[k] = mod
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+        sess["_fresh"] = True
+
+
+def _make_user(username, **kwargs):
+    u = User(username=username, approved=True, plan="alpha", **kwargs)
+    _db.session.add(u)
+    _db.session.flush()
+    return u
+
+
+def _post_conversations(client, raw_conversations):
+    payload = json.dumps(raw_conversations).encode("utf-8")
+    data = {
+        "conversations_file": (io.BytesIO(payload), "conversations.json"),
+    }
+    return client.post(
+        "/api/import/claude/analyze",
+        data=data,
+        content_type="multipart/form-data",
+    )
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+def _msg(text="hello", sender="human", created_at="2023-11-14T22:13:20Z"):
+    return {
+        "text": text,
+        "sender": sender,
+        "created_at": created_at,
+    }
+
+
+def _conv(name="First chat", created_at="2023-11-14T22:13:20Z",
+          chat_messages=None):
+    if chat_messages is None:
+        chat_messages = [
+            _msg(text="hello world", sender="human"),
+            _msg(text="hi there, friend", sender="assistant"),
+        ]
+    return {
+        "name": name,
+        "created_at": created_at,
+        "chat_messages": chat_messages,
+    }
+
+
+# ── POST /api/import/claude/analyze ──────────────────────────────────────
+
+class TestAnalyzeClaudeImport:
+    def test_rejects_missing_field(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        resp = client.post(
+            "/api/import/claude/analyze",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        assert "conversations_file" in resp.get_json()["error"]
+
+    def test_rejects_empty_filename(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        data = {
+            "conversations_file": (io.BytesIO(b"[]"), ""),
+        }
+        resp = client.post(
+            "/api/import/claude/analyze",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+
+    def test_rejects_invalid_json(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        data = {
+            "conversations_file": (
+                io.BytesIO(b"{not json"),
+                "conversations.json",
+            ),
+        }
+        resp = client.post(
+            "/api/import/claude/analyze",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert "parse" in body["error"].lower()
+        assert "details" in body
+
+    def test_empty_array_returns_400(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        resp = _post_conversations(client, [])
+        assert resp.status_code == 400
+        assert "No conversations" in resp.get_json()["error"]
+
+    def test_conversation_without_messages_is_skipped(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        # A conversation whose only message has blank text yields no
+        # usable messages → endpoint reports no conversations.
+        resp = _post_conversations(
+            client,
+            [_conv(chat_messages=[_msg(text="   ")])],
+        )
+        assert resp.status_code == 400
+        assert "No conversations" in resp.get_json()["error"]
+
+    def test_happy_path_single_conversation(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        resp = _post_conversations(
+            client,
+            [_conv(name="First chat")],
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["total_conversations"] == 1
+        assert body["total_messages"] == 2
+        assert body["total_tokens"] > 0
+        assert body["total_size"] > 0
+        conv = body["conversations"][0]
+        assert conv["name"] == "First chat"
+        assert conv["message_count"] == 2
+        senders = [m["sender"] for m in conv["messages"]]
+        assert senders == ["human", "assistant"]
+        texts = [m["text"] for m in conv["messages"]]
+        assert texts == ["hello world", "hi there, friend"]
+
+    def test_happy_path_multiple_conversations(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        resp = _post_conversations(
+            client,
+            [
+                _conv(name="A"),
+                _conv(name="B"),
+            ],
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["total_conversations"] == 2
+        assert body["total_messages"] == 4
+        names = [c["name"] for c in body["conversations"]]
+        assert names == ["A", "B"]
+
+    def test_blank_messages_filtered_within_conversation(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        resp = _post_conversations(
+            client,
+            [
+                _conv(
+                    name="Mixed",
+                    chat_messages=[
+                        _msg(text="real question", sender="human"),
+                        _msg(text="   ", sender="assistant"),
+                        _msg(text="real answer", sender="assistant"),
+                    ],
+                ),
+            ],
+        )
+        assert resp.status_code == 200
+        body = resp.get_json()
+        # Blank message dropped → 2 usable messages remain.
+        assert body["total_messages"] == 2
+        conv = body["conversations"][0]
+        assert conv["message_count"] == 2
+        texts = [m["text"] for m in conv["messages"]]
+        assert texts == ["real question", "real answer"]
+
+    def test_requires_login(self, app):
+        client = app.test_client()
+        resp = _post_conversations(client, [])
+        # flask_login redirects unauthenticated requests (302/401).
+        assert resp.status_code in (302, 401)

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -466,22 +466,36 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
         const importOptions = (
           <div style={{ display: "flex", flexDirection: "column", gap: "0.6rem" }}>
-            <label style={importLabelStyle}>
-              Import Claude
-              <input type="file" accept=".zip" onChange={handleClaudeImportFile} disabled={importing} style={{ display: "none" }} />
-            </label>
-            <label style={importLabelStyle}>
-              Import ChatGPT
-              <input type="file" accept=".zip" onChange={handleChatGPTImportFile} disabled={importing} style={{ display: "none" }} />
-            </label>
-            <label style={importLabelStyle}>
-              Import Markdown (e.g. Obsidian)
-              <input type="file" accept=".zip" onChange={handleImportFile} disabled={importing} style={{ display: "none" }} />
-            </label>
-            <label style={importLabelStyle}>
-              Import Tweets
-              <input type="file" accept=".zip" onChange={handleTwitterImportFile} disabled={importing} style={{ display: "none" }} />
-            </label>
+            {importing ? (
+              // Pre-dialog progress. While we extract the zip client-side and
+              // upload the conversations blob for analysis, the buttons are
+              // disabled and no dialog has appeared yet — without this the page
+              // looks frozen (esp. large Claude/ChatGPT zips, where extraction
+              // takes a few seconds). The .spin transform keeps animating on
+              // the compositor thread even while extraction is busy.
+              <div style={{ ...importLabelStyle, opacity: 1, cursor: "default", color: "var(--accent)" }}>
+                <ImportSpinner stage={importStage} fallback="Working…" />
+              </div>
+            ) : (
+              <>
+                <label style={importLabelStyle}>
+                  Import Claude
+                  <input type="file" accept=".zip" onChange={handleClaudeImportFile} style={{ display: "none" }} />
+                </label>
+                <label style={importLabelStyle}>
+                  Import ChatGPT
+                  <input type="file" accept=".zip" onChange={handleChatGPTImportFile} style={{ display: "none" }} />
+                </label>
+                <label style={importLabelStyle}>
+                  Import Markdown (e.g. Obsidian)
+                  <input type="file" accept=".zip" onChange={handleImportFile} style={{ display: "none" }} />
+                </label>
+                <label style={importLabelStyle}>
+                  Import Tweets
+                  <input type="file" accept=".zip" onChange={handleTwitterImportFile} style={{ display: "none" }} />
+                </label>
+              </>
+            )}
           </div>
         );
 

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import ReactDOM from "react-dom";
 import JSZip from "jszip";
+import { FaSpinner } from "react-icons/fa";
 import api from "../api";
 import PrivacySelector from "./PrivacySelector";
 
@@ -37,6 +38,18 @@ function importErr(userMessage) {
   const e = new Error(userMessage);
   e.userMessage = userMessage;
   return e;
+}
+
+// A spinning icon + stage label, shown inside import buttons while an
+// import is in flight. `stage` is one of STAGE_LABELS' keys; falls back to
+// the provided label when the stage is unknown.
+function ImportSpinner({ stage, fallback }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: "0.4em" }}>
+      <FaSpinner className="spin" aria-hidden="true" />
+      {STAGE_LABELS[stage] || fallback}
+    </span>
+  );
 }
 
 // Extract the conversations.json blob from a Claude/ChatGPT export zip in
@@ -137,6 +150,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     formData.append("zip_file", file);
 
     setImporting(true);
+    setImportStage("analyzing");
     setShowPicker(false);
     api.post("/import/analyze", formData, {
       headers: { "Content-Type": "multipart/form-data" }
@@ -145,11 +159,13 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setImportFiles(response.data);
         setShowImportDialog(true);
         setImporting(false);
+        setImportStage(null);
       })
       .catch((err) => {
         console.error("Error analyzing import file:", err);
         setError(err.response?.data?.error || "Error analyzing import file. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -157,6 +173,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     if (!importFiles) return;
 
     setImporting(true);
+    setImportStage("importing");
     api.post("/import/confirm", {
       files: importFiles.files,
       import_type: importType,
@@ -168,6 +185,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setShowImportDialog(false);
         setImportFiles(null);
         setImporting(false);
+        setImportStage(null);
         setError("");
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
@@ -178,6 +196,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         console.error("Error importing data:", err);
         setError(err.response?.data?.error || "Error importing data. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -194,6 +213,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     formData.append("zip_file", file);
 
     setImporting(true);
+    setImportStage("analyzing");
     setShowPicker(false);
     api.post("/import/twitter/analyze", formData, {
       headers: { "Content-Type": "multipart/form-data" }
@@ -202,11 +222,13 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setTwitterImportData(response.data);
         setShowTwitterImportDialog(true);
         setImporting(false);
+        setImportStage(null);
       })
       .catch((err) => {
         console.error("Error analyzing Twitter import:", err);
         setError(err.response?.data?.error || "Error analyzing Twitter export. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
 
     event.target.value = "";
@@ -216,6 +238,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     if (!twitterImportData) return;
 
     setImporting(true);
+    setImportStage("importing");
     api.post("/import/twitter/confirm", {
       tweets: twitterImportData.tweets,
       import_type: importType,
@@ -227,6 +250,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setShowTwitterImportDialog(false);
         setTwitterImportData(null);
         setImporting(false);
+        setImportStage(null);
         setError("");
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
@@ -237,6 +261,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         console.error("Error importing Twitter data:", err);
         setError(err.response?.data?.error || "Error importing Twitter data. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -294,6 +319,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     if (!claudeImportData) return;
 
     setImporting(true);
+    setImportStage("importing");
     api.post("/import/claude/confirm", {
       conversations: claudeImportData.conversations,
       privacy_level: importPrivacy,
@@ -303,6 +329,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setShowClaudeImportDialog(false);
         setClaudeImportData(null);
         setImporting(false);
+        setImportStage(null);
         setError("");
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
@@ -313,6 +340,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         console.error("Error importing Claude data:", err);
         setError(err.response?.data?.error || "Error importing Claude data. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -327,34 +355,28 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     if (!file) return;
 
     setImporting(true);
+    setImportStage("extracting");
     setShowPicker(false);
 
     let conversationsBlob;
     try {
-      const zip = await JSZip.loadAsync(file);
-      const entry = Object.values(zip.files).find(
-        (f) => !f.dir && f.name.endsWith("conversations.json")
-      );
-      if (!entry) {
-        setError(
-          "Could not find conversations.json in the zip archive. Please upload the original ChatGPT data export."
-        );
-        setImporting(false);
-        return;
-      }
-      conversationsBlob = await entry.async("blob");
+      conversationsBlob = await extractConversationsBlob(file);
     } catch (err) {
       console.error("Error reading ChatGPT export zip:", err);
       setError(
-        "Could not read the zip file. Please make sure it's a valid ChatGPT data export."
+        err && err.userMessage
+          ? err.userMessage
+          : "Could not read the zip file. Please make sure it's a valid ChatGPT data export."
       );
       setImporting(false);
+      setImportStage(null);
       return;
     }
 
     const formData = new FormData();
     formData.append("conversations_file", conversationsBlob, "conversations.json");
 
+    setImportStage("analyzing");
     api.post("/import/chatgpt/analyze", formData, {
       headers: { "Content-Type": "multipart/form-data" }
     })
@@ -362,6 +384,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setChatGPTImportData(response.data);
         setShowChatGPTImportDialog(true);
         setImporting(false);
+        setImportStage(null);
       })
       .catch((err) => {
         console.error("Error analyzing ChatGPT import:", err);
@@ -382,6 +405,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         }
         setError(msg);
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -389,6 +413,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     if (!chatGPTImportData) return;
 
     setImporting(true);
+    setImportStage("importing");
     api.post("/import/chatgpt/confirm", {
       conversations: chatGPTImportData.conversations,
       privacy_level: importPrivacy,
@@ -398,6 +423,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setShowChatGPTImportDialog(false);
         setChatGPTImportData(null);
         setImporting(false);
+        setImportStage(null);
         setError("");
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
@@ -408,6 +434,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         console.error("Error importing ChatGPT data:", err);
         setError(err.response?.data?.error || "Error importing ChatGPT data. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
   };
 
@@ -480,7 +507,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                 }}
               >
                 {importing
-                  ? (STAGE_LABELS[importStage] || "Analyzing…")
+                  ? <ImportSpinner stage={importStage} fallback="Analyzing…" />
                   : (buttonLabel || "Import Data")}
               </button>
             )}
@@ -635,7 +662,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                 opacity: importing ? 0.6 : 1
               }}
             >
-              {importing ? "Importing..." : "Confirm Import"}
+              {importing ? <ImportSpinner stage={importStage} fallback="Importing…" /> : "Confirm Import"}
             </button>
             <button
               onClick={handleCancelImport}
@@ -690,7 +717,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                 opacity: importing ? 0.6 : 1
               }}
             >
-              {importing ? "Importing..." : "Confirm Import"}
+              {importing ? <ImportSpinner stage={importStage} fallback="Importing…" /> : "Confirm Import"}
             </button>
             <button
               onClick={handleCancelClaudeImport}
@@ -745,7 +772,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                 opacity: importing ? 0.6 : 1
               }}
             >
-              {importing ? "Importing..." : "Confirm Import"}
+              {importing ? <ImportSpinner stage={importStage} fallback="Importing…" /> : "Confirm Import"}
             </button>
             <button
               onClick={handleCancelChatGPTImport}
@@ -858,7 +885,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                 opacity: importing ? 0.6 : 1
               }}
             >
-              {importing ? "Importing..." : "Confirm Import"}
+              {importing ? <ImportSpinner stage={importStage} fallback="Importing…" /> : "Confirm Import"}
             </button>
             <button
               onClick={handleCancelTwitterImport}

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -26,6 +26,74 @@ const cancelBtnStyle = {
   ...ghostBtnStyle,
 };
 
+// Coarse stage labels shown while an import is in flight.
+const STAGE_LABELS = {
+  extracting: "Extracting…",
+  analyzing: "Analyzing…",
+  importing: "Importing…",
+};
+
+function importErr(userMessage) {
+  const e = new Error(userMessage);
+  e.userMessage = userMessage;
+  return e;
+}
+
+// Extract the conversations.json blob from a Claude/ChatGPT export zip in
+// the browser, so the full (potentially multi-GB) export with images/audio
+// never has to traverse the network.
+//
+// Entry matching is intentionally flexible:
+//   1. Prefer a file entry whose name ends with "conversations.json".
+//   2. Otherwise fall back to the largest .json entry whose parsed
+//      top-level value is an array (the export's conversation list).
+// Throws an Error with a `.userMessage` if no suitable entry is found or
+// the zip cannot be read.
+async function extractConversationsBlob(file) {
+  let zip;
+  try {
+    zip = await JSZip.loadAsync(file);
+  } catch {
+    throw importErr(
+      "Could not read the zip file. Please make sure it's a valid data export."
+    );
+  }
+
+  const entries = Object.values(zip.files).filter((f) => !f.dir);
+
+  const named = entries.find((f) => f.name.endsWith("conversations.json"));
+  if (named) {
+    return named.async("blob");
+  }
+
+  // Fallback: among .json entries, pick the largest whose top-level
+  // parsed value is an array. Sort by uncompressed size descending so we
+  // parse the most likely candidate first.
+  const jsonEntries = entries
+    .filter((f) => f.name.toLowerCase().endsWith(".json"))
+    .sort((a, b) => {
+      const sa = (a._data && a._data.uncompressedSize) || 0;
+      const sb = (b._data && b._data.uncompressedSize) || 0;
+      return sb - sa;
+    });
+
+  for (const entry of jsonEntries) {
+    try {
+      const text = await entry.async("string");
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return new Blob([text], { type: "application/json" });
+      }
+    } catch {
+      // Not valid JSON or not an array — keep looking.
+    }
+  }
+
+  throw importErr(
+    "Could not find conversations.json in the zip archive. Please upload the original data export."
+  );
+}
+
 export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel, buttonHoverStyle, onProfileUpdateStarted, inline }) {
   const btnStyle = customButtonStyle || ghostBtnStyle;
   const [hovered, setHovered] = useState(false);
@@ -34,6 +102,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
   const [importType, setImportType] = useState("separate_nodes");
   const [dateOrdering, setDateOrdering] = useState("modified");
   const [importing, setImporting] = useState(false);
+  const [importStage, setImportStage] = useState(null);
   const [importPrivacy, setImportPrivacy] = useState("private");
   const [importAiUsage, setImportAiUsage] = useState("none");
   const [error, setError] = useState("");
@@ -176,15 +245,34 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     setTwitterImportData(null);
   };
 
-  const handleClaudeImportFile = (event) => {
+  const handleClaudeImportFile = async (event) => {
     const file = event.target.files[0];
+    event.target.value = "";
     if (!file) return;
 
-    const formData = new FormData();
-    formData.append("zip_file", file);
-
     setImporting(true);
+    setImportStage("extracting");
     setShowPicker(false);
+
+    let conversationsBlob;
+    try {
+      conversationsBlob = await extractConversationsBlob(file);
+    } catch (err) {
+      console.error("Error reading Claude export zip:", err);
+      setError(
+        err && err.userMessage
+          ? err.userMessage
+          : "Could not read the zip file. Please make sure it's a valid Claude data export."
+      );
+      setImporting(false);
+      setImportStage(null);
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("conversations_file", conversationsBlob, "conversations.json");
+
+    setImportStage("analyzing");
     api.post("/import/claude/analyze", formData, {
       headers: { "Content-Type": "multipart/form-data" }
     })
@@ -192,14 +280,14 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         setClaudeImportData(response.data);
         setShowClaudeImportDialog(true);
         setImporting(false);
+        setImportStage(null);
       })
       .catch((err) => {
         console.error("Error analyzing Claude import:", err);
         setError(err.response?.data?.error || "Error analyzing Claude export. Please try again.");
         setImporting(false);
+        setImportStage(null);
       });
-
-    event.target.value = "";
   };
 
   const handleConfirmClaudeImport = () => {
@@ -391,7 +479,9 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
                   opacity: importing ? 0.6 : 1,
                 }}
               >
-                {importing ? "Analyzing..." : (buttonLabel || "Import Data")}
+                {importing
+                  ? (STAGE_LABELS[importStage] || "Analyzing…")
+                  : (buttonLabel || "Import Data")}
               </button>
             )}
 


### PR DESCRIPTION
## Summary

Import stream from a batched, staging-verified effort. Both issues touch `ImportData.js`, kept on one branch.

- **#137 — Claude import: client-side extraction (oversized-zip fix).** Ports the merged ChatGPT fix (`f6d329e`) to the Claude path: extract the conversations JSON in the browser with `JSZip.loadAsync` and POST only the blob (`conversations_file`) to `/import/claude/analyze`, instead of uploading the whole zip (which 413s past the 200 MB nginx limit and pressures server memory). A shared `extractConversationsBlob` helper does flexible entry matching — prefer an entry ending in `conversations.json`, else fall back to the largest `.json` whose top-level value is an array — and shows a **clear error on extraction failure** rather than silently uploading the raw zip. Backend `/import/claude/analyze` rewritten to read `conversations_file` as JSON directly (all zip handling removed). New `backend/tests/test_claude_import.py` mirrors the ChatGPT suite.
- **#135 — Import progress indicator.** `importStage` (`extracting → analyzing → importing`) + an `ImportSpinner` on the main import buttons and every Confirm button, across **all** import paths (ChatGPT, Claude, Twitter, Markdown). Every `setImporting(true)` is paired with a stage and cleared on all success/error/early-return paths. Frontend-only (no SSE/polling rework).

## Staging verification (staging.loore.org, bundle `main.0948b6ae.js`)

- #137 backend (live): `POST /api/import/claude/analyze` with a JSON `conversations_file` → **200** (parsed 1 conv / 2 msgs); the old `zip_file`-only request → **400 "No conversations_file provided"** (raw-zip path is gone). Unit tests: 9 passed (request shape, JSON errors, empty, happy path single/multiple, login). Real Claude export confirmed to carry a top-level `conversations.json` (matcher correct). ✅
- #137 / #135 frontend: `JSZip`/`loadAsync`/`conversations_file`/flexible-matcher + the "Could not read the zip" / "Could not find conversations.json" errors + `Extracting`/`Analyzing`/`Importing` stage labels all present in the deployed bundle. ✅
- **Not exercised:** the in-browser file-picker upload (incl. the 204 MB over-limit case) and the visual spinner — the Chrome automation extension blocks programmatic file uploads. Worth a ~1-min manual spot-check on staging before/after merge.

Per-issue commits preserved: `3a49758` (#137), `9901fa1` (#135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
