### PR TITLE
Deduplicate imported data (re-imports + snapshot overlap) (#136)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -244,6 +244,10 @@ class Node(db.Model):
     # Soft-delete: non-NULL means scheduled for cleanup after SOFT_DELETE_GRACE_DAYS.
     deleted_at = db.Column(db.DateTime, nullable=True, index=True)
 
+    # Stable per-message identity used to deduplicate imported data.
+    # Scoped per user (see import_data.py). NULL for natively-created nodes.
+    source_key = db.Column(db.String(255), nullable=True, index=True)
+
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -245,8 +245,20 @@ class Node(db.Model):
     deleted_at = db.Column(db.DateTime, nullable=True, index=True)
 
     # Stable per-message identity used to deduplicate imported data.
-    # Scoped per user (see import_data.py). NULL for natively-created nodes.
+    # Scoped per importing human (see import_data.py). NULL for
+    # natively-created nodes. Keys are short ("chatgpt:<uuid>") or a
+    # sha256 hex digest, so they always fit String(255).
     source_key = db.Column(db.String(255), nullable=True, index=True)
+
+    # DB-level backstop against concurrent imports racing past the
+    # application dedup check. NULL source_key rows are exempt (both
+    # PostgreSQL and SQLite treat NULLs as distinct in unique indexes).
+    __table_args__ = (
+        db.UniqueConstraint(
+            "human_owner_id", "source_key",
+            name="uq_node_human_owner_source_key",
+        ),
+    )
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -116,12 +116,14 @@ def _deleted_match_response(keys, deleted_keys, on_deleted):
     }), 409
 
 
-def _restore_node(node_id, content, token_count=None):
+def _restore_node(node_id, content, privacy_level, ai_usage,
+                  token_count=None):
     """Un-delete a soft-deleted imported node in place.
 
     Refills content from the archive — this also recovers tombstones
     whose content was already wiped by the cleanup task — and keeps the
-    node id, so existing child links stay intact.
+    node id, so existing child links stay intact. Privacy/AI-usage are
+    set to this import's choices, like any other (re)imported node.
     """
     node = Node.query.get(node_id)
     node.content = content
@@ -129,7 +131,37 @@ def _restore_node(node_id, content, token_count=None):
         token_count if token_count is not None
         else approximate_token_count(content)
     )
+    node.privacy_level = privacy_level
+    node.ai_usage = ai_usage
     node.deleted_at = None
+
+
+def _apply_settings_to_skipped(node_ids, privacy_level, ai_usage):
+    """Apply this import's privacy/ai_usage to already-imported nodes.
+
+    Re-importing an archive is also how users change their mind about
+    import settings, so dedup-skipped (alive) nodes adopt the values
+    chosen for this import instead of being a pure no-op. Returns the
+    number of nodes whose settings actually changed; callers report it
+    as ``updated`` and keep it disjoint from ``skipped``.
+    """
+    from sqlalchemy import or_
+    ids = [i for i in node_ids if i is not None]
+    updated = 0
+    # Chunked so a huge archive doesn't produce an unbounded IN clause.
+    for start in range(0, len(ids), 1000):
+        chunk = ids[start:start + 1000]
+        updated += Node.query.filter(
+            Node.id.in_(chunk),
+            or_(
+                Node.privacy_level != privacy_level,
+                Node.ai_usage != ai_usage,
+            ),
+        ).update(
+            {"privacy_level": privacy_level, "ai_usage": ai_usage},
+            synchronize_session=False,
+        )
+    return updated
 
 
 @import_bp.route("/import/analyze", methods=["POST"])
@@ -304,6 +336,7 @@ def confirm_import():
         nodes_skipped = 0
         nodes_restored = 0
         thread_count = 0
+        skipped_alive_ids = []
         key_index, deleted_keys = _load_source_key_index(current_user.id)
 
         def _file_source_key(filename, content):
@@ -340,11 +373,14 @@ def confirm_import():
                     # Chain the next new file onto the existing copy so
                     # partially-skipped imports don't orphan new nodes.
                     if source_key in deleted_keys and on_deleted == 'restore':
-                        _restore_node(key_index[source_key], node_content)
+                        _restore_node(key_index[source_key], node_content,
+                                      privacy_level, ai_usage)
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     parent_id = key_index[source_key]
                     continue
 
@@ -398,11 +434,14 @@ def confirm_import():
                 source_key = _file_source_key(filename, content)
                 if source_key in key_index:
                     if source_key in deleted_keys and on_deleted == 'restore':
-                        _restore_node(key_index[source_key], node_content)
+                        _restore_node(key_index[source_key], node_content,
+                                      privacy_level, ai_usage)
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     continue
                 key_index[source_key] = None  # id not needed: no chaining
 
@@ -435,6 +474,11 @@ def confirm_import():
                 nodes_created += 1
 
             thread_count = nodes_created
+
+        nodes_updated = _apply_settings_to_skipped(
+            skipped_alive_ids, privacy_level, ai_usage
+        )
+        nodes_skipped -= nodes_updated
 
         # Commit all nodes
         db.session.commit()
@@ -504,6 +548,7 @@ def confirm_import():
             "created": nodes_created,
             "skipped": nodes_skipped,
             "restored": nodes_restored,
+            "updated": nodes_updated,
         }), 201
 
     except Exception as e:
@@ -846,6 +891,7 @@ def confirm_claude_import():
         nodes_skipped = 0
         nodes_restored = 0
         thread_count = 0
+        skipped_alive_ids = []
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -884,11 +930,14 @@ def confirm_claude_import():
                     # so overlap re-imports extend the original thread.
                     if (source_key in deleted_keys
                             and on_deleted == 'restore'):
-                        _restore_node(key_index[source_key], node_content)
+                        _restore_node(key_index[source_key], node_content,
+                                      privacy_level, ai_usage)
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     parent_id = key_index[source_key]
                     continue
 
@@ -934,6 +983,11 @@ def confirm_claude_import():
 
             if conv_started_new_thread:
                 thread_count += 1
+
+        nodes_updated = _apply_settings_to_skipped(
+            skipped_alive_ids, privacy_level, ai_usage
+        )
+        nodes_skipped -= nodes_updated
 
         db.session.commit()
 
@@ -1010,6 +1064,7 @@ def confirm_claude_import():
             "created": nodes_created,
             "skipped": nodes_skipped,
             "restored": nodes_restored,
+            "updated": nodes_updated,
         }), 201
 
     except Exception as e:
@@ -1080,6 +1135,7 @@ def confirm_twitter_import():
         nodes_skipped = 0
         nodes_restored = 0
         thread_count = 0
+        skipped_alive_ids = []
         key_index, deleted_keys = _load_source_key_index(current_user.id)
 
         def _tweet_source_key(tweet_data):
@@ -1115,12 +1171,15 @@ def confirm_twitter_import():
                     # partially-skipped imports don't orphan new nodes.
                     if source_key in deleted_keys and on_deleted == 'restore':
                         _restore_node(
-                            key_index[source_key], content, token_count
+                            key_index[source_key], content,
+                            privacy_level, ai_usage, token_count
                         )
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     parent_id = key_index[source_key]
                     continue
 
@@ -1170,12 +1229,15 @@ def confirm_twitter_import():
                 if source_key in key_index:
                     if source_key in deleted_keys and on_deleted == 'restore':
                         _restore_node(
-                            key_index[source_key], content, token_count
+                            key_index[source_key], content,
+                            privacy_level, ai_usage, token_count
                         )
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     continue
                 key_index[source_key] = None  # id not needed: no chaining
 
@@ -1209,6 +1271,11 @@ def confirm_twitter_import():
                 nodes_created += 1
 
             thread_count = nodes_created
+
+        nodes_updated = _apply_settings_to_skipped(
+            skipped_alive_ids, privacy_level, ai_usage
+        )
+        nodes_skipped -= nodes_updated
 
         db.session.commit()
 
@@ -1282,6 +1349,7 @@ def confirm_twitter_import():
             "created": nodes_created,
             "skipped": nodes_skipped,
             "restored": nodes_restored,
+            "updated": nodes_updated,
         }), 201
 
     except Exception as e:
@@ -1546,6 +1614,7 @@ def confirm_chatgpt_import():
         nodes_skipped = 0
         nodes_restored = 0
         thread_count = 0
+        skipped_alive_ids = []
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -1584,11 +1653,14 @@ def confirm_chatgpt_import():
                     # so overlap re-imports extend the original thread.
                     if (source_key in deleted_keys
                             and on_deleted == 'restore'):
-                        _restore_node(key_index[source_key], node_content)
+                        _restore_node(key_index[source_key], node_content,
+                                      privacy_level, ai_usage)
                         deleted_keys.discard(source_key)
                         nodes_restored += 1
                     else:
                         nodes_skipped += 1
+                        if source_key not in deleted_keys:
+                            skipped_alive_ids.append(key_index[source_key])
                     parent_id = key_index[source_key]
                     continue
 
@@ -1640,6 +1712,11 @@ def confirm_chatgpt_import():
 
             if conv_started_new_thread:
                 thread_count += 1
+
+        nodes_updated = _apply_settings_to_skipped(
+            skipped_alive_ids, privacy_level, ai_usage
+        )
+        nodes_skipped -= nodes_updated
 
         db.session.commit()
 
@@ -1713,6 +1790,7 @@ def confirm_chatgpt_import():
             "created": nodes_created,
             "skipped": nodes_skipped,
             "restored": nodes_restored,
+            "updated": nodes_updated,
         }), 201
 
     except Exception as e:

--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -32,7 +32,8 @@ def _generic_source_key(author, timestamp, content):
 
 def _load_source_key_index(user_id):
     """
-    Map source_key -> node id for this user's previously imported nodes.
+    Map source_key -> node id for this user's previously imported nodes,
+    plus the set of keys whose node is currently soft-deleted.
 
     Loaded once per confirm request so dedup checks are dict lookups
     instead of one query per message. The node ids let partially-skipped
@@ -45,13 +46,90 @@ def _load_source_key_index(user_id):
     importer is recorded in ``human_owner_id``. Scoping on the human owner
     therefore dedups both human and assistant turns per importing user, so
     two different users importing the same archive each keep their own copy.
+
+    Returns:
+        (key_index, deleted_keys) where key_index maps source_key ->
+        node id and deleted_keys contains the keys of soft-deleted nodes.
     """
-    return dict(
-        db.session.query(Node.source_key, Node.id).filter(
-            Node.human_owner_id == user_id,
-            Node.source_key.isnot(None),
-        )
+    rows = db.session.query(
+        Node.source_key, Node.id, Node.deleted_at
+    ).filter(
+        Node.human_owner_id == user_id,
+        Node.source_key.isnot(None),
     )
+    key_index = {}
+    deleted_keys = set()
+    for source_key, node_id, deleted_at in rows:
+        key_index[source_key] = node_id
+        if deleted_at is not None:
+            deleted_keys.add(source_key)
+    return key_index, deleted_keys
+
+
+def _claude_msg_key(msg):
+    """Dedup key for one Claude confirm-payload message.
+
+    Prefers the export's per-message uuid (rename-proof, bounded
+    length); falls back to a content hash when it is missing.
+    """
+    msg_uuid = msg.get('uuid')
+    if msg_uuid:
+        return f"claude:{msg_uuid}"
+    return _generic_source_key(
+        msg.get('sender', 'human'), msg.get('created_at', ''),
+        msg.get('text', ''),
+    )
+
+
+def _chatgpt_msg_key(msg):
+    """Dedup key for one ChatGPT confirm-payload message.
+
+    The mapping id alone identifies the message globally (rename-proof,
+    bounded length); falls back to a content hash when it is missing.
+    """
+    mapping_id = msg.get('mapping_id')
+    if mapping_id:
+        return f"chatgpt:{mapping_id}"
+    return _generic_source_key(
+        msg.get('role', 'user'), msg.get('created_at', ''),
+        msg.get('text', ''),
+    )
+
+
+def _deleted_match_response(keys, deleted_keys, on_deleted):
+    """409 response when the import collides with soft-deleted nodes and
+    the client hasn't said what to do about them.
+
+    The frontend surfaces this as a restore-or-skip dialog and retries
+    the confirm with ``on_deleted`` set: ``"skip"`` leaves the deleted
+    nodes alone (they stay deleted and are not re-imported), ``"restore"``
+    un-deletes them in place. Returns None when no dialog is needed.
+    """
+    if on_deleted in ('restore', 'skip'):
+        return None
+    matches = sum(1 for k in keys if k in deleted_keys)
+    if not matches:
+        return None
+    return jsonify({
+        "error": "deleted_content_matches",
+        "deleted_matches": matches,
+    }), 409
+
+
+def _restore_node(node_id, content, token_count=None):
+    """Un-delete a soft-deleted imported node in place.
+
+    Refills content from the archive — this also recovers tombstones
+    whose content was already wiped by the cleanup task — and keeps the
+    node id, so existing child links stay intact.
+    """
+    node = Node.query.get(node_id)
+    node.content = content
+    node.token_count = (
+        token_count if token_count is not None
+        else approximate_token_count(content)
+    )
+    node.deleted_at = None
 
 
 @import_bp.route("/import/analyze", methods=["POST"])
@@ -206,6 +284,7 @@ def confirm_import():
     date_ordering = data.get('date_ordering', 'modified')
     privacy_level = data.get('privacy_level', 'private')
     ai_usage = data.get('ai_usage', 'none')
+    on_deleted = data.get('on_deleted')
 
     if not files:
         return jsonify({"error": "No files provided"}), 400
@@ -223,13 +302,23 @@ def confirm_import():
 
         nodes_created = 0
         nodes_skipped = 0
+        nodes_restored = 0
         thread_count = 0
-        key_index = _load_source_key_index(current_user.id)
+        key_index, deleted_keys = _load_source_key_index(current_user.id)
 
         def _file_source_key(filename, content):
             """sha256 of (filename, content) for markdown-zip dedup."""
             raw = f"{filename}\x00{content}"
             return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+        conflict = _deleted_match_response(
+            (_file_source_key(f.get('filename_without_ext', 'Untitled'),
+                              f.get('content', ''))
+             for f in files_sorted),
+            deleted_keys, on_deleted,
+        )
+        if conflict:
+            return conflict
 
         if import_type == 'single_thread':
             # Create a single thread with all files as sequential nodes
@@ -239,20 +328,25 @@ def confirm_import():
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
 
-                source_key = _file_source_key(filename, content)
-                if source_key in key_index:
-                    # Chain the next new file onto the existing copy so
-                    # partially-skipped imports don't orphan new nodes.
-                    nodes_skipped += 1
-                    parent_id = key_index[source_key]
-                    continue
-
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
                 if not stripped_content.startswith('# '):
                     node_content = f"# {filename}\n\n{content}"
                 else:
                     node_content = content
+
+                source_key = _file_source_key(filename, content)
+                if source_key in key_index:
+                    # Chain the next new file onto the existing copy so
+                    # partially-skipped imports don't orphan new nodes.
+                    if source_key in deleted_keys and on_deleted == 'restore':
+                        _restore_node(key_index[source_key], node_content)
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
+                    parent_id = key_index[source_key]
+                    continue
 
                 # Parse original timestamp from zip metadata
                 node_created_at = None
@@ -294,18 +388,23 @@ def confirm_import():
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
 
-                source_key = _file_source_key(filename, content)
-                if source_key in key_index:
-                    nodes_skipped += 1
-                    continue
-                key_index[source_key] = None  # id not needed: no chaining
-
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
                 if not stripped_content.startswith('# '):
                     node_content = f"# {filename}\n\n{content}"
                 else:
                     node_content = content
+
+                source_key = _file_source_key(filename, content)
+                if source_key in key_index:
+                    if source_key in deleted_keys and on_deleted == 'restore':
+                        _restore_node(key_index[source_key], node_content)
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
+                    continue
+                key_index[source_key] = None  # id not needed: no chaining
 
                 # Parse original timestamp from zip metadata
                 node_created_at = None
@@ -404,6 +503,7 @@ def confirm_import():
             "profile_update_task_id": profile_update_task_id,
             "created": nodes_created,
             "skipped": nodes_skipped,
+            "restored": nodes_restored,
         }), 201
 
     except Exception as e:
@@ -719,7 +819,20 @@ def confirm_claude_import():
     if not conversations:
         return jsonify({"error": "No conversations provided"}), 400
 
+    on_deleted = data.get('on_deleted')
+
     try:
+        key_index, deleted_keys = _load_source_key_index(current_user.id)
+        conflict = _deleted_match_response(
+            (_claude_msg_key(m)
+             for conv in conversations
+             for m in conv.get('messages', [])
+             if m.get('text')),
+            deleted_keys, on_deleted,
+        )
+        if conflict:
+            return conflict
+
         # Get or create the synthetic user for claude-web nodes
         llm_user = User.query.filter_by(username="claude-web").first()
         if not llm_user:
@@ -731,8 +844,8 @@ def confirm_claude_import():
 
         nodes_created = 0
         nodes_skipped = 0
+        nodes_restored = 0
         thread_count = 0
-        key_index = _load_source_key_index(current_user.id)
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -765,21 +878,17 @@ def confirm_claude_import():
 
                 is_assistant = sender == 'assistant'
 
-                # Stable dedup key. Prefer the export's per-message uuid
-                # (rename-proof, bounded length); fall back to a content
-                # hash when it is missing.
-                msg_uuid = msg.get('uuid')
-                if msg_uuid:
-                    source_key = f"claude:{msg_uuid}"
-                else:
-                    source_key = _generic_source_key(
-                        sender, msg.get('created_at', ''), text
-                    )
-
+                source_key = _claude_msg_key(msg)
                 if source_key in key_index:
                     # Chain the next new message onto the existing copy
                     # so overlap re-imports extend the original thread.
-                    nodes_skipped += 1
+                    if (source_key in deleted_keys
+                            and on_deleted == 'restore'):
+                        _restore_node(key_index[source_key], node_content)
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
                     parent_id = key_index[source_key]
                     continue
 
@@ -900,6 +1009,7 @@ def confirm_claude_import():
             "profile_update_task_id": profile_update_task_id,
             "created": nodes_created,
             "skipped": nodes_skipped,
+            "restored": nodes_restored,
         }), 201
 
     except Exception as e:
@@ -945,6 +1055,7 @@ def confirm_twitter_import():
     include_replies = data.get('include_replies', False)
     privacy_level = data.get('privacy_level', 'private')
     ai_usage = data.get('ai_usage', 'none')
+    on_deleted = data.get('on_deleted')
 
     if not tweets:
         return jsonify({"error": "No tweets provided"}), 400
@@ -967,8 +1078,9 @@ def confirm_twitter_import():
 
         nodes_created = 0
         nodes_skipped = 0
+        nodes_restored = 0
         thread_count = 0
-        key_index = _load_source_key_index(current_user.id)
+        key_index, deleted_keys = _load_source_key_index(current_user.id)
 
         def _tweet_source_key(tweet_data):
             """twitter:<id_str>; content hash when id_str is absent."""
@@ -980,6 +1092,13 @@ def confirm_twitter_import():
                 tweet_data.get('created_at', ''),
                 tweet_data.get('full_text', ''),
             )
+
+        conflict = _deleted_match_response(
+            (_tweet_source_key(t) for t in tweets_sorted),
+            deleted_keys, on_deleted,
+        )
+        if conflict:
+            return conflict
 
         if import_type == 'single_thread':
             parent_id = None
@@ -994,7 +1113,14 @@ def confirm_twitter_import():
                 if source_key in key_index:
                     # Chain the next new tweet onto the existing copy so
                     # partially-skipped imports don't orphan new nodes.
-                    nodes_skipped += 1
+                    if source_key in deleted_keys and on_deleted == 'restore':
+                        _restore_node(
+                            key_index[source_key], content, token_count
+                        )
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
                     parent_id = key_index[source_key]
                     continue
 
@@ -1042,7 +1168,14 @@ def confirm_twitter_import():
 
                 source_key = _tweet_source_key(tweet_data)
                 if source_key in key_index:
-                    nodes_skipped += 1
+                    if source_key in deleted_keys and on_deleted == 'restore':
+                        _restore_node(
+                            key_index[source_key], content, token_count
+                        )
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
                     continue
                 key_index[source_key] = None  # id not needed: no chaining
 
@@ -1148,6 +1281,7 @@ def confirm_twitter_import():
             "profile_update_task_id": profile_update_task_id,
             "created": nodes_created,
             "skipped": nodes_skipped,
+            "restored": nodes_restored,
         }), 201
 
     except Exception as e:
@@ -1385,7 +1519,20 @@ def confirm_chatgpt_import():
     if not conversations:
         return jsonify({"error": "No conversations provided"}), 400
 
+    on_deleted = data.get('on_deleted')
+
     try:
+        key_index, deleted_keys = _load_source_key_index(current_user.id)
+        conflict = _deleted_match_response(
+            (_chatgpt_msg_key(m)
+             for conv in conversations
+             for m in conv.get('messages', [])
+             if m.get('text')),
+            deleted_keys, on_deleted,
+        )
+        if conflict:
+            return conflict
+
         # Get or create the synthetic user for chatgpt nodes
         llm_user = User.query.filter_by(username="chatgpt").first()
         if not llm_user:
@@ -1397,8 +1544,8 @@ def confirm_chatgpt_import():
 
         nodes_created = 0
         nodes_skipped = 0
+        nodes_restored = 0
         thread_count = 0
-        key_index = _load_source_key_index(current_user.id)
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -1431,21 +1578,17 @@ def confirm_chatgpt_import():
 
                 is_assistant = role == 'assistant'
 
-                # Stable dedup key. The mapping id alone identifies the
-                # message globally (rename-proof, bounded length); fall
-                # back to a content hash when it is missing.
-                mapping_id = msg.get('mapping_id')
-                if mapping_id:
-                    source_key = f"chatgpt:{mapping_id}"
-                else:
-                    source_key = _generic_source_key(
-                        role, msg.get('created_at', ''), text
-                    )
-
+                source_key = _chatgpt_msg_key(msg)
                 if source_key in key_index:
                     # Chain the next new message onto the existing copy
                     # so overlap re-imports extend the original thread.
-                    nodes_skipped += 1
+                    if (source_key in deleted_keys
+                            and on_deleted == 'restore'):
+                        _restore_node(key_index[source_key], node_content)
+                        deleted_keys.discard(source_key)
+                        nodes_restored += 1
+                    else:
+                        nodes_skipped += 1
                     parent_id = key_index[source_key]
                     continue
 
@@ -1569,6 +1712,7 @@ def confirm_chatgpt_import():
             "profile_update_task_id": profile_update_task_id,
             "created": nodes_created,
             "skipped": nodes_skipped,
+            "restored": nodes_restored,
         }), 201
 
     except Exception as e:

--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -22,14 +22,22 @@ def approximate_token_count(text):
 
 
 def _generic_source_key(author, timestamp, content):
-    """Stable fallback dedup key when no source-native id is available."""
-    raw = f"{author}:{timestamp}:{content}"
+    """Stable fallback dedup key when no source-native id is available.
+
+    NUL separators prevent boundary ambiguity between the fields.
+    """
+    raw = f"{author}\x00{timestamp}\x00{content}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-def _source_key_exists(user_id, key):
+def _load_source_key_index(user_id):
     """
-    True if a node owned by this user with this source_key already exists.
+    Map source_key -> node id for this user's previously imported nodes.
+
+    Loaded once per confirm request so dedup checks are dict lookups
+    instead of one query per message. The node ids let partially-skipped
+    threads chain new messages onto the existing copy of the previous
+    message rather than orphaning them as new roots.
 
     Scoping is on ``human_owner_id`` (the importing human), NOT ``user_id``:
     imported assistant/LLM messages are stored under a synthetic LLM user
@@ -37,16 +45,13 @@ def _source_key_exists(user_id, key):
     importer is recorded in ``human_owner_id``. Scoping on the human owner
     therefore dedups both human and assistant turns per importing user, so
     two different users importing the same archive each keep their own copy.
-
-    Pending (flushed-but-uncommitted) nodes within the same request are
-    covered because db.session.flush() is called after each insert, so the
-    query sees them too.
     """
-    if not key:
-        return False
-    return db.session.query(Node.id).filter_by(
-        human_owner_id=user_id, source_key=key
-    ).first() is not None
+    return dict(
+        db.session.query(Node.source_key, Node.id).filter(
+            Node.human_owner_id == user_id,
+            Node.source_key.isnot(None),
+        )
+    )
 
 
 @import_bp.route("/import/analyze", methods=["POST"])
@@ -219,28 +224,28 @@ def confirm_import():
         nodes_created = 0
         nodes_skipped = 0
         thread_count = 0
-        seen_keys = set()
+        key_index = _load_source_key_index(current_user.id)
 
         def _file_source_key(filename, content):
-            """sha256 of (filename + content) for markdown-zip dedup."""
-            raw = f"{filename}{content}"
+            """sha256 of (filename, content) for markdown-zip dedup."""
+            raw = f"{filename}\x00{content}"
             return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
         if import_type == 'single_thread':
             # Create a single thread with all files as sequential nodes
-            parent_node = None
+            parent_id = None
 
             for file_data in files_sorted:
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
 
                 source_key = _file_source_key(filename, content)
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                if source_key in key_index:
+                    # Chain the next new file onto the existing copy so
+                    # partially-skipped imports don't orphan new nodes.
                     nodes_skipped += 1
+                    parent_id = key_index[source_key]
                     continue
-                seen_keys.add(source_key)
 
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
@@ -262,7 +267,7 @@ def confirm_import():
                 node = Node(
                     user_id=current_user.id,
                     human_owner_id=current_user.id,
-                    parent_id=parent_node.id if parent_node else None,
+                    parent_id=parent_id,
                     node_type="user",
                     content=node_content,
                     token_count=approximate_token_count(node_content),
@@ -277,7 +282,8 @@ def confirm_import():
                 db.session.add(node)
                 db.session.flush()  # Get the node ID
 
-                parent_node = node
+                key_index[source_key] = node.id
+                parent_id = node.id
                 nodes_created += 1
 
             thread_count = 1
@@ -289,12 +295,10 @@ def confirm_import():
                 content = file_data.get('content', '')
 
                 source_key = _file_source_key(filename, content)
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                if source_key in key_index:
                     nodes_skipped += 1
                     continue
-                seen_keys.add(source_key)
+                key_index[source_key] = None  # id not needed: no chaining
 
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
@@ -329,7 +333,6 @@ def confirm_import():
                     node.created_at = node_created_at
 
                 db.session.add(node)
-                db.session.flush()
                 nodes_created += 1
 
             thread_count = nodes_created
@@ -568,7 +571,8 @@ def analyze_claude_import():
                         {
                             "text": "...",
                             "sender": "human" | "assistant",
-                            "created_at": "..."
+                            "created_at": "...",
+                            "uuid": "..."
                         }
                     ],
                     "message_count": N,
@@ -622,7 +626,11 @@ def analyze_claude_import():
                     "text": text,
                     "sender": sender,
                     "created_at": created_at,
-                    "token_count": token_count
+                    "token_count": token_count,
+                    # Stable per-message id from the Claude export.
+                    # Survives analyze->confirm so re-imports dedup on
+                    # the original message identity (rename-proof).
+                    "uuid": msg.get('uuid', ''),
                 })
 
                 total_tokens += token_count
@@ -724,7 +732,7 @@ def confirm_claude_import():
         nodes_created = 0
         nodes_skipped = 0
         thread_count = 0
-        seen_keys = set()
+        key_index = _load_source_key_index(current_user.id)
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -735,12 +743,12 @@ def confirm_claude_import():
         for conv in conversations_sorted:
             messages = conv.get('messages', [])
             conv_name = conv.get('name', '')
-            conv_created = conv.get('created_at', '')
 
             if not messages:
                 continue
 
-            parent_node = None
+            parent_id = None
+            conv_started_new_thread = False
 
             for i, msg in enumerate(messages):
                 text = msg.get('text', '')
@@ -757,14 +765,23 @@ def confirm_claude_import():
 
                 is_assistant = sender == 'assistant'
 
-                # Stable dedup key keyed on conversation + message index.
-                source_key = f"claude:{conv_name}:{conv_created}:{i}"
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                # Stable dedup key. Prefer the export's per-message uuid
+                # (rename-proof, bounded length); fall back to a content
+                # hash when it is missing.
+                msg_uuid = msg.get('uuid')
+                if msg_uuid:
+                    source_key = f"claude:{msg_uuid}"
+                else:
+                    source_key = _generic_source_key(
+                        sender, msg.get('created_at', ''), text
+                    )
+
+                if source_key in key_index:
+                    # Chain the next new message onto the existing copy
+                    # so overlap re-imports extend the original thread.
                     nodes_skipped += 1
+                    parent_id = key_index[source_key]
                     continue
-                seen_keys.add(source_key)
 
                 # Parse original timestamp from Claude export
                 msg_created_at = None
@@ -781,7 +798,7 @@ def confirm_claude_import():
                 node = Node(
                     user_id=llm_user.id if is_assistant else current_user.id,
                     human_owner_id=current_user.id,
-                    parent_id=parent_node.id if parent_node else None,
+                    parent_id=parent_id,
                     node_type="llm" if is_assistant else "user",
                     llm_model="claude-web" if is_assistant else None,
                     content=node_content,
@@ -794,13 +811,20 @@ def confirm_claude_import():
                 if msg_created_at:
                     node.created_at = msg_created_at
 
+                # A node created without a parent starts a new thread;
+                # nodes chained onto an existing copy extend an old one.
+                if parent_id is None:
+                    conv_started_new_thread = True
+
                 db.session.add(node)
                 db.session.flush()
 
-                parent_node = node
+                key_index[source_key] = node.id
+                parent_id = node.id
                 nodes_created += 1
 
-            thread_count += 1
+            if conv_started_new_thread:
+                thread_count += 1
 
         db.session.commit()
 
@@ -944,7 +968,7 @@ def confirm_twitter_import():
         nodes_created = 0
         nodes_skipped = 0
         thread_count = 0
-        seen_keys = set()
+        key_index = _load_source_key_index(current_user.id)
 
         def _tweet_source_key(tweet_data):
             """twitter:<id_str>; content hash when id_str is absent."""
@@ -958,7 +982,7 @@ def confirm_twitter_import():
             )
 
         if import_type == 'single_thread':
-            parent_node = None
+            parent_id = None
 
             for tweet_data in tweets_sorted:
                 content = tweet_data.get('full_text', '')
@@ -967,12 +991,12 @@ def confirm_twitter_import():
                 )
 
                 source_key = _tweet_source_key(tweet_data)
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                if source_key in key_index:
+                    # Chain the next new tweet onto the existing copy so
+                    # partially-skipped imports don't orphan new nodes.
                     nodes_skipped += 1
+                    parent_id = key_index[source_key]
                     continue
-                seen_keys.add(source_key)
 
                 # Parse original Twitter timestamp
                 tweet_created_at = None
@@ -988,7 +1012,7 @@ def confirm_twitter_import():
                 node = Node(
                     user_id=current_user.id,
                     human_owner_id=current_user.id,
-                    parent_id=parent_node.id if parent_node else None,
+                    parent_id=parent_id,
                     node_type="user",
                     content=content,
                     token_count=token_count,
@@ -1003,7 +1027,8 @@ def confirm_twitter_import():
                 db.session.add(node)
                 db.session.flush()
 
-                parent_node = node
+                key_index[source_key] = node.id
+                parent_id = node.id
                 nodes_created += 1
 
             thread_count = 1
@@ -1016,12 +1041,10 @@ def confirm_twitter_import():
                 )
 
                 source_key = _tweet_source_key(tweet_data)
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                if source_key in key_index:
                     nodes_skipped += 1
                     continue
-                seen_keys.add(source_key)
+                key_index[source_key] = None  # id not needed: no chaining
 
                 # Parse original Twitter timestamp
                 tweet_created_at = None
@@ -1050,7 +1073,6 @@ def confirm_twitter_import():
                     node.created_at = tweet_created_at
 
                 db.session.add(node)
-                db.session.flush()
                 nodes_created += 1
 
             thread_count = nodes_created
@@ -1376,7 +1398,7 @@ def confirm_chatgpt_import():
         nodes_created = 0
         nodes_skipped = 0
         thread_count = 0
-        seen_keys = set()
+        key_index = _load_source_key_index(current_user.id)
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -1387,12 +1409,12 @@ def confirm_chatgpt_import():
         for conv in conversations_sorted:
             messages = conv.get('messages', [])
             conv_name = conv.get('name', '')
-            conv_created = conv.get('created_at', '')
 
             if not messages:
                 continue
 
-            parent_node = None
+            parent_id = None
+            conv_started_new_thread = False
 
             for i, msg in enumerate(messages):
                 text = msg.get('text', '')
@@ -1409,25 +1431,23 @@ def confirm_chatgpt_import():
 
                 is_assistant = role == 'assistant'
 
-                # Compute a stable dedup key. Prefer the ChatGPT mapping
-                # id (survives analyze->confirm); fall back to a content
-                # hash when it is missing.
+                # Stable dedup key. The mapping id alone identifies the
+                # message globally (rename-proof, bounded length); fall
+                # back to a content hash when it is missing.
                 mapping_id = msg.get('mapping_id')
                 if mapping_id:
-                    source_key = (
-                        f"chatgpt:{conv_name}:{conv_created}:{mapping_id}"
-                    )
+                    source_key = f"chatgpt:{mapping_id}"
                 else:
                     source_key = _generic_source_key(
-                        role, msg.get('created_at', ''), node_content
+                        role, msg.get('created_at', ''), text
                     )
 
-                if source_key in seen_keys or _source_key_exists(
-                    current_user.id, source_key
-                ):
+                if source_key in key_index:
+                    # Chain the next new message onto the existing copy
+                    # so overlap re-imports extend the original thread.
                     nodes_skipped += 1
+                    parent_id = key_index[source_key]
                     continue
-                seen_keys.add(source_key)
 
                 # Parse original timestamp
                 msg_created_at = None
@@ -1448,7 +1468,7 @@ def confirm_chatgpt_import():
                         llm_user.id if is_assistant else current_user.id
                     ),
                     human_owner_id=current_user.id,
-                    parent_id=parent_node.id if parent_node else None,
+                    parent_id=parent_id,
                     node_type="llm" if is_assistant else "user",
                     llm_model=model_slug or (
                         "chatgpt" if is_assistant else None
@@ -1463,13 +1483,20 @@ def confirm_chatgpt_import():
                 if msg_created_at:
                     node.created_at = msg_created_at
 
+                # A node created without a parent starts a new thread;
+                # nodes chained onto an existing copy extend an old one.
+                if parent_id is None:
+                    conv_started_new_thread = True
+
                 db.session.add(node)
                 db.session.flush()
 
-                parent_node = node
+                key_index[source_key] = node.id
+                parent_id = node.id
                 nodes_created += 1
 
-            thread_count += 1
+            if conv_started_new_thread:
+                thread_count += 1
 
         db.session.commit()
 

--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -4,6 +4,7 @@ from backend.models import Node, User, UserProfile
 from backend.extensions import db
 from backend.utils.privacy import AI_ALLOWED
 from datetime import datetime
+import hashlib
 import zipfile
 import io
 import json
@@ -18,6 +19,34 @@ def approximate_token_count(text):
     Uses a simple heuristic: ~4 characters per token.
     """
     return len(text) // 4
+
+
+def _generic_source_key(author, timestamp, content):
+    """Stable fallback dedup key when no source-native id is available."""
+    raw = f"{author}:{timestamp}:{content}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _source_key_exists(user_id, key):
+    """
+    True if a node owned by this user with this source_key already exists.
+
+    Scoping is on ``human_owner_id`` (the importing human), NOT ``user_id``:
+    imported assistant/LLM messages are stored under a synthetic LLM user
+    (e.g. ``chatgpt`` / ``claude-web``) via ``user_id`` while the real
+    importer is recorded in ``human_owner_id``. Scoping on the human owner
+    therefore dedups both human and assistant turns per importing user, so
+    two different users importing the same archive each keep their own copy.
+
+    Pending (flushed-but-uncommitted) nodes within the same request are
+    covered because db.session.flush() is called after each insert, so the
+    query sees them too.
+    """
+    if not key:
+        return False
+    return db.session.query(Node.id).filter_by(
+        human_owner_id=user_id, source_key=key
+    ).first() is not None
 
 
 @import_bp.route("/import/analyze", methods=["POST"])
@@ -188,7 +217,14 @@ def confirm_import():
         files_sorted = sorted(files, key=lambda f: f.get('modified_at', ''))
 
         nodes_created = 0
+        nodes_skipped = 0
         thread_count = 0
+        seen_keys = set()
+
+        def _file_source_key(filename, content):
+            """sha256 of (filename + content) for markdown-zip dedup."""
+            raw = f"{filename}{content}"
+            return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
         if import_type == 'single_thread':
             # Create a single thread with all files as sequential nodes
@@ -197,6 +233,14 @@ def confirm_import():
             for file_data in files_sorted:
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
+
+                source_key = _file_source_key(filename, content)
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
 
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
@@ -223,7 +267,8 @@ def confirm_import():
                     content=node_content,
                     token_count=approximate_token_count(node_content),
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if node_created_at:
@@ -242,6 +287,14 @@ def confirm_import():
             for file_data in files_sorted:
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
+
+                source_key = _file_source_key(filename, content)
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
 
                 # Add filename as markdown headline only if content doesn't have H1
                 stripped_content = content.lstrip()
@@ -268,16 +321,18 @@ def confirm_import():
                     content=node_content,
                     token_count=approximate_token_count(node_content),
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if node_created_at:
                     node.created_at = node_created_at
 
                 db.session.add(node)
+                db.session.flush()
                 nodes_created += 1
 
-            thread_count = len(files_sorted)
+            thread_count = nodes_created
 
         # Commit all nodes
         db.session.commit()
@@ -344,6 +399,8 @@ def confirm_import():
             "nodes_created": nodes_created,
             "thread_count": thread_count,
             "profile_update_task_id": profile_update_task_id,
+            "created": nodes_created,
+            "skipped": nodes_skipped,
         }), 201
 
     except Exception as e:
@@ -665,7 +722,9 @@ def confirm_claude_import():
             db.session.flush()
 
         nodes_created = 0
+        nodes_skipped = 0
         thread_count = 0
+        seen_keys = set()
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -676,6 +735,7 @@ def confirm_claude_import():
         for conv in conversations_sorted:
             messages = conv.get('messages', [])
             conv_name = conv.get('name', '')
+            conv_created = conv.get('created_at', '')
 
             if not messages:
                 continue
@@ -696,6 +756,15 @@ def confirm_claude_import():
                     node_content = text
 
                 is_assistant = sender == 'assistant'
+
+                # Stable dedup key keyed on conversation + message index.
+                source_key = f"claude:{conv_name}:{conv_created}:{i}"
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
 
                 # Parse original timestamp from Claude export
                 msg_created_at = None
@@ -718,7 +787,8 @@ def confirm_claude_import():
                     content=node_content,
                     token_count=approximate_token_count(node_content),
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if msg_created_at:
@@ -804,6 +874,8 @@ def confirm_claude_import():
             "nodes_created": nodes_created,
             "thread_count": thread_count,
             "profile_update_task_id": profile_update_task_id,
+            "created": nodes_created,
+            "skipped": nodes_skipped,
         }), 201
 
     except Exception as e:
@@ -870,7 +942,20 @@ def confirm_twitter_import():
         )
 
         nodes_created = 0
+        nodes_skipped = 0
         thread_count = 0
+        seen_keys = set()
+
+        def _tweet_source_key(tweet_data):
+            """twitter:<id_str>; content hash when id_str is absent."""
+            id_str = tweet_data.get('id_str', '')
+            if id_str:
+                return f"twitter:{id_str}"
+            return _generic_source_key(
+                "twitter",
+                tweet_data.get('created_at', ''),
+                tweet_data.get('full_text', ''),
+            )
 
         if import_type == 'single_thread':
             parent_node = None
@@ -880,6 +965,14 @@ def confirm_twitter_import():
                 token_count = tweet_data.get(
                     'token_count', approximate_token_count(content)
                 )
+
+                source_key = _tweet_source_key(tweet_data)
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
 
                 # Parse original Twitter timestamp
                 tweet_created_at = None
@@ -900,7 +993,8 @@ def confirm_twitter_import():
                     content=content,
                     token_count=token_count,
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if tweet_created_at:
@@ -921,6 +1015,14 @@ def confirm_twitter_import():
                     'token_count', approximate_token_count(content)
                 )
 
+                source_key = _tweet_source_key(tweet_data)
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
+
                 # Parse original Twitter timestamp
                 tweet_created_at = None
                 raw_ts = tweet_data.get('created_at', '')
@@ -940,16 +1042,18 @@ def confirm_twitter_import():
                     content=content,
                     token_count=token_count,
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if tweet_created_at:
                     node.created_at = tweet_created_at
 
                 db.session.add(node)
+                db.session.flush()
                 nodes_created += 1
 
-            thread_count = len(tweets_sorted)
+            thread_count = nodes_created
 
         db.session.commit()
 
@@ -1020,6 +1124,8 @@ def confirm_twitter_import():
             "nodes_created": nodes_created,
             "thread_count": thread_count,
             "profile_update_task_id": profile_update_task_id,
+            "created": nodes_created,
+            "skipped": nodes_skipped,
         }), 201
 
     except Exception as e:
@@ -1089,6 +1195,10 @@ def _linearize_chatgpt_messages(mapping):
                         "role": role,
                         "created_at": msg_created_at or '',
                         "model": model,
+                        # Stable per-message id from the export graph.
+                        # Survives analyze->confirm so re-imports dedup
+                        # on the original ChatGPT message identity.
+                        "mapping_id": current,
                     })
 
         children = entry.get('children', [])
@@ -1264,7 +1374,9 @@ def confirm_chatgpt_import():
             db.session.flush()
 
         nodes_created = 0
+        nodes_skipped = 0
         thread_count = 0
+        seen_keys = set()
 
         # Sort conversations by created_at ascending
         conversations_sorted = sorted(
@@ -1275,6 +1387,7 @@ def confirm_chatgpt_import():
         for conv in conversations_sorted:
             messages = conv.get('messages', [])
             conv_name = conv.get('name', '')
+            conv_created = conv.get('created_at', '')
 
             if not messages:
                 continue
@@ -1295,6 +1408,26 @@ def confirm_chatgpt_import():
                     node_content = text
 
                 is_assistant = role == 'assistant'
+
+                # Compute a stable dedup key. Prefer the ChatGPT mapping
+                # id (survives analyze->confirm); fall back to a content
+                # hash when it is missing.
+                mapping_id = msg.get('mapping_id')
+                if mapping_id:
+                    source_key = (
+                        f"chatgpt:{conv_name}:{conv_created}:{mapping_id}"
+                    )
+                else:
+                    source_key = _generic_source_key(
+                        role, msg.get('created_at', ''), node_content
+                    )
+
+                if source_key in seen_keys or _source_key_exists(
+                    current_user.id, source_key
+                ):
+                    nodes_skipped += 1
+                    continue
+                seen_keys.add(source_key)
 
                 # Parse original timestamp
                 msg_created_at = None
@@ -1323,7 +1456,8 @@ def confirm_chatgpt_import():
                     content=node_content,
                     token_count=approximate_token_count(node_content),
                     privacy_level=privacy_level,
-                    ai_usage=ai_usage
+                    ai_usage=ai_usage,
+                    source_key=source_key,
                 )
 
                 if msg_created_at:
@@ -1406,6 +1540,8 @@ def confirm_chatgpt_import():
             "nodes_created": nodes_created,
             "thread_count": thread_count,
             "profile_update_task_id": profile_update_task_id,
+            "created": nodes_created,
+            "skipped": nodes_skipped,
         }), 201
 
     except Exception as e:

--- a/backend/tests/test_chatgpt_import.py
+++ b/backend/tests/test_chatgpt_import.py
@@ -35,7 +35,7 @@ for _mod in ["flask_login", "backend.models", "backend.extensions"]:
 
 import flask_login as _real_flask_login          # noqa: E402
 from backend.extensions import db as _db         # noqa: E402
-from backend.models import User                  # noqa: E402
+from backend.models import User, Node            # noqa: E402
 import backend.models as _real_backend_models    # noqa: E402
 
 
@@ -95,6 +95,19 @@ def _login(client, user_id):
         sess["_fresh"] = True
 
 
+def _reset_login_cache():
+    """Clear Flask-Login's per-context user cache.
+
+    The ``app`` fixture wraps the whole test in a single application
+    context, so ``flask.g._login_user`` (set by Flask-Login on the first
+    authenticated request) leaks into subsequent requests and pins
+    ``current_user`` to the first user. Pop it so the next request
+    re-loads the identity from its own session cookie.
+    """
+    from flask import g
+    g.pop("_login_user", None)
+
+
 def _make_user(username, **kwargs):
     u = User(username=username, approved=True, plan="alpha", **kwargs)
     _db.session.add(u)
@@ -111,6 +124,17 @@ def _post_conversations(client, raw_conversations):
         "/api/import/chatgpt/analyze",
         data=data,
         content_type="multipart/form-data",
+    )
+
+
+def _confirm_conversations(client, conversations, **extra):
+    """POST analyzed conversations to the ChatGPT confirm endpoint."""
+    body = {"conversations": conversations}
+    body.update(extra)
+    return client.post(
+        "/api/import/chatgpt/confirm",
+        data=json.dumps(body),
+        content_type="application/json",
     )
 
 
@@ -453,3 +477,161 @@ class TestAnalyzeChatgptImport:
         resp = _post_conversations(client, [])
         # flask_login redirects unauthenticated requests (302/401).
         assert resp.status_code in (302, 401)
+
+
+# ── POST /api/import/chatgpt/confirm (dedup) ─────────────────────────────
+
+def _analyzed_conv(name="First chat", created_at="2023-11-14T22:13:20",
+                   messages=None):
+    """Build a confirm-shaped conversation (mirrors analyze output)."""
+    if messages is None:
+        messages = [
+            {
+                "text": "hello world",
+                "role": "user",
+                "created_at": "2023-11-14T22:13:20",
+                "model": "",
+                "mapping_id": "u1",
+            },
+            {
+                "text": "hi there, friend",
+                "role": "assistant",
+                "created_at": "2023-11-14T22:13:21",
+                "model": "gpt-4o",
+                "mapping_id": "a1",
+            },
+        ]
+    return {
+        "name": name,
+        "created_at": created_at,
+        "default_model": "gpt-4o",
+        "messages": messages,
+        "message_count": len(messages),
+        "token_count": sum(len(m["text"]) // 4 for m in messages),
+    }
+
+
+class TestConfirmChatgptImportDedup:
+    def _count_nodes(self, user_id):
+        return Node.query.filter_by(human_owner_id=user_id).count()
+
+    def test_reimport_same_archive_creates_zero_new_nodes(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+
+        # First import: both messages become nodes.
+        r1 = _confirm_conversations(client, convs)
+        assert r1.status_code == 201
+        b1 = r1.get_json()
+        assert b1["created"] == 2
+        assert b1["skipped"] == 0
+        assert b1["nodes_created"] == 2
+        assert self._count_nodes(alice.id) == 2
+
+        # Re-import the identical archive: zero new nodes.
+        r2 = _confirm_conversations(client, convs)
+        assert r2.status_code == 201
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 2
+
+    def test_overlapping_snapshot_adds_only_new_messages(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        first = [_analyzed_conv()]
+        r1 = _confirm_conversations(client, first)
+        assert r1.status_code == 201
+        assert r1.get_json()["created"] == 2
+        assert self._count_nodes(alice.id) == 2
+
+        # A later snapshot of the same conversation: the original two
+        # messages plus one genuinely-new follow-up.
+        extended_messages = [
+            {
+                "text": "hello world",
+                "role": "user",
+                "created_at": "2023-11-14T22:13:20",
+                "model": "",
+                "mapping_id": "u1",
+            },
+            {
+                "text": "hi there, friend",
+                "role": "assistant",
+                "created_at": "2023-11-14T22:13:21",
+                "model": "gpt-4o",
+                "mapping_id": "a1",
+            },
+            {
+                "text": "one more question",
+                "role": "user",
+                "created_at": "2023-11-14T22:14:00",
+                "model": "",
+                "mapping_id": "u2",
+            },
+        ]
+        second = [_analyzed_conv(messages=extended_messages)]
+        r2 = _confirm_conversations(client, second)
+        assert r2.status_code == 201
+        b2 = r2.get_json()
+        assert b2["created"] == 1
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 3
+
+    def test_dedup_is_scoped_per_user(self, app):
+        alice = _make_user("alice")
+        bob = _make_user("bob")
+        _db.session.commit()
+
+        convs = [_analyzed_conv()]
+
+        alice_client = app.test_client()
+        _login(alice_client, alice.id)
+        ra = _confirm_conversations(alice_client, convs)
+        assert ra.get_json()["created"] == 2
+
+        # Bob importing the same archive gets his own copy. Clear the
+        # leaked Flask-Login cache so current_user re-loads as Bob.
+        _reset_login_cache()
+        bob_client = app.test_client()
+        _login(bob_client, bob.id)
+        rb = _confirm_conversations(bob_client, convs)
+        assert rb.get_json()["created"] == 2
+        assert rb.get_json()["skipped"] == 0
+        assert self._count_nodes(alice.id) == 2
+        assert self._count_nodes(bob.id) == 2
+
+    def test_intra_request_duplicates_are_deduped(self, app):
+        # Same conversation appears twice within one payload.
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv(), _analyzed_conv()]
+        r = _confirm_conversations(client, convs)
+        assert r.status_code == 201
+        b = r.get_json()
+        assert b["created"] == 2
+        assert b["skipped"] == 2
+        assert self._count_nodes(alice.id) == 2
+
+    def test_source_key_persisted_on_created_nodes(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        _confirm_conversations(client, [_analyzed_conv()])
+        keys = [
+            n.source_key
+            for n in Node.query.filter_by(human_owner_id=alice.id).all()
+        ]
+        assert all(k and k.startswith("chatgpt:") for k in keys)

--- a/backend/tests/test_chatgpt_import.py
+++ b/backend/tests/test_chatgpt_import.py
@@ -921,3 +921,111 @@ class TestConfirmImportDeletedContent:
         assert body["restored"] == 1
         assert body["skipped"] == 1
         assert Node.query.get(node_a.id).deleted_at is None
+
+
+# ── POST confirm endpoints: settings update on re-import ─────────────────
+
+class TestConfirmImportSettingsUpdate:
+    """Re-importing with different privacy/ai_usage updates the
+    already-imported nodes instead of being a pure no-op."""
+
+    def _nodes(self, user_id):
+        return Node.query.filter_by(human_owner_id=user_id).all()
+
+    def test_reimport_with_new_settings_updates_existing_nodes(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        r1 = _confirm_conversations(client, convs)  # private / none
+        assert r1.get_json()["created"] == 2
+
+        r2 = _confirm_conversations(
+            client, convs, privacy_level="public", ai_usage="chat"
+        )
+        assert r2.status_code == 201
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["updated"] == 2
+        assert b2["skipped"] == 0
+        nodes = self._nodes(alice.id)
+        assert len(nodes) == 2
+        assert all(n.privacy_level == "public" for n in nodes)
+        assert all(n.ai_usage == "chat" for n in nodes)
+
+    def test_reimport_same_settings_is_pure_skip(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        _confirm_conversations(client, convs)
+        b2 = _confirm_conversations(client, convs).get_json()
+        assert b2["updated"] == 0
+        assert b2["skipped"] == 2
+
+    def test_settings_update_leaves_deleted_nodes_untouched(self, app):
+        # With on_deleted="skip", deleted matches keep their old
+        # settings (and stay deleted); only alive duplicates update.
+        from datetime import datetime
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        _confirm_conversations(client, convs)
+        deleted_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:u1"
+        ).one()
+        deleted_node.deleted_at = datetime.utcnow()
+        _db.session.commit()
+
+        r = _confirm_conversations(
+            client, convs, on_deleted="skip",
+            privacy_level="public", ai_usage="chat",
+        )
+        b = r.get_json()
+        assert b["updated"] == 1
+        assert b["skipped"] == 1
+        assert b["restored"] == 0
+
+        deleted_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:u1"
+        ).one()
+        alive_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:a1"
+        ).one()
+        assert deleted_node.deleted_at is not None
+        assert deleted_node.privacy_level == "private"
+        assert deleted_node.ai_usage == "none"
+        assert alive_node.privacy_level == "public"
+        assert alive_node.ai_usage == "chat"
+
+    def test_restore_applies_new_settings(self, app):
+        from datetime import datetime
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        _confirm_conversations(client, convs)
+        for node in self._nodes(alice.id):
+            node.deleted_at = datetime.utcnow()
+        _db.session.commit()
+
+        r = _confirm_conversations(
+            client, convs, on_deleted="restore",
+            privacy_level="public", ai_usage="chat",
+        )
+        b = r.get_json()
+        assert b["restored"] == 2
+        assert b["updated"] == 0
+        nodes = self._nodes(alice.id)
+        assert all(n.deleted_at is None for n in nodes)
+        assert all(n.privacy_level == "public" for n in nodes)
+        assert all(n.ai_usage == "chat" for n in nodes)

--- a/backend/tests/test_chatgpt_import.py
+++ b/backend/tests/test_chatgpt_import.py
@@ -583,7 +583,36 @@ class TestConfirmChatgptImportDedup:
         b2 = r2.get_json()
         assert b2["created"] == 1
         assert b2["skipped"] == 2
+        # No new thread was started: the follow-up extends the old one.
+        assert b2["thread_count"] == 0
         assert self._count_nodes(alice.id) == 3
+
+        # The new message must chain onto the existing copy of the
+        # message that precedes it — not become an orphaned root.
+        new_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:u2"
+        ).one()
+        prev_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:a1"
+        ).one()
+        assert new_node.parent_id == prev_node.id
+
+    def test_renamed_conversation_still_dedups(self, app):
+        # Renaming a conversation between exports must not change the
+        # dedup keys (they are based on the mapping id alone).
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        r1 = _confirm_conversations(client, [_analyzed_conv(name="Old")])
+        assert r1.get_json()["created"] == 2
+
+        r2 = _confirm_conversations(client, [_analyzed_conv(name="New")])
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 2
 
     def test_dedup_is_scoped_per_user(self, app):
         alice = _make_user("alice")
@@ -635,3 +664,89 @@ class TestConfirmChatgptImportDedup:
             for n in Node.query.filter_by(human_owner_id=alice.id).all()
         ]
         assert all(k and k.startswith("chatgpt:") for k in keys)
+
+
+# ── POST /api/import/confirm (markdown zip, dedup) ───────────────────────
+
+def _confirm_files(client, files, **extra):
+    """POST analyzed markdown files to the generic confirm endpoint."""
+    body = {"files": files}
+    body.update(extra)
+    return client.post(
+        "/api/import/confirm",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+
+def _md_file(name, content, modified_at):
+    return {
+        "filename_without_ext": name,
+        "content": content,
+        "modified_at": modified_at,
+    }
+
+
+class TestConfirmMarkdownImportDedup:
+    def _count_nodes(self, user_id):
+        return Node.query.filter_by(human_owner_id=user_id).count()
+
+    def test_reimport_separate_nodes_skips_existing(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        files = [
+            _md_file("a", "file a content", "2024-01-01T12:00:00"),
+            _md_file("b", "file b content", "2024-01-02T12:00:00"),
+        ]
+
+        r1 = _confirm_files(client, files, import_type="separate_nodes")
+        assert r1.status_code == 201
+        b1 = r1.get_json()
+        assert b1["created"] == 2
+        assert b1["skipped"] == 0
+        assert self._count_nodes(alice.id) == 2
+
+        r2 = _confirm_files(client, files, import_type="separate_nodes")
+        assert r2.status_code == 201
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert b2["thread_count"] == 0
+        assert self._count_nodes(alice.id) == 2
+
+    def test_single_thread_overlap_chains_onto_existing(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        files = [
+            _md_file("a", "file a content", "2024-01-01T12:00:00"),
+            _md_file("b", "file b content", "2024-01-02T12:00:00"),
+        ]
+        r1 = _confirm_files(client, files, import_type="single_thread")
+        assert r1.get_json()["created"] == 2
+
+        # Re-import with one extra file: the new node must chain onto
+        # the existing copy of "b", not start a fresh root.
+        files_plus = files + [
+            _md_file("c", "file c content", "2024-01-03T12:00:00"),
+        ]
+        r2 = _confirm_files(client, files_plus, import_type="single_thread")
+        b2 = r2.get_json()
+        assert b2["created"] == 1
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 3
+
+        node_b = Node.query.filter(
+            Node.human_owner_id == alice.id,
+            Node.content.contains("file b content"),
+        ).one()
+        node_c = Node.query.filter(
+            Node.human_owner_id == alice.id,
+            Node.content.contains("file c content"),
+        ).one()
+        assert node_c.parent_id == node_b.id

--- a/backend/tests/test_chatgpt_import.py
+++ b/backend/tests/test_chatgpt_import.py
@@ -750,3 +750,174 @@ class TestConfirmMarkdownImportDedup:
             Node.content.contains("file c content"),
         ).one()
         assert node_c.parent_id == node_b.id
+
+
+# ── POST confirm endpoints: soft-deleted content (restore-or-skip) ───────
+
+class TestConfirmImportDeletedContent:
+    """Imports colliding with soft-deleted nodes prompt restore-or-skip."""
+
+    def _count_nodes(self, user_id):
+        return Node.query.filter_by(human_owner_id=user_id).count()
+
+    def _soft_delete_all(self, user_id, wipe_content=False):
+        """Soft-delete all of the user's nodes (optionally as wiped
+        tombstones, mirroring the cleanup task's content wipe)."""
+        from datetime import datetime
+        for node in Node.query.filter_by(human_owner_id=user_id).all():
+            node.deleted_at = datetime.utcnow()
+            if wipe_content:
+                node.content = None
+        _db.session.commit()
+
+    def test_reimport_of_deleted_content_returns_409(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        assert _confirm_conversations(client, convs).status_code == 201
+        self._soft_delete_all(alice.id)
+
+        r = _confirm_conversations(client, convs)
+        assert r.status_code == 409
+        body = r.get_json()
+        assert body["error"] == "deleted_content_matches"
+        assert body["deleted_matches"] == 2
+        # Nothing changed: no new nodes, originals still deleted.
+        assert self._count_nodes(alice.id) == 2
+        assert all(
+            n.deleted_at is not None
+            for n in Node.query.filter_by(human_owner_id=alice.id)
+        )
+
+    def test_on_deleted_skip_keeps_nodes_deleted(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        _confirm_conversations(client, convs)
+        self._soft_delete_all(alice.id)
+
+        r = _confirm_conversations(client, convs, on_deleted="skip")
+        assert r.status_code == 201
+        body = r.get_json()
+        assert body["created"] == 0
+        assert body["skipped"] == 2
+        assert body["restored"] == 0
+        assert self._count_nodes(alice.id) == 2
+        assert all(
+            n.deleted_at is not None
+            for n in Node.query.filter_by(human_owner_id=alice.id)
+        )
+
+    def test_on_deleted_restore_undeletes_wiped_tombstones(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+        _confirm_conversations(client, convs)
+        original_ids = sorted(
+            n.id for n in Node.query.filter_by(human_owner_id=alice.id)
+        )
+        # Wiped tombstones: content already cleared by the cleanup task.
+        self._soft_delete_all(alice.id, wipe_content=True)
+
+        r = _confirm_conversations(client, convs, on_deleted="restore")
+        assert r.status_code == 201
+        body = r.get_json()
+        assert body["created"] == 0
+        assert body["skipped"] == 0
+        assert body["restored"] == 2
+        # Same rows, un-deleted, content refilled from the archive.
+        nodes = Node.query.filter_by(human_owner_id=alice.id).all()
+        assert sorted(n.id for n in nodes) == original_ids
+        assert all(n.deleted_at is None for n in nodes)
+        assert all(n.content for n in nodes)
+
+    def test_overlap_snapshot_chains_onto_restored_node(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        _confirm_conversations(client, [_analyzed_conv()])
+        self._soft_delete_all(alice.id)
+
+        extended = _analyzed_conv(messages=[
+            {
+                "text": "hello world",
+                "role": "user",
+                "created_at": "2023-11-14T22:13:20",
+                "model": "",
+                "mapping_id": "u1",
+            },
+            {
+                "text": "hi there, friend",
+                "role": "assistant",
+                "created_at": "2023-11-14T22:13:21",
+                "model": "gpt-4o",
+                "mapping_id": "a1",
+            },
+            {
+                "text": "one more question",
+                "role": "user",
+                "created_at": "2023-11-14T22:14:00",
+                "model": "",
+                "mapping_id": "u2",
+            },
+        ])
+        r = _confirm_conversations(client, [extended], on_deleted="restore")
+        assert r.status_code == 201
+        body = r.get_json()
+        assert body["created"] == 1
+        assert body["restored"] == 2
+        assert body["skipped"] == 0
+
+        new_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:u2"
+        ).one()
+        prev_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="chatgpt:a1"
+        ).one()
+        assert prev_node.deleted_at is None
+        assert new_node.parent_id == prev_node.id
+
+    def test_markdown_reimport_restore_only_deleted_file(self, app):
+        # One deleted file out of two: 409 reports 1 match; restore
+        # un-deletes it while the alive duplicate is just skipped.
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        from datetime import datetime
+        files = [
+            _md_file("a", "file a content", "2024-01-01T12:00:00"),
+            _md_file("b", "file b content", "2024-01-02T12:00:00"),
+        ]
+        _confirm_files(client, files, import_type="separate_nodes")
+        node_a = Node.query.filter(
+            Node.human_owner_id == alice.id,
+            Node.content.contains("file a content"),
+        ).one()
+        node_a.deleted_at = datetime.utcnow()
+        _db.session.commit()
+
+        r1 = _confirm_files(client, files, import_type="separate_nodes")
+        assert r1.status_code == 409
+        assert r1.get_json()["deleted_matches"] == 1
+
+        r2 = _confirm_files(client, files, import_type="separate_nodes",
+                            on_deleted="restore")
+        assert r2.status_code == 201
+        body = r2.get_json()
+        assert body["created"] == 0
+        assert body["restored"] == 1
+        assert body["skipped"] == 1
+        assert Node.query.get(node_a.id).deleted_at is None

--- a/backend/tests/test_claude_import.py
+++ b/backend/tests/test_claude_import.py
@@ -40,7 +40,7 @@ for _mod in ["flask_login", "backend.models", "backend.extensions"]:
 
 import flask_login as _real_flask_login          # noqa: E402
 from backend.extensions import db as _db         # noqa: E402
-from backend.models import User                  # noqa: E402
+from backend.models import User, Node            # noqa: E402
 import backend.models as _real_backend_models    # noqa: E402
 
 
@@ -300,3 +300,178 @@ class TestAnalyzeClaudeImport:
         resp = _post_conversations(client, [])
         # flask_login redirects unauthenticated requests (302/401).
         assert resp.status_code in (302, 401)
+
+
+# ── POST /api/import/claude/confirm (dedup) ──────────────────────────────
+
+def _confirm_conversations(client, conversations, **extra):
+    """POST analyzed conversations to the Claude confirm endpoint."""
+    body = {"conversations": conversations}
+    body.update(extra)
+    return client.post(
+        "/api/import/claude/confirm",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+
+def _analyzed_conv(name="First chat", created_at="2023-11-14T22:13:20Z",
+                   messages=None):
+    """Build a confirm-shaped conversation (mirrors analyze output)."""
+    if messages is None:
+        messages = [
+            {
+                "text": "hello world",
+                "sender": "human",
+                "created_at": "2023-11-14T22:13:20Z",
+                "uuid": "m1",
+            },
+            {
+                "text": "hi there, friend",
+                "sender": "assistant",
+                "created_at": "2023-11-14T22:13:21Z",
+                "uuid": "m2",
+            },
+        ]
+    return {
+        "name": name,
+        "created_at": created_at,
+        "messages": messages,
+        "message_count": len(messages),
+        "token_count": sum(len(m["text"]) // 4 for m in messages),
+    }
+
+
+class TestAnalyzeClaudeImportUuid:
+    def test_message_uuid_passes_through_analyze(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        msg = _msg(text="hello world")
+        msg["uuid"] = "msg-uuid-1"
+        resp = _post_conversations(
+            client, [_conv(chat_messages=[msg])]
+        )
+        assert resp.status_code == 200
+        out = resp.get_json()["conversations"][0]["messages"][0]
+        assert out["uuid"] == "msg-uuid-1"
+
+
+class TestConfirmClaudeImportDedup:
+    def _count_nodes(self, user_id):
+        return Node.query.filter_by(human_owner_id=user_id).count()
+
+    def test_reimport_same_archive_creates_zero_new_nodes(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        convs = [_analyzed_conv()]
+
+        r1 = _confirm_conversations(client, convs)
+        assert r1.status_code == 201
+        b1 = r1.get_json()
+        assert b1["created"] == 2
+        assert b1["skipped"] == 0
+        assert self._count_nodes(alice.id) == 2
+
+        r2 = _confirm_conversations(client, convs)
+        assert r2.status_code == 201
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert b2["thread_count"] == 0
+        assert self._count_nodes(alice.id) == 2
+
+    def test_overlapping_snapshot_chains_onto_existing_thread(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        r1 = _confirm_conversations(client, [_analyzed_conv()])
+        assert r1.get_json()["created"] == 2
+
+        extended = _analyzed_conv(messages=[
+            {
+                "text": "hello world",
+                "sender": "human",
+                "created_at": "2023-11-14T22:13:20Z",
+                "uuid": "m1",
+            },
+            {
+                "text": "hi there, friend",
+                "sender": "assistant",
+                "created_at": "2023-11-14T22:13:21Z",
+                "uuid": "m2",
+            },
+            {
+                "text": "one more question",
+                "sender": "human",
+                "created_at": "2023-11-14T22:14:00Z",
+                "uuid": "m3",
+            },
+        ])
+        r2 = _confirm_conversations(client, [extended])
+        b2 = r2.get_json()
+        assert b2["created"] == 1
+        assert b2["skipped"] == 2
+        assert b2["thread_count"] == 0
+        assert self._count_nodes(alice.id) == 3
+
+        new_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="claude:m3"
+        ).one()
+        prev_node = Node.query.filter_by(
+            human_owner_id=alice.id, source_key="claude:m2"
+        ).one()
+        assert new_node.parent_id == prev_node.id
+
+    def test_renamed_conversation_still_dedups(self, app):
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        r1 = _confirm_conversations(client, [_analyzed_conv(name="Old")])
+        assert r1.get_json()["created"] == 2
+
+        r2 = _confirm_conversations(client, [_analyzed_conv(name="New")])
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 2
+
+    def test_missing_uuid_falls_back_to_content_hash(self, app):
+        # Older analyze payloads (no uuid field) still dedup via the
+        # generic content-hash fallback.
+        client = app.test_client()
+        alice = _make_user("alice")
+        _db.session.commit()
+        _login(client, alice.id)
+
+        messages = [
+            {
+                "text": "hello world",
+                "sender": "human",
+                "created_at": "2023-11-14T22:13:20Z",
+            },
+            {
+                "text": "hi there, friend",
+                "sender": "assistant",
+                "created_at": "2023-11-14T22:13:21Z",
+            },
+        ]
+        convs = [_analyzed_conv(messages=messages)]
+
+        r1 = _confirm_conversations(client, convs)
+        assert r1.get_json()["created"] == 2
+
+        r2 = _confirm_conversations(client, convs)
+        b2 = r2.get_json()
+        assert b2["created"] == 0
+        assert b2["skipped"] == 2
+        assert self._count_nodes(alice.id) == 2

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -132,6 +132,25 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
   const [showPicker, setShowPicker] = useState(false);
 
+  // Restore-or-skip prompt shown when a confirm collides with content
+  // the user previously deleted: { count, retry }. `retry` re-runs the
+  // confirm with on_deleted set to the user's choice.
+  const [deletedPrompt, setDeletedPrompt] = useState(null);
+
+  // Returns true when the error is the backend's 409 "this import
+  // matches soft-deleted nodes" conflict, in which case the prompt is
+  // shown instead of an error message.
+  const handleDeletedConflict = (err, retry) => {
+    const data = err.response?.data;
+    if (err.response?.status === 409 && data?.error === "deleted_content_matches") {
+      setDeletedPrompt({ count: data.deleted_matches, retry });
+      setImporting(false);
+      setImportStage(null);
+      return true;
+    }
+    return false;
+  };
+
   // Close picker dialog on Escape
   useEffect(() => {
     if (!showPicker) return;
@@ -169,7 +188,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
       });
   };
 
-  const handleConfirmImport = () => {
+  const handleConfirmImport = (onDeleted) => {
     if (!importFiles) return;
 
     setImporting(true);
@@ -179,7 +198,8 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
       import_type: importType,
       date_ordering: dateOrdering,
       privacy_level: importPrivacy,
-      ai_usage: importAiUsage
+      ai_usage: importAiUsage,
+      ...(onDeleted ? { on_deleted: onDeleted } : {})
     })
       .then((response) => {
         setShowImportDialog(false);
@@ -193,6 +213,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         window.location.reload();
       })
       .catch((err) => {
+        if (handleDeletedConflict(err, handleConfirmImport)) return;
         console.error("Error importing data:", err);
         setError(err.response?.data?.error || "Error importing data. Please try again.");
         setImporting(false);
@@ -234,7 +255,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     event.target.value = "";
   };
 
-  const handleConfirmTwitterImport = () => {
+  const handleConfirmTwitterImport = (onDeleted) => {
     if (!twitterImportData) return;
 
     setImporting(true);
@@ -244,7 +265,8 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
       import_type: importType,
       include_replies: includeReplies,
       privacy_level: importPrivacy,
-      ai_usage: importAiUsage
+      ai_usage: importAiUsage,
+      ...(onDeleted ? { on_deleted: onDeleted } : {})
     })
       .then((response) => {
         setShowTwitterImportDialog(false);
@@ -258,6 +280,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         window.location.reload();
       })
       .catch((err) => {
+        if (handleDeletedConflict(err, handleConfirmTwitterImport)) return;
         console.error("Error importing Twitter data:", err);
         setError(err.response?.data?.error || "Error importing Twitter data. Please try again.");
         setImporting(false);
@@ -315,7 +338,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
       });
   };
 
-  const handleConfirmClaudeImport = () => {
+  const handleConfirmClaudeImport = (onDeleted) => {
     if (!claudeImportData) return;
 
     setImporting(true);
@@ -323,7 +346,8 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     api.post("/import/claude/confirm", {
       conversations: claudeImportData.conversations,
       privacy_level: importPrivacy,
-      ai_usage: importAiUsage
+      ai_usage: importAiUsage,
+      ...(onDeleted ? { on_deleted: onDeleted } : {})
     })
       .then((response) => {
         setShowClaudeImportDialog(false);
@@ -337,6 +361,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         window.location.reload();
       })
       .catch((err) => {
+        if (handleDeletedConflict(err, handleConfirmClaudeImport)) return;
         console.error("Error importing Claude data:", err);
         setError(err.response?.data?.error || "Error importing Claude data. Please try again.");
         setImporting(false);
@@ -409,7 +434,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
       });
   };
 
-  const handleConfirmChatGPTImport = () => {
+  const handleConfirmChatGPTImport = (onDeleted) => {
     if (!chatGPTImportData) return;
 
     setImporting(true);
@@ -417,7 +442,8 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
     api.post("/import/chatgpt/confirm", {
       conversations: chatGPTImportData.conversations,
       privacy_level: importPrivacy,
-      ai_usage: importAiUsage
+      ai_usage: importAiUsage,
+      ...(onDeleted ? { on_deleted: onDeleted } : {})
     })
       .then((response) => {
         setShowChatGPTImportDialog(false);
@@ -431,6 +457,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         window.location.reload();
       })
       .catch((err) => {
+        if (handleDeletedConflict(err, handleConfirmChatGPTImport)) return;
         console.error("Error importing ChatGPT data:", err);
         setError(err.response?.data?.error || "Error importing ChatGPT data. Please try again.");
         setImporting(false);
@@ -446,6 +473,56 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
   return (
     <div>
       {error && <div style={{ color: "var(--accent)", marginBottom: "0.8rem", fontSize: "0.88rem" }}>{error}</div>}
+
+      {/* Restore-or-skip prompt for imports matching deleted content */}
+      {deletedPrompt && (
+        <div style={{
+          marginTop: "20px",
+          padding: "2rem",
+          backgroundColor: "var(--bg-card)",
+          borderRadius: "10px",
+          border: "1px solid var(--border)"
+        }}>
+          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>
+            Previously Deleted Content Found
+          </h3>
+          <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
+            <strong style={{ color: "var(--text-primary)" }}>{deletedPrompt.count}</strong>{" "}
+            message{deletedPrompt.count !== 1 ? "s" : ""} in this import match
+            content you previously deleted. Do you want to restore{" "}
+            {deletedPrompt.count !== 1 ? "them" : "it"}, or keep{" "}
+            {deletedPrompt.count !== 1 ? "them" : "it"} deleted?
+          </p>
+          <div style={{ display: "flex", gap: "10px", marginTop: "15px", flexWrap: "wrap" }}>
+            <button
+              onClick={() => {
+                const retry = deletedPrompt.retry;
+                setDeletedPrompt(null);
+                retry("restore");
+              }}
+              style={primaryBtnStyle}
+            >
+              Restore deleted content
+            </button>
+            <button
+              onClick={() => {
+                const retry = deletedPrompt.retry;
+                setDeletedPrompt(null);
+                retry("skip");
+              }}
+              style={cancelBtnStyle}
+            >
+              Keep it deleted
+            </button>
+            <button
+              onClick={() => setDeletedPrompt(null)}
+              style={cancelBtnStyle}
+            >
+              Cancel import
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Shared import option labels */}
       {(() => {
@@ -668,7 +745,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
           <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
             <button
-              onClick={handleConfirmImport}
+              onClick={() => handleConfirmImport()}
               disabled={importing}
               style={{
                 ...primaryBtnStyle,
@@ -723,7 +800,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
           <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
             <button
-              onClick={handleConfirmClaudeImport}
+              onClick={() => handleConfirmClaudeImport()}
               disabled={importing}
               style={{
                 ...primaryBtnStyle,
@@ -778,7 +855,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
           <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
             <button
-              onClick={handleConfirmChatGPTImport}
+              onClick={() => handleConfirmChatGPTImport()}
               disabled={importing}
               style={{
                 ...primaryBtnStyle,
@@ -891,7 +968,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
           <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
             <button
-              onClick={handleConfirmTwitterImport}
+              onClick={() => handleConfirmTwitterImport()}
               disabled={importing}
               style={{
                 ...primaryBtnStyle,

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -564,6 +564,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
             {[
               { label: "Imported", value: importResult.created, highlight: importResult.created > 0 },
               { label: "Restored", value: importResult.restored || 0, highlight: importResult.restored > 0 },
+              { label: "Updated", value: importResult.updated || 0, highlight: importResult.updated > 0 },
               { label: "Skipped", value: importResult.skipped || 0, highlight: false },
             ].filter((s) => s.label === "Imported" || s.value > 0).map((s) => (
               <div key={s.label}>
@@ -586,14 +587,24 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
               </div>
             ))}
           </div>
-          {importResult.created === 0 && !importResult.restored ? (
+          {importResult.created === 0 && !importResult.restored && !importResult.updated ? (
             <p style={{ fontFamily: "var(--serif)", fontStyle: "italic", fontWeight: 300, color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
               Everything in this archive was already imported — nothing new was added.
             </p>
           ) : (
-            <p style={{ fontFamily: "var(--sans)", fontWeight: 300, fontSize: "0.88rem", color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
-              Skipped items were already imported and left untouched.
-            </p>
+            <>
+              {importResult.updated > 0 && (
+                <p style={{ fontFamily: "var(--sans)", fontWeight: 300, fontSize: "0.88rem", color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
+                  Updated items were already imported; their privacy and
+                  AI-usage settings now match this import.
+                </p>
+              )}
+              {importResult.skipped > 0 && (
+                <p style={{ fontFamily: "var(--sans)", fontWeight: 300, fontSize: "0.88rem", color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
+                  Skipped items were already imported and left untouched.
+                </p>
+              )}
+            </>
           )}
           <button
             onClick={() => window.location.reload()}

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -97,6 +97,8 @@ function ModalShell({ onDismiss, children, maxWidth = "440px" }) {
           maxWidth,
           width: "90vw",
           boxShadow: "0 24px 80px rgba(0,0,0,0.5)",
+          maxHeight: "85vh",
+          overflowY: "auto",
           animation: "loore-modal-rise 0.35s cubic-bezier(0.22, 1, 0.36, 1)",
         }}
       >
@@ -218,6 +220,14 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
   // as a summary after the import finishes; dismissing it reloads the
   // page so the new nodes appear.
   const [importResult, setImportResult] = useState(null);
+
+  // Backdrop/Escape dismiss for the confirm-dialog modals: ignored while
+  // a request is in flight or while a prompt modal is stacked on top
+  // (Escape would otherwise close both layers at once).
+  const dismissGuard = (cancel) => () => {
+    if (importing || deletedPrompt || importResult) return;
+    cancel();
+  };
 
   // Returns true when the error is the backend's 409 "this import
   // matches soft-deleted nodes" conflict, in which case the prompt is
@@ -784,14 +794,8 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
       {/* Markdown import confirmation dialog */}
       {showImportDialog && importFiles && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>Confirm Import</h3>
+        <ModalShell onDismiss={dismissGuard(handleCancelImport)} maxWidth="520px">
+          <ModalTitle>Confirm Import</ModalTitle>
           <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
             Found <strong style={{ color: "var(--text-primary)" }}>{importFiles.total_files}</strong> .md file{importFiles.total_files !== 1 ? 's' : ''}
             ({importFiles.total_size.toLocaleString()} bytes)
@@ -901,19 +905,13 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
               Cancel
             </button>
           </div>
-        </div>
+        </ModalShell>
       )}
 
       {/* Claude import confirmation dialog */}
       {showClaudeImportDialog && claudeImportData && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>Confirm Claude Import</h3>
+        <ModalShell onDismiss={dismissGuard(handleCancelClaudeImport)} maxWidth="520px">
+          <ModalTitle>Confirm Claude Import</ModalTitle>
           <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
             Found <strong style={{ color: "var(--text-primary)" }}>{claudeImportData.total_conversations}</strong> conversation{claudeImportData.total_conversations !== 1 ? 's' : ''} with{" "}
             <strong style={{ color: "var(--text-primary)" }}>{claudeImportData.total_messages}</strong> messages
@@ -956,19 +954,13 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
               Cancel
             </button>
           </div>
-        </div>
+        </ModalShell>
       )}
 
       {/* ChatGPT import confirmation dialog */}
       {showChatGPTImportDialog && chatGPTImportData && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>Confirm ChatGPT Import</h3>
+        <ModalShell onDismiss={dismissGuard(handleCancelChatGPTImport)} maxWidth="520px">
+          <ModalTitle>Confirm ChatGPT Import</ModalTitle>
           <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
             Found <strong style={{ color: "var(--text-primary)" }}>{chatGPTImportData.total_conversations}</strong> conversation{chatGPTImportData.total_conversations !== 1 ? 's' : ''} with{" "}
             <strong style={{ color: "var(--text-primary)" }}>{chatGPTImportData.total_messages}</strong> messages
@@ -1011,19 +1003,13 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
               Cancel
             </button>
           </div>
-        </div>
+        </ModalShell>
       )}
 
       {/* Twitter import confirmation dialog */}
       {showTwitterImportDialog && twitterImportData && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>Confirm Twitter Import</h3>
+        <ModalShell onDismiss={dismissGuard(handleCancelTwitterImport)} maxWidth="520px">
+          <ModalTitle>Confirm Twitter Import</ModalTitle>
           <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
             Found <strong style={{ color: "var(--text-primary)" }}>{twitterImportData.total_tweets}</strong> tweets
             ({twitterImportData.original_count} original, {twitterImportData.reply_count} replies)
@@ -1124,7 +1110,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
               Cancel
             </button>
           </div>
-        </div>
+        </ModalShell>
       )}
     </div>
   );

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -588,7 +588,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
             ))}
           </div>
           {importResult.created === 0 && !importResult.restored && !importResult.updated ? (
-            <p style={{ fontFamily: "var(--serif)", fontStyle: "italic", fontWeight: 300, color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
+            <p style={{ fontFamily: "var(--sans)", fontWeight: 300, fontSize: "0.92rem", color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
               Everything in this archive was already imported — nothing new was added.
             </p>
           ) : (

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -137,6 +137,11 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
   // confirm with on_deleted set to the user's choice.
   const [deletedPrompt, setDeletedPrompt] = useState(null);
 
+  // Confirm-response stats ({ created, skipped, restored, ... }) shown
+  // as a summary after the import finishes; dismissing it reloads the
+  // page so the new nodes appear.
+  const [importResult, setImportResult] = useState(null);
+
   // Returns true when the error is the backend's 409 "this import
   // matches soft-deleted nodes" conflict, in which case the prompt is
   // shown instead of an error message.
@@ -210,7 +215,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
         }
-        window.location.reload();
+        setImportResult(response.data);
       })
       .catch((err) => {
         if (handleDeletedConflict(err, handleConfirmImport)) return;
@@ -277,7 +282,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
         }
-        window.location.reload();
+        setImportResult(response.data);
       })
       .catch((err) => {
         if (handleDeletedConflict(err, handleConfirmTwitterImport)) return;
@@ -358,7 +363,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
         }
-        window.location.reload();
+        setImportResult(response.data);
       })
       .catch((err) => {
         if (handleDeletedConflict(err, handleConfirmClaudeImport)) return;
@@ -454,7 +459,7 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
         if (response.data.profile_update_task_id && onProfileUpdateStarted) {
           onProfileUpdateStarted(response.data.profile_update_task_id);
         }
-        window.location.reload();
+        setImportResult(response.data);
       })
       .catch((err) => {
         if (handleDeletedConflict(err, handleConfirmChatGPTImport)) return;
@@ -473,6 +478,53 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
   return (
     <div>
       {error && <div style={{ color: "var(--accent)", marginBottom: "0.8rem", fontSize: "0.88rem" }}>{error}</div>}
+
+      {/* Post-import summary: what was actually imported vs skipped */}
+      {importResult && (
+        <div style={{
+          marginTop: "20px",
+          padding: "2rem",
+          backgroundColor: "var(--bg-card)",
+          borderRadius: "10px",
+          border: "1px solid var(--border)"
+        }}>
+          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>
+            Import Finished
+          </h3>
+          <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
+            <strong style={{ color: "var(--text-primary)" }}>{importResult.created}</strong>{" "}
+            new node{importResult.created !== 1 ? "s" : ""} imported
+            {importResult.restored > 0 && (
+              <>
+                {", "}
+                <strong style={{ color: "var(--text-primary)" }}>{importResult.restored}</strong>{" "}
+                restored from deleted
+              </>
+            )}
+            {importResult.skipped > 0 && (
+              <>
+                {", "}
+                <strong style={{ color: "var(--text-primary)" }}>{importResult.skipped}</strong>{" "}
+                skipped (already imported)
+              </>
+            )}
+            .
+          </p>
+          {importResult.created === 0 && !importResult.restored && (
+            <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
+              Everything in this archive was already imported — nothing new was added.
+            </p>
+          )}
+          <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
+            <button
+              onClick={() => window.location.reload()}
+              style={primaryBtnStyle}
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Restore-or-skip prompt for imports matching deleted content */}
       {deletedPrompt && (

--- a/frontend/src/components/ImportData.js
+++ b/frontend/src/components/ImportData.js
@@ -52,6 +52,83 @@ function ImportSpinner({ stage, fallback }) {
   );
 }
 
+// Centered modal overlay matching the import-picker pattern: portal to
+// document.body, dimmed blurred backdrop, card with a quiet rise-in.
+// Backdrop click and Escape both call onDismiss.
+function ModalShell({ onDismiss, children, maxWidth = "440px" }) {
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onDismiss();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onDismiss]);
+
+  return ReactDOM.createPortal(
+    <div
+      onClick={onDismiss}
+      style={{
+        position: "fixed",
+        top: 0, left: 0, right: 0, bottom: 0,
+        backgroundColor: "rgba(5, 4, 3, 0.75)",
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 2000,
+        animation: "loore-modal-fade 0.25s ease-out",
+      }}
+    >
+      <style>{`
+        @keyframes loore-modal-fade { from { opacity: 0; } }
+        @keyframes loore-modal-rise {
+          from { opacity: 0; transform: translateY(14px) scale(0.98); }
+        }
+      `}</style>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--bg-card)",
+          border: "1px solid var(--border)",
+          borderRadius: "12px",
+          padding: "2.5rem",
+          minWidth: "300px",
+          maxWidth,
+          width: "90vw",
+          boxShadow: "0 24px 80px rgba(0,0,0,0.5)",
+          animation: "loore-modal-rise 0.35s cubic-bezier(0.22, 1, 0.36, 1)",
+        }}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// Serif modal heading with a short amber hairline underneath.
+function ModalTitle({ children }) {
+  return (
+    <>
+      <h3 style={{
+        fontFamily: "var(--serif)",
+        fontWeight: 300,
+        fontSize: "1.35rem",
+        color: "var(--text-primary)",
+        margin: 0,
+      }}>{children}</h3>
+      <div style={{
+        width: "2rem",
+        height: "1px",
+        backgroundColor: "var(--accent)",
+        opacity: 0.6,
+        margin: "0.9rem 0 1.4rem",
+      }} />
+    </>
+  );
+}
+
 // Extract the conversations.json blob from a Claude/ChatGPT export zip in
 // the browser, so the full (potentially multi-GB) export with images/audio
 // never has to traverse the network.
@@ -481,71 +558,65 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
 
       {/* Post-import summary: what was actually imported vs skipped */}
       {importResult && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>
-            Import Finished
-          </h3>
-          <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
-            <strong style={{ color: "var(--text-primary)" }}>{importResult.created}</strong>{" "}
-            new node{importResult.created !== 1 ? "s" : ""} imported
-            {importResult.restored > 0 && (
-              <>
-                {", "}
-                <strong style={{ color: "var(--text-primary)" }}>{importResult.restored}</strong>{" "}
-                restored from deleted
-              </>
-            )}
-            {importResult.skipped > 0 && (
-              <>
-                {", "}
-                <strong style={{ color: "var(--text-primary)" }}>{importResult.skipped}</strong>{" "}
-                skipped (already imported)
-              </>
-            )}
-            .
-          </p>
-          {importResult.created === 0 && !importResult.restored && (
-            <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
+        <ModalShell onDismiss={() => window.location.reload()}>
+          <ModalTitle>Import Finished</ModalTitle>
+          <div style={{ display: "flex", gap: "2.4rem", marginBottom: "1.3rem" }}>
+            {[
+              { label: "Imported", value: importResult.created, highlight: importResult.created > 0 },
+              { label: "Restored", value: importResult.restored || 0, highlight: importResult.restored > 0 },
+              { label: "Skipped", value: importResult.skipped || 0, highlight: false },
+            ].filter((s) => s.label === "Imported" || s.value > 0).map((s) => (
+              <div key={s.label}>
+                <div style={{
+                  fontFamily: "var(--serif)",
+                  fontWeight: 300,
+                  fontSize: "2.2rem",
+                  lineHeight: 1.1,
+                  color: s.highlight ? "var(--accent)" : "var(--text-primary)",
+                }}>{s.value}</div>
+                <div style={{
+                  fontFamily: "var(--sans)",
+                  fontWeight: 400,
+                  fontSize: "0.7rem",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.14em",
+                  color: "var(--text-muted)",
+                  marginTop: "0.3rem",
+                }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+          {importResult.created === 0 && !importResult.restored ? (
+            <p style={{ fontFamily: "var(--serif)", fontStyle: "italic", fontWeight: 300, color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
               Everything in this archive was already imported — nothing new was added.
             </p>
+          ) : (
+            <p style={{ fontFamily: "var(--sans)", fontWeight: 300, fontSize: "0.88rem", color: "var(--text-secondary)", margin: "0 0 1.4rem" }}>
+              Skipped items were already imported and left untouched.
+            </p>
           )}
-          <div style={{ display: "flex", gap: "10px", marginTop: "15px" }}>
-            <button
-              onClick={() => window.location.reload()}
-              style={primaryBtnStyle}
-            >
-              OK
-            </button>
-          </div>
-        </div>
+          <button
+            onClick={() => window.location.reload()}
+            style={primaryBtnStyle}
+          >
+            OK
+          </button>
+        </ModalShell>
       )}
 
       {/* Restore-or-skip prompt for imports matching deleted content */}
       {deletedPrompt && (
-        <div style={{
-          marginTop: "20px",
-          padding: "2rem",
-          backgroundColor: "var(--bg-card)",
-          borderRadius: "10px",
-          border: "1px solid var(--border)"
-        }}>
-          <h3 style={{ fontFamily: "var(--serif)", fontWeight: 300, color: "var(--text-primary)", margin: "0 0 12px 0" }}>
-            Previously Deleted Content Found
-          </h3>
-          <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300 }}>
+        <ModalShell onDismiss={() => setDeletedPrompt(null)}>
+          <ModalTitle>Previously Deleted Content</ModalTitle>
+          <p style={{ color: "var(--text-secondary)", fontFamily: "var(--sans)", fontWeight: 300, margin: "0 0 1.4rem" }}>
             <strong style={{ color: "var(--text-primary)" }}>{deletedPrompt.count}</strong>{" "}
-            message{deletedPrompt.count !== 1 ? "s" : ""} in this import match
-            content you previously deleted. Do you want to restore{" "}
+            message{deletedPrompt.count !== 1 ? "s" : ""} in this import{" "}
+            {deletedPrompt.count !== 1 ? "match" : "matches"} content you
+            previously deleted. Restore{" "}
             {deletedPrompt.count !== 1 ? "them" : "it"}, or keep{" "}
             {deletedPrompt.count !== 1 ? "them" : "it"} deleted?
           </p>
-          <div style={{ display: "flex", gap: "10px", marginTop: "15px", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", gap: "10px", flexWrap: "wrap", alignItems: "center" }}>
             <button
               onClick={() => {
                 const retry = deletedPrompt.retry;
@@ -568,12 +639,12 @@ export default function ImportData({ buttonStyle: customButtonStyle, buttonLabel
             </button>
             <button
               onClick={() => setDeletedPrompt(null)}
-              style={cancelBtnStyle}
+              style={{ ...ghostBtnStyle, border: "none", color: "var(--text-muted)" }}
             >
               Cancel import
             </button>
           </div>
-        </div>
+        </ModalShell>
       )}
 
       {/* Shared import option labels */}


### PR DESCRIPTION
## #136 — Deduplicate imported data (re-imports + snapshot overlap)

Re-importing the same archive used to create duplicate nodes. This adds a per-user `source_key` on `Node` (stable source id where available — ChatGPT mapping id, Claude message uuid, Twitter `id_str`; content hash fallback for markdown zips and legacy payloads) and a dedup check in every `confirm` path. Each confirm response now returns `{created, skipped}`.

Dedup is scoped on `human_owner_id` (the importing human), so assistant turns stored under synthetic LLM users dedup too, while different users importing the same archive each keep their own copy. A `UniqueConstraint(human_owner_id, source_key)` backstops concurrent imports at the DB level.

Key properties:
- **Overlap-safe chaining**: when a later snapshot of a conversation is imported, the already-imported messages are skipped and the genuinely-new messages chain onto the existing copy of the thread (not orphaned as new roots).
- **Rename-proof**: keys are per-message ids alone (`chatgpt:<mapping_id>`, `claude:<uuid>`), so renaming a conversation between exports doesn't re-duplicate it. Keys are bounded well under `String(255)`.
- **One query per import**: existing keys are prefetched into a dict per confirm request instead of one existence query per message.

Model-change only — no hand-written migration (auto-generated on deploy, per CLAUDE.md).

**Verified on staging (combined Chrome pass):**
- Import A,B → `created:2` (nodes 2→4)
- Same archive again → `created:0, skipped:2` (no-op, nodes 4→4)
- Overlap snapshot A,B,C → `created:1, skipped:2` (only the new one, nodes 4→5)

**Test coverage**: re-import no-op, overlap chaining (with parent-linkage assertions), rename-proof dedup, per-user scoping, intra-request dupes, markdown-zip dedup, Claude uuid + hash-fallback dedup, analyze uuid passthrough.

**Soft-deleted content (restore-or-skip)**: when an import collides with nodes the user previously soft-deleted, the confirm endpoints return `409 deleted_content_matches` and the frontend shows a restore-or-skip dialog, retrying with `on_deleted`:
- `skip` — deleted nodes stay deleted (and are not re-imported)
- `restore` — un-deletes them in place, refilling content from the archive (recovers even content-wiped tombstones) while keeping node ids so child links survive

Responses gain a `restored` count alongside `created`/`skipped`.

**Settings update on re-import**: re-importing with a different `privacy_level`/`ai_usage` applies the new values to the already-imported (alive) nodes via one chunked bulk UPDATE per confirm — only rows whose settings actually differ are touched. Restored nodes take the new settings too; deleted matches kept via `on_deleted: "skip"` stay untouched. The response gains an `updated` count, disjoint from `skipped` (skipped = matched and unchanged).

**Post-import summary**: the frontend no longer reloads immediately on confirm — it shows an "Import Finished" card with the actual created/restored/skipped counts (and an explicit "nothing new was added" note for full-duplicate re-imports); the reload happens on dismiss.

**Known limitation**: nodes imported before this PR deployed have NULL `source_key`, so re-importing an archive that was first imported pre-deploy will still duplicate. Dedup only applies between imports that both ran with this change in place.

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

