### PR TITLE
Implement protected/reserved usernames list (#91)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -67,13 +67,15 @@ jobs:
         env:
           VM_HOST: ${{ secrets.VM_HOST }}
           VM_USER: ${{ secrets.VM_USER }}
+          STAGING_ADMIN_EMAIL: ${{ secrets.STAGING_ADMIN_EMAIL }}
           PROJECT_PATH: /home/hrosspet/write-or-perish
         run: |
           # Upload pre-built frontend
           scp -i ~/.ssh/deploy_key frontend-build.tar.gz $VM_USER@$VM_HOST:$PROJECT_PATH/
 
-          # Deploy on VM
-          ssh -i ~/.ssh/deploy_key $VM_USER@$VM_HOST << 'ENDSSH'
+          # Deploy on VM. The heredoc is quoted (no local expansion), so the
+          # admin email is passed as an env var into the remote shell.
+          ssh -i ~/.ssh/deploy_key $VM_USER@$VM_HOST "STAGING_ADMIN_EMAIL='$STAGING_ADMIN_EMAIL' bash -s" << 'ENDSSH'
             set -e
             cd /home/hrosspet/write-or-perish
             git fetch origin
@@ -143,9 +145,9 @@ jobs:
             echo "Seeding admin user..."
             docker compose -p wop-staging exec -T db \
               psql -U staging -d writeorperish_staging \
-              -c "INSERT INTO \"user\" (username, approved, is_admin, craft_mode, plan, created_at, profile_needs_full_regen)
-                  VALUES ('hrosspet', true, true, false, 'alpha', NOW(), false)
-                  ON CONFLICT (username) DO UPDATE SET approved = true, is_admin = true;" < /dev/null
+              -c "INSERT INTO \"user\" (username, email, approved, is_admin, craft_mode, plan, created_at, profile_needs_full_regen)
+                  VALUES ('hrosspet', NULLIF('$STAGING_ADMIN_EMAIL', ''), true, true, false, 'alpha', NOW(), false)
+                  ON CONFLICT (username) DO UPDATE SET email = NULLIF('$STAGING_ADMIN_EMAIL', ''), approved = true, is_admin = true;" < /dev/null
             echo "Database setup complete."
 
             # Switch back to main so production deploys aren't blocked

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -15,11 +15,14 @@ logger = logging.getLogger(__name__)
 
 admin_bp = Blueprint("admin_bp", __name__)
 
-# Decorator to check that the current user is the admin (placeholder check by username)
+# Decorator to check that the current user is an admin. Keyed on the
+# is_admin column (matching nodes.py/sse.py), NOT the username — usernames
+# are renamable, and #91 made 'hrosspet' reserved, so a username-keyed check
+# turns an admin rename into a permanent lockout.
 def admin_required(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
-        if not current_user.is_authenticated or current_user.username != "hrosspet":
+        if not current_user.is_authenticated or not getattr(current_user, "is_admin", False):
             abort(403)  # Forbidden if not admin
         return func(*args, **kwargs)
     return decorated_function

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -9,7 +9,7 @@ from backend.utils.timefmt import iso_utc
 from sqlalchemy import func
 from backend.utils.magic_link import generate_magic_link_token, hash_token
 from backend.utils.email import send_welcome_email
-from backend.utils.reserved_usernames import is_username_reserved
+from backend.utils.reserved_usernames import validate_username
 
 logger = logging.getLogger(__name__)
 
@@ -106,13 +106,11 @@ def whitelist_user():
     if not handle:
         return jsonify({"error": "Handle is required."}), 400
 
-    # Reject reserved/protected handles (brand/founder/system names).
-    if is_username_reserved(handle):
-        return jsonify({"error": "That username is reserved."}), 400
-
-    # Check if a user with that handle already exists.
-    if User.query.filter_by(username=handle).first():
-        return jsonify({"error": "User with that handle already exists."}), 400
+    # Full username validation: format, length, reserved/protected names
+    # (brand/founder/system), and case-insensitive uniqueness.
+    error = validate_username(handle)
+    if error:
+        return jsonify({"error": error}), 400
 
     # Create a new user with the handle
     user = User(twitter_id=None, username=handle, approved=True)

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -9,6 +9,7 @@ from backend.utils.timefmt import iso_utc
 from sqlalchemy import func
 from backend.utils.magic_link import generate_magic_link_token, hash_token
 from backend.utils.email import send_welcome_email
+from backend.utils.reserved_usernames import is_username_reserved
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,10 @@ def whitelist_user():
     handle = data.get("handle", "").strip()
     if not handle:
         return jsonify({"error": "Handle is required."}), 400
+
+    # Reject reserved/protected handles (brand/founder/system names).
+    if is_username_reserved(handle):
+        return jsonify({"error": "That username is reserved."}), 400
 
     # Check if a user with that handle already exists.
     if User.query.filter_by(username=handle).first():

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -12,6 +12,7 @@ from backend.utils.magic_link import (
     hash_token, generate_unique_username,
 )
 from backend.utils.email import send_magic_link_email
+from backend.utils.reserved_usernames import is_username_reserved
 import logging
 from urllib.parse import urlparse
 
@@ -19,6 +20,22 @@ logger = logging.getLogger(__name__)
 auth_bp = Blueprint("auth_bp", __name__)
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _derive_non_reserved_username(handle):
+    """Derive a username that is neither reserved nor already taken.
+
+    Appends an incrementing numeric suffix to the original handle until both
+    the reserved check and the uniqueness check pass. Used when a Twitter
+    screen_name collides with a reserved name during OAuth signup.
+    """
+    suffix = 1
+    while True:
+        candidate = f"{handle}{suffix}"
+        if (not is_username_reserved(candidate)
+                and not User.query.filter_by(username=candidate).first()):
+            return candidate
+        suffix += 1
 
 
 def is_safe_redirect_url(target):
@@ -69,7 +86,11 @@ def login():
             user.twitter_id = twitter_id
             db.session.commit()
         else:
-            # create new user
+            # create new user. If the Twitter handle collides with a reserved
+            # name (brand/founder/system), derive a non-reserved, unique
+            # fallback rather than 400-ing the OAuth callback.
+            if is_username_reserved(username):
+                username = _derive_non_reserved_username(username)
             user = User(twitter_id=twitter_id, username=username)
             db.session.add(user)
             db.session.commit()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -26,14 +26,22 @@ def _derive_non_reserved_username(handle):
     """Derive a username that is neither reserved nor already taken.
 
     Appends an incrementing numeric suffix to the original handle until both
-    the reserved check and the uniqueness check pass. Used when a Twitter
-    screen_name collides with a reserved name during OAuth signup.
+    the reserved check and the uniqueness check (case-insensitive, matching
+    validate_username) pass. Used when a Twitter screen_name collides with a
+    reserved name during OAuth signup.
     """
+    # Brand-substring / founder-prefix reserved matches can't be escaped by
+    # appending digits (e.g. 'myloore1' still contains 'loore'), so fall back
+    # to the neutral 'user' base instead of suffixing forever.
+    if is_username_reserved(f"{handle}1"):
+        handle = "user"
     suffix = 1
     while True:
         candidate = f"{handle}{suffix}"
         if (not is_username_reserved(candidate)
-                and not User.query.filter_by(username=candidate).first()):
+                and not User.query.filter(
+                    db.func.lower(User.username) == candidate.lower()
+                ).first()):
             return candidate
         suffix += 1
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -12,7 +12,9 @@ from backend.utils.magic_link import (
     hash_token, generate_unique_username,
 )
 from backend.utils.email import send_magic_link_email
-from backend.utils.reserved_usernames import is_username_reserved
+from backend.utils.reserved_usernames import (
+    is_username_reserved, derive_available_username,
+)
 import logging
 from urllib.parse import urlparse
 
@@ -20,30 +22,6 @@ logger = logging.getLogger(__name__)
 auth_bp = Blueprint("auth_bp", __name__)
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
-
-
-def _derive_non_reserved_username(handle):
-    """Derive a username that is neither reserved nor already taken.
-
-    Appends an incrementing numeric suffix to the original handle until both
-    the reserved check and the uniqueness check (case-insensitive, matching
-    validate_username) pass. Used when a Twitter screen_name collides with a
-    reserved name during OAuth signup.
-    """
-    # Brand-substring / founder-prefix reserved matches can't be escaped by
-    # appending digits (e.g. 'myloore1' still contains 'loore'), so fall back
-    # to the neutral 'user' base instead of suffixing forever.
-    if is_username_reserved(f"{handle}1"):
-        handle = "user"
-    suffix = 1
-    while True:
-        candidate = f"{handle}{suffix}"
-        if (not is_username_reserved(candidate)
-                and not User.query.filter(
-                    db.func.lower(User.username) == candidate.lower()
-                ).first()):
-            return candidate
-        suffix += 1
 
 
 def is_safe_redirect_url(target):
@@ -98,7 +76,7 @@ def login():
             # name (brand/founder/system), derive a non-reserved, unique
             # fallback rather than 400-ing the OAuth callback.
             if is_username_reserved(username):
-                username = _derive_non_reserved_username(username)
+                username = derive_available_username(username)
             user = User(twitter_id=twitter_id, username=username)
             db.session.add(user)
             db.session.commit()

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -1,5 +1,3 @@
-import re
-
 from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
 from backend.models import Node, User, UserProfile
@@ -9,6 +7,7 @@ from backend.utils.privacy import (
     accessible_nodes_filter, VALID_PRIVACY_LEVELS, VALID_AI_USAGE,
 )
 from backend.routes.terms import CURRENT_TERMS_VERSION
+from backend.utils.reserved_usernames import validate_username
 
 dashboard_bp = Blueprint("dashboard_bp", __name__)
 
@@ -191,21 +190,11 @@ def update_user():
 
     if new_username:
         new_username = new_username.strip()
-        if not new_username:
-            return jsonify({"error": "Username cannot be empty."}), 400
-        if len(new_username) > 64:
-            return jsonify({"error": "Username must be 64 characters or fewer."}), 400
-        if not re.fullmatch(r'[a-zA-Z0-9_]+', new_username):
-            return jsonify({
-                "error": "Username may only contain letters, numbers, and underscores."
-            }), 400
-        # Case-insensitive uniqueness check (exclude current user)
-        existing = User.query.filter(
-            db.func.lower(User.username) == new_username.lower(),
-            User.id != current_user.id
-        ).first()
-        if existing:
-            return jsonify({"error": "That username is already taken."}), 400
+        # Validates non-empty, length, allowed chars, reserved names, and
+        # case-insensitive uniqueness (excluding the current user's own row).
+        error = validate_username(new_username, exclude_user_id=current_user.id)
+        if error:
+            return jsonify({"error": error}), 400
         current_user.username = new_username
 
     if new_description is not None:

--- a/backend/tests/test_admin_access.py
+++ b/backend/tests/test_admin_access.py
@@ -1,0 +1,131 @@
+"""Tests for admin endpoint access control.
+
+admin_required must be keyed on the is_admin column, NOT the username:
+usernames are renamable, and #91 made 'hrosspet' reserved, so the old
+username-keyed placeholder check turned an admin rename into a permanent
+lockout (rename away allowed, rename back rejected as reserved).
+
+Follows the real-app + sqlite pattern from test_audio_access.py.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+# Mock optional heavy deps that may not be installed locally
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest
+from flask import Flask
+
+# ── Force-import real modules ────────────────────────────────────────────
+# Only evict specific mocks that other test files may have installed.
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+import flask_login as _real_flask_login  # noqa: E402
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User  # noqa: E402
+import backend.models as _real_backend_models  # noqa: E402
+
+
+def _make_app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+
+    _db.init_app(app)
+
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.admin import admin_bp
+    app.register_blueprint(admin_bp, url_prefix="/api/admin")
+
+    return app
+
+
+@pytest.fixture
+def app():
+    _affected = lambda k: (  # noqa: E731
+        k == "flask_login"
+        or k.startswith("backend.routes")
+        or k == "backend.models"
+    )
+    saved = {k: sys.modules[k] for k in list(sys.modules) if _affected(k)}
+
+    sys.modules["flask_login"] = _real_flask_login
+    sys.modules["backend.models"] = _real_backend_models
+    for _k in [k for k in list(sys.modules) if k.startswith("backend.routes")]:
+        del sys.modules[_k]
+
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+    for k in [k for k in list(sys.modules) if _affected(k)]:
+        if k not in saved:
+            del sys.modules[k]
+    for k, mod in saved.items():
+        sys.modules[k] = mod
+
+
+@pytest.fixture
+def users(app):
+    """Two users covering both sides of the is_admin/username matrix:
+
+    - renamed_admin: is_admin=True with a non-founder username (an admin
+      who renamed away from 'hrosspet' must keep admin access)
+    - impostor: username 'hrosspet' but is_admin=False (the username alone
+      must no longer grant admin)
+    """
+    renamed_admin = User(username="explore", approved=True, is_admin=True)
+    impostor = User(username="hrosspet", approved=True, is_admin=False)
+    _db.session.add_all([renamed_admin, impostor])
+    _db.session.commit()
+    return {"renamed_admin": renamed_admin, "impostor": impostor}
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+
+
+class TestAdminRequired:
+    def test_is_admin_user_allowed_regardless_of_username(self, app, users):
+        client = app.test_client()
+        _login(client, users["renamed_admin"].id)
+        resp = client.get("/api/admin/users")
+        assert resp.status_code == 200
+
+    def test_username_hrosspet_without_is_admin_forbidden(self, app, users):
+        client = app.test_client()
+        _login(client, users["impostor"].id)
+        resp = client.get("/api/admin/users")
+        assert resp.status_code == 403
+
+    def test_unauthenticated_rejected(self, app, users):
+        client = app.test_client()
+        resp = client.get("/api/admin/users")
+        # login_required fires first; unauthenticated is 401 by default
+        assert resp.status_code in (401, 403)

--- a/backend/tests/test_magic_link.py
+++ b/backend/tests/test_magic_link.py
@@ -137,9 +137,11 @@ class TestGenerateUniqueUsername:
             assert result == "johndoetag"
 
     def test_empty_prefix_fallback(self, app):
-        mock_user = self._make_mock_user([None])
+        # The bare 'user' fallback is itself a reserved name (issue #91), so
+        # generate_unique_username must skip it and append a suffix.
+        mock_user = self._make_mock_user([None, None])
         with app.app_context(), \
                 patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("@example.com")
-            assert result == "user"
+            assert result == "user2"

--- a/backend/tests/test_magic_link.py
+++ b/backend/tests/test_magic_link.py
@@ -92,19 +92,27 @@ class TestHashToken:
 class TestGenerateUniqueUsername:
     """Test username generation from email.
 
-    generate_unique_username does a deferred import of User from
-    backend.models, so we mock it via the module that gets imported.
+    generate_unique_username does deferred imports of User (backend.models)
+    and db (backend.extensions), so we mock them via the modules that get
+    imported. The uniqueness check is case-insensitive (query.filter with
+    lower()), so the mock tracks .filter, not .filter_by.
     """
 
     def _make_mock_user(self, side_effect):
         mock_user = MagicMock()
-        mock_user.query.filter_by.return_value.first.side_effect = side_effect
+        mock_user.query.filter.return_value.first.side_effect = side_effect
         return mock_user
+
+    def _patched_modules(self, mock_user):
+        return {
+            "backend.models": MagicMock(User=mock_user),
+            "backend.extensions": MagicMock(),
+        }
 
     def test_simple_email(self, app):
         mock_user = self._make_mock_user([None])
         with app.app_context(), \
-                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
             # Re-import to pick up the patched module
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("john@gmail.com")
@@ -114,7 +122,7 @@ class TestGenerateUniqueUsername:
         existing = MagicMock()
         mock_user = self._make_mock_user([existing, None])
         with app.app_context(), \
-                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("john@gmail.com")
             assert result == "john2"
@@ -123,7 +131,7 @@ class TestGenerateUniqueUsername:
         existing = MagicMock()
         mock_user = self._make_mock_user([existing, existing, existing, None])
         with app.app_context(), \
-                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("john@gmail.com")
             assert result == "john4"
@@ -131,7 +139,7 @@ class TestGenerateUniqueUsername:
     def test_email_with_dots_and_plus(self, app):
         mock_user = self._make_mock_user([None])
         with app.app_context(), \
-                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("john.doe+tag@gmail.com")
             assert result == "johndoetag"
@@ -141,7 +149,36 @@ class TestGenerateUniqueUsername:
         # generate_unique_username must skip it and append a suffix.
         mock_user = self._make_mock_user([None, None])
         with app.app_context(), \
-                patch.dict("sys.modules", {"backend.models": MagicMock(User=mock_user)}):
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
             import backend.utils.magic_link as ml
             result = ml.generate_unique_username("@example.com")
             assert result == "user2"
+
+    def test_brand_substring_email_falls_back_to_user(self, app):
+        # 'myloore' contains the brand substring; appending digits never
+        # escapes it, so the generator must fall back to the 'user' base
+        # instead of looping forever.
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("myloore@example.com")
+            assert result == "user2"
+
+    def test_founder_prefix_email_falls_back_to_user(self, app):
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("hrosspetfan@example.com")
+            assert result == "user2"
+
+    def test_exact_reserved_email_keeps_base(self, app):
+        # Exact-match reservations ARE escaped by a suffix, so the original
+        # base is kept: admin -> admin2.
+        mock_user = self._make_mock_user([None])
+        with app.app_context(), \
+                patch.dict("sys.modules", self._patched_modules(mock_user)):
+            import backend.utils.magic_link as ml
+            result = ml.generate_unique_username("admin@example.com")
+            assert result == "admin2"

--- a/backend/tests/test_reserved_usernames.py
+++ b/backend/tests/test_reserved_usernames.py
@@ -46,9 +46,20 @@ class TestIsReservedExact:
 
 
 class TestIsReservedBrandSubstring:
-    @pytest.mark.parametrize("name", ["loore", "LOORE", "Loore", "myloore", "loore123"])
+    @pytest.mark.parametrize("name", [
+        "loore", "LOORE", "Loore", "myloore", "loore123",
+        # Any number of repeated o's (>= 2) and e's (>= 1) -- #175 follow-up
+        "looore", "loooooore", "looree", "loooreee", "LoOoRe",
+        "my_loooree_123",
+    ])
     def test_brand_substring_blocked(self, name):
         assert is_username_reserved(name) is True
+
+    @pytest.mark.parametrize("name", ["loor", "looor"])
+    def test_no_trailing_e_not_brand(self, name):
+        # Without the final 'e' it isn't the brand name. 'loor'/'looor' are
+        # not exact-reserved either, so they remain available.
+        assert is_username_reserved(name) is False
 
 
 class TestIsReservedFounderPrefix:

--- a/backend/tests/test_reserved_usernames.py
+++ b/backend/tests/test_reserved_usernames.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from backend.utils.reserved_usernames import (
+    derive_available_username,
     is_username_reserved,
     validate_username,
     _normalize,
@@ -125,3 +126,47 @@ class TestValidateUsernameUniqueness:
     def test_valid_unique_with_exclude(self):
         with patch.dict(sys.modules, self._patch_modules(exists=False)):
             assert validate_username("alice", exclude_user_id=42) is None
+
+
+class TestDeriveAvailableUsername:
+    """Shared fallback generator used by magic-link and Twitter OAuth signup.
+
+    Mocks the deferred User/db imports; ``side_effect`` is the sequence of
+    .first() results, one per uniqueness DB query (reserved candidates are
+    rejected before any query).
+    """
+
+    def _patch_modules(self, side_effect):
+        mock_user = MagicMock()
+        mock_user.query.filter.return_value.first.side_effect = side_effect
+        return {
+            "backend.models": MagicMock(User=mock_user),
+            "backend.extensions": MagicMock(),
+        }
+
+    def test_available_base_kept(self):
+        with patch.dict(sys.modules, self._patch_modules([None])):
+            assert derive_available_username("alice") == "alice"
+
+    def test_taken_base_gets_suffix(self):
+        with patch.dict(sys.modules, self._patch_modules([MagicMock(), None])):
+            assert derive_available_username("alice") == "alice2"
+
+    def test_exact_reserved_escapes_with_suffix(self):
+        # 'admin' is rejected without a DB query; 'admin2' is queried once.
+        with patch.dict(sys.modules, self._patch_modules([None])):
+            assert derive_available_username("admin") == "admin2"
+
+    def test_brand_substring_falls_back_to_user(self):
+        # Digits never escape a substring match, so the base flips to 'user'
+        # ('user' itself is exact-reserved, hence 'user2').
+        with patch.dict(sys.modules, self._patch_modules([None])):
+            assert derive_available_username("myloore") == "user2"
+
+    def test_founder_prefix_falls_back_to_user(self):
+        with patch.dict(sys.modules, self._patch_modules([None])):
+            assert derive_available_username("hrosspetfan") == "user2"
+
+    def test_empty_base_falls_back_to_user(self):
+        with patch.dict(sys.modules, self._patch_modules([None])):
+            assert derive_available_username("") == "user2"

--- a/backend/tests/test_reserved_usernames.py
+++ b/backend/tests/test_reserved_usernames.py
@@ -1,0 +1,129 @@
+"""Tests for reserved/protected username matching (issue #91).
+
+``is_username_reserved`` is a pure function (no DB), so it is tested directly.
+``validate_username``'s format/reserved checks also short-circuit before any
+DB access; the uniqueness path performs a deferred import of User/db, which we
+mock following the pattern used in test_magic_link.py.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.utils.reserved_usernames import (
+    is_username_reserved,
+    validate_username,
+    _normalize,
+)
+
+
+class TestNormalize:
+    def test_lowercases_and_strips_non_alnum(self):
+        assert _normalize("Pe.ter_X!") == "peterx"
+
+    def test_empty(self):
+        assert _normalize("") == ""
+        assert _normalize(None) == ""
+
+
+class TestIsReservedExact:
+    @pytest.mark.parametrize("name", [
+        "admin", "administrator", "system", "support", "official",
+        "moderator", "dashboard", "api", "lore", "lor", "root", "owner",
+    ])
+    def test_exact_reserved(self, name):
+        assert is_username_reserved(name) is True
+
+    def test_exact_case_insensitive(self):
+        assert is_username_reserved("ADMIN") is True
+        assert is_username_reserved("Admin") is True
+
+    def test_exact_with_punctuation_normalizes(self):
+        # 'a.d.m.i.n' normalizes to 'admin'
+        assert is_username_reserved("a.d.m.i.n") is True
+
+
+class TestIsReservedBrandSubstring:
+    @pytest.mark.parametrize("name", ["loore", "LOORE", "Loore", "myloore", "loore123"])
+    def test_brand_substring_blocked(self, name):
+        assert is_username_reserved(name) is True
+
+
+class TestIsReservedFounderPrefix:
+    @pytest.mark.parametrize("name", ["hrosspet", "peter", "peta", "peterx", "hrosspet_official"])
+    def test_founder_prefix_blocked(self, name):
+        assert is_username_reserved(name) is True
+
+
+class TestNotReserved:
+    @pytest.mark.parametrize("name", [
+        "explore",     # contains 'lore' but not exact, not 'loore'
+        "folklore",    # contains 'lore' but not exact
+        "alice",
+        "bob123",
+        "writer",
+        "petersen_is_not_me",  # does NOT start with a founder prefix? -> starts with 'peter'
+    ])
+    def test_allowed(self, name):
+        # 'petersen_is_not_me' DOES start with 'peter' -> reserved; handle it separately.
+        if name == "petersen_is_not_me":
+            assert is_username_reserved(name) is True
+        else:
+            assert is_username_reserved(name) is False
+
+    def test_explore_explicitly_allowed(self):
+        # Critical: the short exact tokens 'lore'/'lor' must not block 'explore'.
+        assert is_username_reserved("explore") is False
+
+    def test_empty_not_reserved(self):
+        assert is_username_reserved("") is False
+
+
+class TestValidateUsernamePureChecks:
+    """These checks short-circuit before any DB access."""
+
+    def test_empty(self):
+        assert validate_username("") == "Username cannot be empty."
+
+    def test_too_long(self):
+        assert validate_username("a" * 65) == "Username must be 64 characters or fewer."
+
+    def test_bad_chars(self):
+        err = validate_username("bad name!")
+        assert err == "Username may only contain letters, numbers, and underscores."
+
+    @pytest.mark.parametrize("name", ["admin", "LOORE", "Loore", "myloore", "loore123", "peterx"])
+    def test_reserved(self, name):
+        assert validate_username(name) == "That username is reserved."
+
+
+class TestValidateUsernameUniqueness:
+    """The uniqueness path mocks the deferred User/db imports."""
+
+    def _patch_modules(self, exists):
+        mock_user = MagicMock()
+        mock_user.query.filter.return_value.filter.return_value.first.return_value = (
+            MagicMock() if exists else None
+        )
+        # When exclude_user_id is None, only one .filter() is chained.
+        mock_user.query.filter.return_value.first.return_value = (
+            MagicMock() if exists else None
+        )
+        mock_db = MagicMock()
+        return {
+            "backend.models": MagicMock(User=mock_user),
+            "backend.extensions": MagicMock(db=mock_db),
+        }
+
+    def test_valid_unique_allowed(self):
+        with patch.dict(sys.modules, self._patch_modules(exists=False)):
+            assert validate_username("explore") is None
+
+    def test_duplicate_rejected(self):
+        with patch.dict(sys.modules, self._patch_modules(exists=True)):
+            assert validate_username("explore") == "That username is already taken."
+
+    def test_valid_unique_with_exclude(self):
+        with patch.dict(sys.modules, self._patch_modules(exists=False)):
+            assert validate_username("alice", exclude_user_id=42) is None

--- a/backend/tests/test_reserved_usernames.py
+++ b/backend/tests/test_reserved_usernames.py
@@ -48,9 +48,9 @@ class TestIsReservedExact:
 class TestIsReservedBrandSubstring:
     @pytest.mark.parametrize("name", [
         "loore", "LOORE", "Loore", "myloore", "loore123",
-        # Any number of repeated o's (>= 2) and e's (>= 1) -- #175 follow-up
+        # Any number of repeated letters (o's >= 2) -- #175 follow-up
         "looore", "loooooore", "looree", "loooreee", "LoOoRe",
-        "my_loooree_123",
+        "my_loooree_123", "lloore", "loorre", "lloorree", "llooorrreee",
     ])
     def test_brand_substring_blocked(self, name):
         assert is_username_reserved(name) is True

--- a/backend/tests/test_reserved_usernames.py
+++ b/backend/tests/test_reserved_usernames.py
@@ -51,7 +51,7 @@ class TestIsReservedBrandSubstring:
 
 
 class TestIsReservedFounderPrefix:
-    @pytest.mark.parametrize("name", ["hrosspet", "peter", "peta", "peterx", "hrosspet_official"])
+    @pytest.mark.parametrize("name", ["hrosspet", "HRosspet", "hrosspetx", "hrosspet_official"])
     def test_founder_prefix_blocked(self, name):
         assert is_username_reserved(name) is True
 
@@ -63,14 +63,12 @@ class TestNotReserved:
         "alice",
         "bob123",
         "writer",
-        "petersen_is_not_me",  # does NOT start with a founder prefix? -> starts with 'peter'
+        "peter",       # common first names are deliberately not founder-blocked
+        "peta",
+        "petersen_is_not_me",
     ])
     def test_allowed(self, name):
-        # 'petersen_is_not_me' DOES start with 'peter' -> reserved; handle it separately.
-        if name == "petersen_is_not_me":
-            assert is_username_reserved(name) is True
-        else:
-            assert is_username_reserved(name) is False
+        assert is_username_reserved(name) is False
 
     def test_explore_explicitly_allowed(self):
         # Critical: the short exact tokens 'lore'/'lor' must not block 'explore'.
@@ -93,7 +91,7 @@ class TestValidateUsernamePureChecks:
         err = validate_username("bad name!")
         assert err == "Username may only contain letters, numbers, and underscores."
 
-    @pytest.mark.parametrize("name", ["admin", "LOORE", "Loore", "myloore", "loore123", "peterx"])
+    @pytest.mark.parametrize("name", ["admin", "LOORE", "Loore", "myloore", "loore123", "hrosspetx"])
     def test_reserved(self, name):
         assert validate_username(name) == "That username is reserved."
 

--- a/backend/utils/magic_link.py
+++ b/backend/utils/magic_link.py
@@ -39,37 +39,9 @@ def hash_token(token):
 
 
 def generate_unique_username(email):
-    from backend.models import User
-    from backend.extensions import db
-    from backend.utils.reserved_usernames import is_username_reserved
+    from backend.utils.reserved_usernames import derive_available_username
 
     prefix = email.split("@")[0]
     # Clean up prefix: keep only alphanumeric and underscores
     clean = "".join(c for c in prefix if c.isalnum() or c == "_")
-    if not clean:
-        clean = "user"
-
-    # Brand-substring / founder-prefix reserved matches can't be escaped by
-    # appending digits (e.g. 'myloore2' still contains 'loore'), so fall back
-    # to the neutral base instead of suffixing forever.
-    if is_username_reserved(clean) and is_username_reserved(f"{clean}2"):
-        clean = "user"
-
-    def _ok(candidate):
-        # Candidate must be neither reserved nor already taken
-        # (case-insensitive, matching validate_username).
-        if is_username_reserved(candidate):
-            return False
-        return not User.query.filter(
-            db.func.lower(User.username) == candidate.lower()
-        ).first()
-
-    if _ok(clean):
-        return clean
-
-    suffix = 2
-    while True:
-        candidate = f"{clean}{suffix}"
-        if _ok(candidate):
-            return candidate
-        suffix += 1
+    return derive_available_username(clean)

--- a/backend/utils/magic_link.py
+++ b/backend/utils/magic_link.py
@@ -40,6 +40,7 @@ def hash_token(token):
 
 def generate_unique_username(email):
     from backend.models import User
+    from backend.extensions import db
     from backend.utils.reserved_usernames import is_username_reserved
 
     prefix = email.split("@")[0]
@@ -48,11 +49,20 @@ def generate_unique_username(email):
     if not clean:
         clean = "user"
 
+    # Brand-substring / founder-prefix reserved matches can't be escaped by
+    # appending digits (e.g. 'myloore2' still contains 'loore'), so fall back
+    # to the neutral base instead of suffixing forever.
+    if is_username_reserved(clean) and is_username_reserved(f"{clean}2"):
+        clean = "user"
+
     def _ok(candidate):
-        # Candidate must be neither reserved nor already taken.
+        # Candidate must be neither reserved nor already taken
+        # (case-insensitive, matching validate_username).
         if is_username_reserved(candidate):
             return False
-        return not User.query.filter_by(username=candidate).first()
+        return not User.query.filter(
+            db.func.lower(User.username) == candidate.lower()
+        ).first()
 
     if _ok(clean):
         return clean

--- a/backend/utils/magic_link.py
+++ b/backend/utils/magic_link.py
@@ -40,6 +40,7 @@ def hash_token(token):
 
 def generate_unique_username(email):
     from backend.models import User
+    from backend.utils.reserved_usernames import is_username_reserved
 
     prefix = email.split("@")[0]
     # Clean up prefix: keep only alphanumeric and underscores
@@ -47,13 +48,18 @@ def generate_unique_username(email):
     if not clean:
         clean = "user"
 
-    candidate = clean
-    if not User.query.filter_by(username=candidate).first():
-        return candidate
+    def _ok(candidate):
+        # Candidate must be neither reserved nor already taken.
+        if is_username_reserved(candidate):
+            return False
+        return not User.query.filter_by(username=candidate).first()
+
+    if _ok(clean):
+        return clean
 
     suffix = 2
     while True:
         candidate = f"{clean}{suffix}"
-        if not User.query.filter_by(username=candidate).first():
+        if _ok(candidate):
             return candidate
         suffix += 1

--- a/backend/utils/reserved_usernames.py
+++ b/backend/utils/reserved_usernames.py
@@ -9,9 +9,11 @@ Matching strategy (after normalizing to lowercase alphanumerics):
   - RESERVED_EXACT: blocked only on an *exact* normalized match. This keeps
     short tokens like 'lore'/'lor' from collateral-blocking words such as
     'explore' or 'folklore'.
-  - BRAND_SUBSTRING: the coined brand name 'loore' is blocked as a substring
-    (so 'myloore', 'loore123' are blocked) -- it does not appear inside common
-    English words, so 'explore' is safe.
+  - BRAND_SUBSTRING_RE: the coined brand name 'loore' -- with any number of
+    repeated o's and e's (loore, looore, looree, ...) -- is blocked as a
+    substring (so 'myloore', 'loore123', 'looore' are blocked). Two o's
+    minimum: the single-o 'lore' appears inside common English words
+    ('explore', 'folklore'), so it is exact-match-only via RESERVED_EXACT.
   - FOUNDER_PREFIXES: blocked when the normalized name *starts with* one of
     these (e.g. 'hrosspetx', 'hrosspet_official').
 """
@@ -33,8 +35,10 @@ RESERVED_EXACT = frozenset({
     "founder", "creator", "www", "mail", "smtp", "lore", "lor",
 })
 
-# Coined brand name -- substring match (does not collide with English words).
-BRAND_SUBSTRING = ("loore",)
+# Coined brand name -- substring match with any number of repeated o's (>= 2,
+# so the single-o English 'lore' in 'explore'/'folklore' stays available) and
+# e's (>= 1). Does not collide with English words.
+BRAND_SUBSTRING_RE = re.compile(r"lo{2,}re+")
 
 # Founder identifiers -- prefix match. Common first names ('peter', 'peta')
 # are deliberately NOT listed: prefix-blocking them locks out real people.
@@ -61,7 +65,7 @@ def is_username_reserved(username: str) -> bool:
         return False
     if norm in RESERVED_EXACT:
         return True
-    if any(brand in norm for brand in BRAND_SUBSTRING):
+    if BRAND_SUBSTRING_RE.search(norm):
         return True
     if any(norm.startswith(prefix) for prefix in FOUNDER_PREFIXES):
         return True

--- a/backend/utils/reserved_usernames.py
+++ b/backend/utils/reserved_usernames.py
@@ -10,8 +10,8 @@ Matching strategy (after normalizing to lowercase alphanumerics):
     short tokens like 'lore'/'lor' from collateral-blocking words such as
     'explore' or 'folklore'.
   - BRAND_SUBSTRING_RE: the coined brand name 'loore' -- with any number of
-    repeated o's and e's (loore, looore, looree, ...) -- is blocked as a
-    substring (so 'myloore', 'loore123', 'looore' are blocked). Two o's
+    repeated letters (loore, looore, looree, lloorree, ...) -- is blocked as
+    a substring (so 'myloore', 'loore123', 'looore' are blocked). Two o's
     minimum: the single-o 'lore' appears inside common English words
     ('explore', 'folklore'), so it is exact-match-only via RESERVED_EXACT.
   - FOUNDER_PREFIXES: blocked when the normalized name *starts with* one of
@@ -35,10 +35,10 @@ RESERVED_EXACT = frozenset({
     "founder", "creator", "www", "mail", "smtp", "lore", "lor",
 })
 
-# Coined brand name -- substring match with any number of repeated o's (>= 2,
-# so the single-o English 'lore' in 'explore'/'folklore' stays available) and
-# e's (>= 1). Does not collide with English words.
-BRAND_SUBSTRING_RE = re.compile(r"lo{2,}re+")
+# Coined brand name -- substring match with any number of repeated letters
+# (o's >= 2, so the single-o English 'lore' in 'explore'/'folklore' stays
+# available). Does not collide with English words.
+BRAND_SUBSTRING_RE = re.compile(r"l+o{2,}r+e+")
 
 # Founder identifiers -- prefix match. Common first names ('peter', 'peta')
 # are deliberately NOT listed: prefix-blocking them locks out real people.

--- a/backend/utils/reserved_usernames.py
+++ b/backend/utils/reserved_usernames.py
@@ -99,3 +99,43 @@ def validate_username(username: str, exclude_user_id=None) -> Optional[str]:
         return "That username is already taken."
 
     return None
+
+
+def derive_available_username(base):
+    """Derive a username from ``base`` that is neither reserved nor taken.
+
+    Returns ``base`` itself when it passes both checks (case-insensitive
+    uniqueness, matching validate_username); otherwise appends an
+    incrementing numeric suffix starting at 2. Used by the magic-link signup
+    (email prefix) and Twitter OAuth signup (screen_name) to pick a fallback
+    instead of failing the auth callback.
+    """
+    from backend.models import User
+    from backend.extensions import db
+
+    if not base:
+        base = "user"
+    # Brand-substring / founder-prefix reserved matches can't be escaped by
+    # appending digits (e.g. 'myloore2' still contains 'loore'), while
+    # exact-match reservations can ('admin2'). Probe with a suffix appended to
+    # tell them apart, and fall back to the neutral base instead of suffixing
+    # forever.
+    if is_username_reserved(base) and is_username_reserved(f"{base}2"):
+        base = "user"
+
+    def _available(candidate):
+        if is_username_reserved(candidate):
+            return False
+        return not User.query.filter(
+            db.func.lower(User.username) == candidate.lower()
+        ).first()
+
+    if _available(base):
+        return base
+
+    suffix = 2
+    while True:
+        candidate = f"{base}{suffix}"
+        if _available(candidate):
+            return candidate
+        suffix += 1

--- a/backend/utils/reserved_usernames.py
+++ b/backend/utils/reserved_usernames.py
@@ -13,7 +13,7 @@ Matching strategy (after normalizing to lowercase alphanumerics):
     (so 'myloore', 'loore123' are blocked) -- it does not appear inside common
     English words, so 'explore' is safe.
   - FOUNDER_PREFIXES: blocked when the normalized name *starts with* one of
-    these (e.g. 'peterx', 'hrosspet_official').
+    these (e.g. 'hrosspetx', 'hrosspet_official').
 """
 
 import re
@@ -36,8 +36,9 @@ RESERVED_EXACT = frozenset({
 # Coined brand name -- substring match (does not collide with English words).
 BRAND_SUBSTRING = ("loore",)
 
-# Founder identifiers -- prefix match.
-FOUNDER_PREFIXES = ("hrosspet", "peter", "peta")
+# Founder identifiers -- prefix match. Common first names ('peter', 'peta')
+# are deliberately NOT listed: prefix-blocking them locks out real people.
+FOUNDER_PREFIXES = ("hrosspet",)
 
 _NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
 

--- a/backend/utils/reserved_usernames.py
+++ b/backend/utils/reserved_usernames.py
@@ -1,0 +1,100 @@
+"""Reserved / protected username matching.
+
+Centralizes the rules that prevent users from claiming usernames that
+impersonate the brand, the founders, or system/route names. Used by the
+dashboard username-update endpoint, Twitter OAuth login, the magic-link
+unique-username generator, and the admin whitelist endpoint.
+
+Matching strategy (after normalizing to lowercase alphanumerics):
+  - RESERVED_EXACT: blocked only on an *exact* normalized match. This keeps
+    short tokens like 'lore'/'lor' from collateral-blocking words such as
+    'explore' or 'folklore'.
+  - BRAND_SUBSTRING: the coined brand name 'loore' is blocked as a substring
+    (so 'myloore', 'loore123' are blocked) -- it does not appear inside common
+    English words, so 'explore' is safe.
+  - FOUNDER_PREFIXES: blocked when the normalized name *starts with* one of
+    these (e.g. 'peterx', 'hrosspet_official').
+"""
+
+import re
+from typing import Optional
+
+# Exact-match reserved names (lowercased, normalized). 'lore'/'lor' are here
+# (exact-only) so that 'explore'/'folklore' remain available.
+RESERVED_EXACT = frozenset({
+    "admin", "administrator", "system", "bot", "ai", "support", "help",
+    "feedback", "info", "contact", "official", "team", "staff", "mod",
+    "moderator", "profile", "settings", "login", "logout", "signup",
+    "register", "node", "thread", "export", "archive", "feed", "log", "api",
+    "webhook", "status", "health", "ping", "about", "terms", "privacy",
+    "legal", "dashboard", "account", "welcome", "voice", "converse", "todo",
+    "prompts", "import", "null", "undefined", "anonymous", "guest", "user",
+    "test", "demo", "root", "superuser", "sysadmin", "god", "owner",
+    "founder", "creator", "www", "mail", "smtp", "lore", "lor",
+})
+
+# Coined brand name -- substring match (does not collide with English words).
+BRAND_SUBSTRING = ("loore",)
+
+# Founder identifiers -- prefix match.
+FOUNDER_PREFIXES = ("hrosspet", "peter", "peta")
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]")
+
+# Mirrors the username format rule used elsewhere in the app.
+_USERNAME_FORMAT_RE = re.compile(r"[a-zA-Z0-9_]+")
+_MAX_USERNAME_LEN = 64
+
+
+def _normalize(username: str) -> str:
+    """Lowercase and strip all non-alphanumeric characters."""
+    if not username:
+        return ""
+    return _NON_ALNUM_RE.sub("", username.lower())
+
+
+def is_username_reserved(username: str) -> bool:
+    """Return True if the (normalized) username is reserved/protected."""
+    norm = _normalize(username)
+    if not norm:
+        return False
+    if norm in RESERVED_EXACT:
+        return True
+    if any(brand in norm for brand in BRAND_SUBSTRING):
+        return True
+    if any(norm.startswith(prefix) for prefix in FOUNDER_PREFIXES):
+        return True
+    return False
+
+
+def validate_username(username: str, exclude_user_id=None) -> Optional[str]:
+    """Validate a desired username.
+
+    Returns an error string describing the first problem found, or None if the
+    username is acceptable. Checks (in order): non-empty, length, allowed
+    characters, reserved, and case-insensitive uniqueness.
+
+    ``exclude_user_id`` lets the caller exclude the user's own current row from
+    the uniqueness check (so re-saving the same username is allowed).
+    """
+    if not username:
+        return "Username cannot be empty."
+    if len(username) > _MAX_USERNAME_LEN:
+        return "Username must be 64 characters or fewer."
+    if not _USERNAME_FORMAT_RE.fullmatch(username):
+        return "Username may only contain letters, numbers, and underscores."
+    if is_username_reserved(username):
+        return "That username is reserved."
+
+    # Deferred import to avoid a hard dependency on the app/db at import time
+    # (keeps the pure helpers above unit-testable in isolation).
+    from backend.models import User
+    from backend.extensions import db
+
+    query = User.query.filter(db.func.lower(User.username) == username.lower())
+    if exclude_user_id is not None:
+        query = query.filter(User.id != exclude_user_id)
+    if query.first():
+        return "That username is already taken."
+
+    return None


### PR DESCRIPTION
## #91 — Protected / reserved usernames

New `backend/utils/reserved_usernames.py` (single source of truth) wired into all four username set/validate paths (rename, Twitter login, magic-link signup, admin whitelist). Tiered, case-insensitive matching: exact for system/route/impersonation names; substring for the coined brand `loore`; prefix for the founder namespace. The existing `Lore` user is left in place (grandfathered).

**Review follow-ups (da45c4d):** consolidated the duplicated fallback-username generators into `derive_available_username()`; admin whitelist now uses full `validate_username` (adds format/length checks and case-insensitive uniqueness — was a case-sensitive exact match).

**CI follow-up (da01f78):** staging deploy seeds the admin user's email from the `STAGING_ADMIN_EMAIL` repo secret, so the admin session is recoverable via magic link after DB resets.

## Staging verification

**First pass (combined Chrome pass):**
- `admin`, `loore`, `LOORE`, `loore123`, `myloore`, `system`, `peterson` → 400 "That username is reserved." (value unchanged; inline error shown in Account UI)
- `explore` (contains "lore") → 200 — false-positive guard holds

**Full single-item UI pass (2026-06-12, deploy of da01f78):**
- Account rename: `loore`, `LOORE`, `loore123`, `admin`, `l_o_o_r_e` (normalization bypass probe) → inline "That username is reserved."; `explore` → "Username updated." ✅
- Admin whitelist: `loore123` + `Lore` (the original incident name) → reserved; `bad name!` → format error; `testfriend` → created; `TestFriend` → "That username is already taken." (case-insensitive dup, no row created) ✅
- **Regex follow-up (d1b9bd6):** `looore` was accepted (found by @hrosspet in manual staging testing) — brand tier is now `lo{2,}re+` (any number of repeated o's ≥2 and e's ≥1). Verified live: `looore` (rename) + `looree` (whitelist) → reserved; `explore` → still created ✅. Extended in 5069700 to `l+o{2,}r+e+` (repeated l's/r's covered; unit-tested, not staging-tested per @hrosspet).

### ⚠️ Finding: admin lockout via rename (demonstrated live) — FIXED in 9ad5815
`admin_required` (`backend/routes/admin.py`) granted admin by **literal username** `hrosspet`, which this PR makes a reserved name. Renaming the admin account away (allowed) was **irreversible** — the rename back is rejected as reserved — so admin rights were permanently lost through the UI. Demonstrated on staging: renamed admin → `explore`, `/api/admin/users` → 403, rename back to `hrosspet` → 400 "That username is reserved."

**Fix (9ad5815):** `admin_required` is now keyed on the `is_admin` column (matching `nodes.py`/`sse.py`); the username is just a display name. Covered by `test_admin_access.py` (renamed admin keeps access; username `hrosspet` without `is_admin` gets 403).

**✅ Prod precondition verified (2026-06-12):** prod admin row has `is_admin = true` (checked via flask shell: `1 hrosspet True`), so the decorator swap is safe to merge.

**✅ Fix verified live on staging (2026-06-12):** renamed the seeded admin `hrosspet` → `explore`, then `/admin` loaded the user list AND whitelisting a new user succeeded — both admin read and write survive a rename under the `is_admin`-keyed decorator (the same sequence that 403'd before the fix). Staging redeployed afterward to restore the seeded state.

**Decision (@hrosspet):** grandfathered reserved usernames (e.g. Tonda's `Lore`) deliberately remain one-way doors — rename away (or even a case change) cannot be undone. No re-save exemption added.

### ✅ Magic-link signup fallback — verified by @hrosspet (2026-06-12)
Signed up on staging with `hrosspet+wop91@loore.org` → user id 3 created with username **`user2`**, Inactive/unapproved — exactly as predicted (prefix `hrosspetwop91` hits the founder-prefix tier; base falls back to `user`, itself exact-reserved; suffixing starts at 2). All four enforcement paths are now staging-verified. Original steps for reference:
1. On staging in a logged-out/incognito window, request a magic link for `hrosspet+wop91@gmail.com` (alias → new user; prefix cleans to `hrosspetwop91` → founder prefix).
2. Click the link from the inbox.
3. **Expected:** account is created with username `user2` (founder-prefix can't be escaped by digits → falls back to `user` base, `user` itself is exact-reserved → `user2`), lands on /alpha-thank-you (unapproved).

Unit tests cover this path (`test_magic_link.py`, `test_reserved_usernames.py`); only the live e2e is missing. The Twitter-OAuth reserved-handle fallback shares the same helper and is impractical to e2e-test.

> Security-critical: per the triage plan, do a single-item staging pass before merging this one alone. ✅ done (see above)

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
