### PR TITLE
Surface clear error when mic permission is denied (#160)

### DIFF
--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -176,6 +176,34 @@ export function useStreamingMediaRecorder({
 
     console.log('[StreamingRecorder] Codec support:', codecSupport, 'chosen:', chosenMime, 'forced:', forced, 'UA:', navigator.userAgent);
 
+    // Pre-check the microphone permission where the Permissions API is
+    // available. On some platforms (notably Android Chrome) a previously
+    // denied permission makes getUserMedia reject silently/inconsistently or
+    // hang; querying first lets us fail fast with an unambiguous
+    // NotAllowedError so the caller surfaces a clear "permission denied"
+    // toast instead of a stuck "recording" state. Wrapped in try/catch so
+    // browsers that don't support permissions.query (or the 'microphone'
+    // name) simply fall through to getUserMedia as before.
+    try {
+      if (navigator.permissions?.query) {
+        const permStatus = await navigator.permissions.query({ name: 'microphone' });
+        if (permStatus?.state === 'denied') {
+          const permErr = new Error('Microphone permission is denied.');
+          permErr.name = 'NotAllowedError';
+          throw permErr;
+        }
+      }
+    } catch (permCheckErr) {
+      // Re-throw our own denial; swallow unsupported-query errors so we still
+      // attempt getUserMedia (the source of truth for the prompt/grant flow).
+      if (permCheckErr?.name === 'NotAllowedError') {
+        console.error('Microphone permission denied (permissions.query):', permCheckErr);
+        setError(permCheckErr.message);
+        throw permCheckErr;
+      }
+      console.log('[StreamingRecorder] permissions.query unavailable or failed; falling through to getUserMedia:', permCheckErr?.message);
+    }
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
@@ -284,6 +312,16 @@ export function useStreamingMediaRecorder({
     } catch (err) {
       console.error('Error accessing microphone:', err);
       setError(err.message);
+      // Preserve the permission-denial identity when rethrowing so the
+      // parent's onError handler maps it to the right toast. Some browsers
+      // use the legacy 'PermissionDeniedError' name; normalize both to a
+      // rethrown error whose .name survives (a plain `throw err` already
+      // preserves it, but guard against any environment that strips it).
+      if (err && (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError')) {
+        const permErr = new Error(err.message || 'Microphone permission is denied.');
+        permErr.name = err.name;
+        throw permErr;
+      }
       throw err;
     }
   }, [resetRecording, chunkIntervalMs, onChunkReady]);

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -460,6 +460,31 @@ export function useStreamingTranscription(options = {}) {
 
     } catch (err) {
       console.error('Failed to start streaming:', err);
+      // Always land in a terminal state. The error path here means recording
+      // never started, so the session must not be left in 'recording' or
+      // 'initializing' (which would strand the parent UI). 'error' is set
+      // below; permission denials with an orphaned draft are cleaned up first.
+      const name = err?.name || err?.error?.name;
+      const isPermissionDenial =
+        name === 'NotAllowedError' || name === 'PermissionDeniedError';
+
+      // If initSession created a draft but recording could not start because
+      // the mic permission was denied, the draft is a dead streaming session
+      // (streaming_status='recording', zero chunks). Best-effort discard it so
+      // the "resume interrupted session" recovery banner — which lists drafts
+      // with streaming_status='recording' — doesn't later offer this empty,
+      // doomed session. The discard endpoint is keyed by session_id (not
+      // draft_id) and removes the draft, its chunk records, and audio dir.
+      // Failures here are non-fatal (network/permissions).
+      if (isPermissionDenial && initSucceeded && sessionIdRef.current) {
+        try {
+          await api.delete(`/drafts/streaming/${sessionIdRef.current}/discard`);
+          console.log('[StreamingTranscription] Discarded orphaned draft after permission denial (session):', sessionIdRef.current);
+        } catch (delErr) {
+          console.warn('[StreamingTranscription] Failed to discard orphaned draft after permission denial (non-fatal):', delErr?.message);
+        }
+      }
+
       setSessionState('error');
       setErrorMessage(err.message);
       // initSession's catch already invokes onError before re-throwing, so

--- a/frontend/src/hooks/useVoiceSession.js
+++ b/frontend/src/hooks/useVoiceSession.js
@@ -151,7 +151,7 @@ export function useVoiceSession({ apiEndpoint, ttsTitle = 'Audio', onLLMComplete
         // Use the fatal-error message verbatim — it's already user-facing.
         message = err.message;
       } else if (name === 'NotAllowedError' || name === 'PermissionDeniedError') {
-        message = "Microphone access was denied. Allow microphone access for this site in your browser and OS settings, then try again.";
+        message = "Microphone access is blocked. On Android, update this browser app's microphone permission in your phone's Settings. On iPhone or desktop, re-grant microphone access for this site via the browser's site-permissions menu (tap the address-bar icon). Then reload and try again.";
       } else if (name === 'NotFoundError' || name === 'DevicesNotFoundError') {
         message = "No microphone was found on this device.";
       } else if (name === 'NotReadableError' || name === 'TrackStartError') {


### PR DESCRIPTION
## #160 — Surface a clear error when mic permission is denied

Adds a `navigator.permissions.query({name:'microphone'})` pre-flight check before `getUserMedia`, preserves `NotAllowedError`/`PermissionDeniedError` through the chain, shows an actionable toast (Android app-permission + iOS/desktop site-permission guidance), and **discards the orphaned draft** so the recovery banner no longer offers a dead session. No more silent failure.

**Verified on staging (combined Chrome pass, `getUserMedia` monkeypatched to deny):**
- Console: `permissions.query` detects denial → "Failed to start streaming" → "Discarded orphaned draft after permission denial"
- Toast shown with Android + iOS/desktop guidance
- UI does NOT enter recording state; `/drafts/interrupted` returns empty (no orphan)

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
