### PR TITLE
Improve markdown rendering to match canonical expectations (#138)

### DIFF
--- a/frontend/src/components/BubbleKebabMenu.js
+++ b/frontend/src/components/BubbleKebabMenu.js
@@ -90,7 +90,7 @@ function BubbleKebabMenu({ visible, items, onFocus, onBlur }) {
           borderRadius: '6px',
           boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
           minWidth: '160px',
-          zIndex: 5,
+          zIndex: 1000,
           overflow: 'hidden',
         }}>
           {items.map((item) => (

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -232,7 +232,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
                   className="loore-add-task"
                   title="Add an item below"
                   aria-label="Add an item below"
-                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); setAddingAfter(itemText); }}
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); setAddingAfter(itemText); }}
                   style={{
                     background: 'none',

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -3,14 +3,28 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 /**
- * Extract plain text from React children recursively.
+ * True when a rendered child is a nested list element (<ul>/<ol>). Detected via
+ * the hast `node` react-markdown passes to every component, because when these
+ * helpers run the element's `type` is our custom `ul`/`ol` component (a
+ * function), not the string 'ul'.
+ */
+function isListElement(child) {
+  const tag = child && child.props && child.props.node && child.props.node.tagName;
+  return tag === 'ul' || tag === 'ol';
+}
+
+/**
+ * Extract plain text from React children recursively, WITHOUT descending into
+ * nested lists — so a task item's label is just its own text, not its
+ * sub-items' text concatenated (which would never match its source line when
+ * toggling).
  */
 function extractText(children) {
   let text = '';
   React.Children.forEach(children, child => {
     if (typeof child === 'string') {
       text += child;
-    } else if (child && child.props && child.props.children) {
+    } else if (child && child.props && child.props.children && !isListElement(child)) {
       text += extractText(child.props.children);
     }
   });
@@ -30,8 +44,12 @@ function replaceCheckboxes(children, renderToggle) {
       found = true;
       return renderToggle(!!child.props.checked);
     }
-    // Recurse into wrapper elements like <p>
-    if (child && child.props && child.props.children) {
+    // Recurse into wrapper elements like <p>, but NOT into nested lists. A
+    // nested <li>'s checkbox is still a raw <input> when the parent <li>
+    // renders, so descending here would let the parent steal it (binding the
+    // toggle to the parent's label). Leaving nested lists untouched lets each
+    // nested <li> wire its own checkbox when it renders.
+    if (child && child.props && child.props.children && !isListElement(child)) {
       const inner = replaceCheckboxes(child.props.children, renderToggle);
       if (inner.found) {
         found = true;
@@ -100,9 +118,15 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
     img: ({ node, alt, ...props }) => (
       <img alt={alt || ''} style={{ maxWidth: '100%', height: 'auto' }} {...props} />
     ),
-    ul: ({ node, ...props }) => (
-      <ul style={{ margin: '4px 0', paddingLeft: '24px' }} {...props} />
-    ),
+    ul: ({ node, ...props }) => {
+      const isTaskList = (props.className || '').split(/\s+/).includes('contains-task-list');
+      // Task lists are styled via the `.loore-md ul.contains-task-list` rules in
+      // index.css so nested levels indent correctly. Inline padding here would
+      // override that CSS and flatten the tree (#138). Plain lists stay inline.
+      return isTaskList
+        ? <ul {...props} />
+        : <ul style={{ margin: '4px 0', paddingLeft: '24px' }} {...props} />;
+    },
     ol: ({ node, ...props }) => (
       <ol style={{ margin: '4px 0', paddingLeft: '24px' }} {...props} />
     ),
@@ -165,7 +189,6 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
               overflowWrap: 'break-word',
               marginBottom: '2px',
               listStyleType: 'none',
-              marginLeft: '-24px',
             }}
             {...props}
           >
@@ -238,7 +261,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
   };
 
   return (
-    <div style={style}>
+    <div className="loore-md" style={style}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -54,8 +54,51 @@ function replaceCheckboxes(children, renderToggle) {
  */
 const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckboxToggle }) => {
   const components = {
+    h1: ({ node, ...props }) => (
+      <h1 style={{ fontFamily: 'var(--serif)', fontSize: '2.2em', fontWeight: 700, lineHeight: 1.2, margin: '1.2em 0 0.4em', color: 'var(--text-primary)' }} {...props} />
+    ),
+    h2: ({ node, ...props }) => (
+      <h2 style={{ fontFamily: 'var(--serif)', fontSize: '1.8em', fontWeight: 700, lineHeight: 1.25, margin: '1.1em 0 0.4em', color: 'var(--text-primary)' }} {...props} />
+    ),
+    h3: ({ node, ...props }) => (
+      <h3 style={{ fontFamily: 'var(--serif)', fontSize: '1.5em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props} />
+    ),
+    h4: ({ node, ...props }) => (
+      <h4 style={{ fontFamily: 'var(--serif)', fontSize: '1.25em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props} />
+    ),
+    h5: ({ node, ...props }) => (
+      <h5 style={{ fontFamily: 'var(--serif)', fontSize: '1.1em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props} />
+    ),
+    h6: ({ node, ...props }) => (
+      <h6 style={{ fontFamily: 'var(--serif)', fontSize: '0.95em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props} />
+    ),
     p: ({ node, ...props }) => (
       <p style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', margin: paragraphMargin }} {...props} />
+    ),
+    blockquote: ({ node, ...props }) => (
+      <blockquote
+        style={{
+          borderLeft: '3px solid var(--accent-dim)',
+          background: 'var(--bg-card)',
+          padding: '0.5em 1em',
+          margin: '0.75em 0',
+          color: 'var(--text-secondary)',
+          fontStyle: 'italic',
+        }}
+        {...props}
+      />
+    ),
+    strong: ({ node, ...props }) => (
+      <strong style={{ fontWeight: 700 }} {...props} />
+    ),
+    em: ({ node, ...props }) => (
+      <em style={{ fontStyle: 'italic' }} {...props} />
+    ),
+    del: ({ node, ...props }) => (
+      <del style={{ textDecoration: 'line-through', color: 'var(--text-muted)' }} {...props} />
+    ),
+    img: ({ node, ...props }) => (
+      <img style={{ maxWidth: '100%', height: 'auto' }} {...props} />
     ),
     ul: ({ node, ...props }) => (
       <ul style={{ margin: '4px 0', paddingLeft: '24px' }} {...props} />
@@ -147,15 +190,27 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
     hr: ({ node, ...props }) => (
       <hr style={{ border: 'none', borderTop: '1px solid var(--border)', margin: '20px 0' }} {...props} />
     ),
+    pre: ({ node, ...props }) => (
+      <pre
+        style={{
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: '6px',
+          padding: '0.75em 1em',
+          margin: '0.75em 0',
+          overflowX: 'auto',
+          fontSize: '0.9em',
+        }}
+        {...props}
+      />
+    ),
     code: ({ node, inline, className, children, ...props }) =>
       inline ? (
         <code style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', fontSize: '0.9em' }} {...props}>
           {children}
         </code>
       ) : (
-        <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', fontSize: '0.9em' }} {...props}>
-          <code>{children}</code>
-        </pre>
+        <code className={className} {...props}>{children}</code>
       ),
     a: ({ node, children, ...props }) => (
       <a

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -232,6 +232,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
                   className="loore-add-task"
                   title="Add an item below"
                   aria-label="Add an item below"
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); setAddingAfter(itemText); }}
                   style={{
                     background: 'none',

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -62,6 +62,31 @@ function replaceCheckboxes(children, renderToggle) {
 }
 
 /**
+ * Inline "add a task here" input row, shown below a checklist item when its
+ * hover "+" is clicked. Type + Enter inserts; Esc / blur-when-empty cancels.
+ */
+function AddTaskInput({ onSubmit, onCancel }) {
+  const [val, setVal] = React.useState('');
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', margin: '4px 0' }}>
+      <span style={{ width: '18px', height: '18px', borderRadius: '50%', border: '1.5px dashed var(--border-hover)', flexShrink: 0, opacity: 0.5 }} />
+      <input
+        autoFocus
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); const t = val.trim(); if (t) onSubmit(t); }
+          else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+        }}
+        onBlur={() => { if (!val.trim()) onCancel(); }}
+        placeholder="New task…"
+        style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text-primary)', fontFamily: 'var(--sans)', fontSize: '0.92em', padding: '4px 8px' }}
+      />
+    </div>
+  );
+}
+
+/**
  * MarkdownBody — shared ReactMarkdown wrapper with consistent styling.
  *
  * Props:
@@ -69,8 +94,10 @@ function replaceCheckboxes(children, renderToggle) {
  *   style: optional style object applied to the outer <div>
  *   paragraphMargin: optional margin for <p> elements (default: "0.5em 0")
  *   onCheckboxToggle: optional callback(lineText, currentChecked) for clickable checkboxes
+ *   onAddTask: optional callback(afterItemText, newText) — enables the per-row hover "+"
  */
-const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckboxToggle }) => {
+const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckboxToggle, onAddTask }) => {
+  const [addingAfter, setAddingAfter] = React.useState(null);
   const components = {
     h1: ({ node, children, ...props }) => (
       <h1 style={{ fontFamily: 'var(--serif)', fontSize: '2.2em', fontWeight: 700, lineHeight: 1.2, margin: '1.2em 0 0.4em', color: 'var(--text-primary)' }} {...props}>{children}</h1>
@@ -134,7 +161,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
       const isTask = props.className === 'task-list-item';
 
       if (isTask) {
-        const itemText = onCheckboxToggle ? extractText(liChildren).trim() : null;
+        const itemText = (onCheckboxToggle || onAddTask) ? extractText(liChildren).trim() : null;
         const { children: filteredChildren } = replaceCheckboxes(
           liChildren,
           (isChecked) => {
@@ -182,6 +209,11 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
           },
         );
 
+        const childArr = React.Children.toArray(filteredChildren);
+        const ownContent = childArr.filter((c) => !isListElement(c));
+        const nestedLists = childArr.filter((c) => isListElement(c));
+        const addable = !!onAddTask;
+
         return (
           <li
             style={{
@@ -192,7 +224,37 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
             }}
             {...props}
           >
-            {filteredChildren}
+            <span className="loore-task-row" style={{ display: 'block', position: 'relative' }}>
+              {ownContent}
+              {addable && (
+                <button
+                  type="button"
+                  className="loore-add-task"
+                  title="Add a task below"
+                  aria-label="Add a task below"
+                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); setAddingAfter(itemText); }}
+                  style={{
+                    position: 'absolute',
+                    right: 0,
+                    top: 0,
+                    background: 'none',
+                    border: 'none',
+                    color: 'var(--accent)',
+                    cursor: 'pointer',
+                    fontSize: '1.1em',
+                    lineHeight: 1,
+                    padding: '0 2px',
+                  }}
+                >+</button>
+              )}
+            </span>
+            {nestedLists}
+            {addable && addingAfter === itemText && (
+              <AddTaskInput
+                onSubmit={(t) => { onAddTask(itemText, t); setAddingAfter(null); }}
+                onCancel={() => setAddingAfter(null)}
+              />
+            )}
           </li>
         );
       }

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -54,23 +54,23 @@ function replaceCheckboxes(children, renderToggle) {
  */
 const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckboxToggle }) => {
   const components = {
-    h1: ({ node, ...props }) => (
-      <h1 style={{ fontFamily: 'var(--serif)', fontSize: '2.2em', fontWeight: 700, lineHeight: 1.2, margin: '1.2em 0 0.4em', color: 'var(--text-primary)' }} {...props} />
+    h1: ({ node, children, ...props }) => (
+      <h1 style={{ fontFamily: 'var(--serif)', fontSize: '2.2em', fontWeight: 700, lineHeight: 1.2, margin: '1.2em 0 0.4em', color: 'var(--text-primary)' }} {...props}>{children}</h1>
     ),
-    h2: ({ node, ...props }) => (
-      <h2 style={{ fontFamily: 'var(--serif)', fontSize: '1.8em', fontWeight: 700, lineHeight: 1.25, margin: '1.1em 0 0.4em', color: 'var(--text-primary)' }} {...props} />
+    h2: ({ node, children, ...props }) => (
+      <h2 style={{ fontFamily: 'var(--serif)', fontSize: '1.8em', fontWeight: 700, lineHeight: 1.25, margin: '1.1em 0 0.4em', color: 'var(--text-primary)' }} {...props}>{children}</h2>
     ),
-    h3: ({ node, ...props }) => (
-      <h3 style={{ fontFamily: 'var(--serif)', fontSize: '1.5em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props} />
+    h3: ({ node, children, ...props }) => (
+      <h3 style={{ fontFamily: 'var(--serif)', fontSize: '1.5em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props}>{children}</h3>
     ),
-    h4: ({ node, ...props }) => (
-      <h4 style={{ fontFamily: 'var(--serif)', fontSize: '1.25em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props} />
+    h4: ({ node, children, ...props }) => (
+      <h4 style={{ fontFamily: 'var(--serif)', fontSize: '1.25em', fontWeight: 600, lineHeight: 1.3, margin: '1em 0 0.35em', color: 'var(--text-primary)' }} {...props}>{children}</h4>
     ),
-    h5: ({ node, ...props }) => (
-      <h5 style={{ fontFamily: 'var(--serif)', fontSize: '1.1em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props} />
+    h5: ({ node, children, ...props }) => (
+      <h5 style={{ fontFamily: 'var(--serif)', fontSize: '1.1em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props}>{children}</h5>
     ),
-    h6: ({ node, ...props }) => (
-      <h6 style={{ fontFamily: 'var(--serif)', fontSize: '0.95em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props} />
+    h6: ({ node, children, ...props }) => (
+      <h6 style={{ fontFamily: 'var(--serif)', fontSize: '0.95em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props}>{children}</h6>
     ),
     p: ({ node, ...props }) => (
       <p style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', margin: paragraphMargin }} {...props} />
@@ -97,8 +97,8 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
     del: ({ node, ...props }) => (
       <del style={{ textDecoration: 'line-through', color: 'var(--text-muted)' }} {...props} />
     ),
-    img: ({ node, ...props }) => (
-      <img style={{ maxWidth: '100%', height: 'auto' }} {...props} />
+    img: ({ node, alt, ...props }) => (
+      <img alt={alt || ''} style={{ maxWidth: '100%', height: 'auto' }} {...props} />
     ),
     ul: ({ node, ...props }) => (
       <ul style={{ margin: '4px 0', paddingLeft: '24px' }} {...props} />

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -79,7 +79,7 @@ function AddTaskInput({ onSubmit, onCancel }) {
           else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
         }}
         onBlur={() => { if (!val.trim()) onCancel(); }}
-        placeholder="New task…"
+        placeholder="New item…"
         style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text-primary)', fontFamily: 'var(--sans)', fontSize: '0.92em', padding: '4px 8px' }}
       />
     </div>
@@ -224,19 +224,16 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
             }}
             {...props}
           >
-            <span className="loore-task-row" style={{ display: 'block', position: 'relative' }}>
+            <span className="loore-task-row" style={{ display: 'block' }}>
               {ownContent}
               {addable && (
                 <button
                   type="button"
                   className="loore-add-task"
-                  title="Add a task below"
-                  aria-label="Add a task below"
+                  title="Add an item below"
+                  aria-label="Add an item below"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); setAddingAfter(itemText); }}
                   style={{
-                    position: 'absolute',
-                    right: 0,
-                    top: 0,
                     background: 'none',
                     border: 'none',
                     color: 'var(--accent)',
@@ -244,6 +241,8 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
                     fontSize: '1.1em',
                     lineHeight: 1,
                     padding: '0 2px',
+                    marginLeft: '4px',
+                    verticalAlign: 'middle',
                   }}
                 >+</button>
               )}

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -11,7 +11,7 @@ import { useUser } from "../contexts/UserContext";
 import { useToast } from "../contexts/ToastContext";
 import { useAsyncTaskPolling } from "../hooks/useAsyncTaskPolling";
 import api from "../api";
-import { useCheckboxToggle } from "../utils/markdown";
+import { useCheckboxToggle, useTaskInsert } from "../utils/markdown";
 import { contextAllowsAi } from "../utils/aiUsage";
 import NodeFormModal from "./NodeFormModal";
 import Bubble from "./Bubble";
@@ -220,11 +220,11 @@ function NodeDetail() {
     }
   }, [llmStatus, llmData, llmError, navigate, id, llmTaskNodeId]);
 
-  const handleCheckboxToggle = useCheckboxToggle(
-    useCallback(() => node?.content, [node]),
-    useCallback((newContent) => setNode(prev => ({ ...prev, content: newContent })), []),
-    useCallback((newContent) => api.put(`/nodes/${id}`, { content: newContent }), [id]),
-  );
+  const getNodeContent = useCallback(() => node?.content, [node]);
+  const setNodeContent = useCallback((newContent) => setNode(prev => ({ ...prev, content: newContent })), []);
+  const saveNodeContent = useCallback((newContent) => api.put(`/nodes/${id}`, { content: newContent }), [id]);
+  const handleCheckboxToggle = useCheckboxToggle(getNodeContent, setNodeContent, saveNodeContent);
+  const handleTaskInsert = useTaskInsert(getNodeContent, setNodeContent, saveNodeContent);
 
   if (loading) return <div style={{ color: "var(--text-muted)", padding: "20px" }}>Loading node...</div>;
   if (error) return <div style={{ color: "var(--accent)", padding: "20px" }}>{error}</div>;
@@ -728,6 +728,7 @@ function NodeDetail() {
             contextArtifacts={node.context_artifacts || null}
             onQuoteClick={handleBubbleClick}
             onCheckboxToggle={isOwner ? handleCheckboxToggle : undefined}
+            onAddTask={isOwner ? handleTaskInsert : undefined}
           />
         )}
         {showProposal && (

--- a/frontend/src/components/ProposalInline.js
+++ b/frontend/src/components/ProposalInline.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import api from '../api';
 import MarkdownBody from './MarkdownBody';
-import { appendItemToSection } from '../utils/markdown';
+import { appendItemToSection, insertItemAfter } from '../utils/markdown';
 import useSubmitShortcut from '../hooks/useSubmitShortcut';
 
 export function stripInlineMarkdown(text) {
@@ -328,6 +328,74 @@ function sizeStyles(size) {
   };
 }
 
+// A single "New Tasks" proposal row with a hover "+" that opens an inline
+// input to insert a sibling task right below it (Voice + Text modes share
+// this — both render through the same row path).
+function NewTaskRow({ item, styles, toggleable, onToggle, onInsert }) {
+  const [hovered, setHovered] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [addText, setAddText] = useState('');
+  const submit = () => {
+    const t = addText.trim();
+    if (t) onInsert(item, t);
+    setAdding(false);
+    setAddText('');
+  };
+  return (
+    <>
+      <div
+        style={{ ...styles.row, position: 'relative' }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <div
+          onClick={toggleable ? () => onToggle(item, 'new task', 'completed') : undefined}
+          title={toggleable ? 'Mark as done' : undefined}
+          style={{ ...styles.circleBase, ...styles.circleNewExtra, cursor: toggleable ? 'pointer' : 'default' }}
+        />
+        <div style={styles.itemText}>{item}</div>
+        {toggleable && (
+          <button
+            type="button"
+            onClick={() => { setAdding(true); setAddText(''); }}
+            title="Add a task below"
+            aria-label="Add a task below"
+            style={{
+              marginLeft: 'auto', opacity: hovered ? 1 : 0,
+              transition: 'opacity 0.12s ease', background: 'none', border: 'none',
+              color: 'var(--accent)', cursor: 'pointer', fontSize: '1.2rem',
+              lineHeight: 1, padding: '0 4px',
+            }}
+          >+</button>
+        )}
+      </div>
+      {adding && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: styles.roomy ? '12px' : '10px', padding: styles.roomy ? '12px 0' : '8px 0' }}>
+          <span style={{ width: styles.roomy ? '18px' : '16px', height: styles.roomy ? '18px' : '16px', borderRadius: '50%', border: '1.5px dashed var(--border-hover)', flexShrink: 0, opacity: 0.5 }} />
+          <input
+            autoFocus
+            value={addText}
+            onChange={(e) => setAddText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); submit(); }
+              else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
+            }}
+            onBlur={() => { if (!addText.trim()) setAdding(false); }}
+            placeholder="New task…"
+            style={{
+              flex: 1, minWidth: 0, background: 'var(--bg-input)',
+              border: '1px solid var(--border)', borderRadius: '6px',
+              color: 'var(--text-primary)', fontFamily: 'var(--sans)',
+              fontSize: styles.roomy ? '0.92rem' : '0.85rem', fontWeight: 300,
+              padding: '8px 12px',
+            }}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
 export default function ProposalInline({
   content,
   nodeId,
@@ -404,6 +472,24 @@ export default function ProposalInline({
       })
       .finally(() => setQuickAddSaving(false));
   }, [content, nodeId, onContentChange, onError, toggleable, quickAddText, quickAddSaving]);
+
+  // Insert a new task immediately below a given "New Tasks" row (the hover "+"),
+  // preserving the section's plain-bullet style. Same optimistic+revert path.
+  const handleInsertAfter = useCallback((afterItem, newTask) => {
+    const task = (newTask || '').trim();
+    if (!toggleable || !nodeId || !task) return;
+    const newContent = insertItemAfter(content, afterItem, task);
+    if (newContent === content) return;
+    const prevContent = content;
+    onContentChange(newContent);
+    api.put(`/nodes/${nodeId}`, { content: newContent }).catch((err) => {
+      onContentChange(prevContent);
+      if (onError) {
+        const reason = err?.response?.data?.error || err?.message || 'Unknown error';
+        onError(`Couldn't add task — reverted (${reason})`);
+      }
+    });
+  }, [content, nodeId, onContentChange, onError, toggleable]);
 
   // Cmd+Return (macOS) / Ctrl+Enter (Win/Linux) submits the quick-add input,
   // matching the primary-submit shortcut used across the app (#129). Plain
@@ -538,20 +624,14 @@ export default function ProposalInline({
                 </div>
               ))}
               {parsed.newTasks && parseTodoItems(parsed.newTasks).map((item, i) => (
-                <div key={`new-${i}`} style={styles.row}>
-                  <div
-                    onClick={toggleable
-                      ? () => handleToggleItem(item, 'new task', 'completed')
-                      : undefined}
-                    title={toggleable ? 'Mark as done' : undefined}
-                    style={{
-                      ...styles.circleBase,
-                      ...styles.circleNewExtra,
-                      cursor: toggleable ? 'pointer' : 'default',
-                    }}
-                  />
-                  <div style={styles.itemText}>{item}</div>
-                </div>
+                <NewTaskRow
+                  key={`new-${i}`}
+                  item={item}
+                  styles={styles}
+                  toggleable={toggleable}
+                  onToggle={handleToggleItem}
+                  onInsert={handleInsertAfter}
+                />
               ))}
               {toggleable && (
                 quickAddOpen ? (

--- a/frontend/src/components/ProposalInline.js
+++ b/frontend/src/components/ProposalInline.js
@@ -365,7 +365,7 @@ function ProposalTaskRow({ item, styles, toggleable, variant, addingKey, setAddi
         {toggleable && (
           <button
             type="button"
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={(e) => { e.preventDefault(); setAddText(''); setAddingKey(rowKey); }}
             onClick={() => { setAddText(''); setAddingKey(rowKey); }}
             title="Add an item below"
             aria-label="Add an item below"

--- a/frontend/src/components/ProposalInline.js
+++ b/frontend/src/components/ProposalInline.js
@@ -1,8 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import api from '../api';
 import MarkdownBody from './MarkdownBody';
-import { appendItemToSection, insertItemAfter } from '../utils/markdown';
-import useSubmitShortcut from '../hooks/useSubmitShortcut';
+import { insertItemAfter } from '../utils/markdown';
 
 export function stripInlineMarkdown(text) {
   return text.replace(/\*\*(.+?)\*\*/g, '$1').replace(/__(.+?)__/g, '$1');
@@ -331,10 +330,14 @@ function sizeStyles(size) {
 // A single "New Tasks" proposal row with a hover "+" that opens an inline
 // input to insert a sibling task right below it (Voice + Text modes share
 // this — both render through the same row path).
-function NewTaskRow({ item, styles, toggleable, onToggle, onInsert }) {
+// A single proposal row (Completed or New Tasks) with a hover "+" right after
+// the text that opens an inline input to insert a sibling item below it.
+// Voice + Text modes share this (only `styles` differ via `size`).
+function ProposalTaskRow({ item, styles, toggleable, variant, onToggle, onInsert }) {
   const [hovered, setHovered] = useState(false);
   const [adding, setAdding] = useState(false);
   const [addText, setAddText] = useState('');
+  const completed = variant === 'completed';
   const submit = () => {
     const t = addText.trim();
     if (t) onInsert(item, t);
@@ -344,24 +347,28 @@ function NewTaskRow({ item, styles, toggleable, onToggle, onInsert }) {
   return (
     <>
       <div
-        style={{ ...styles.row, position: 'relative' }}
+        style={styles.row}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
         <div
-          onClick={toggleable ? () => onToggle(item, 'new task', 'completed') : undefined}
-          title={toggleable ? 'Mark as done' : undefined}
-          style={{ ...styles.circleBase, ...styles.circleNewExtra, cursor: toggleable ? 'pointer' : 'default' }}
-        />
-        <div style={styles.itemText}>{item}</div>
+          onClick={toggleable
+            ? () => (completed
+                ? onToggle(item, 'completed', 'new task', { prepend: true })
+                : onToggle(item, 'new task', 'completed'))
+            : undefined}
+          title={toggleable ? (completed ? 'Unmark as done' : 'Mark as done') : undefined}
+          style={{ ...styles.circleBase, ...(completed ? styles.circleCompletedExtra : styles.circleNewExtra), cursor: toggleable ? 'pointer' : 'default' }}
+        >{completed ? '✓' : null}</div>
+        <div style={{ ...styles.itemText, ...(completed ? { textDecoration: 'line-through', opacity: 0.4 } : null) }}>{item}</div>
         {toggleable && (
           <button
             type="button"
             onClick={() => { setAdding(true); setAddText(''); }}
-            title="Add a task below"
-            aria-label="Add a task below"
+            title="Add an item below"
+            aria-label="Add an item below"
             style={{
-              marginLeft: 'auto', opacity: hovered ? 1 : 0,
+              opacity: hovered ? 1 : 0,
               transition: 'opacity 0.12s ease', background: 'none', border: 'none',
               color: 'var(--accent)', cursor: 'pointer', fontSize: '1.2rem',
               lineHeight: 1, padding: '0 4px',
@@ -381,7 +388,7 @@ function NewTaskRow({ item, styles, toggleable, onToggle, onInsert }) {
               else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
             }}
             onBlur={() => { if (!addText.trim()) setAdding(false); }}
-            placeholder="New task…"
+            placeholder="New item…"
             style={{
               flex: 1, minWidth: 0, background: 'var(--bg-input)',
               border: '1px solid var(--border)', borderRadius: '6px',
@@ -413,10 +420,6 @@ export default function ProposalInline({
   const [issueApplyError, setIssueApplyError] = useState(null);
   const [issueResult, setIssueResult] = useState(null);
   const mergePollingRef = useRef(null);
-  const [quickAddOpen, setQuickAddOpen] = useState(false);
-  const [quickAddText, setQuickAddText] = useState('');
-  const [quickAddSaving, setQuickAddSaving] = useState(false);
-  const quickAddInputRef = useRef(null);
   const styles = sizeStyles(size);
   const toggleable = typeof onContentChange === 'function'
     && applyStatus !== 'completed'
@@ -438,41 +441,6 @@ export default function ProposalInline({
     });
   }, [content, nodeId, onContentChange, onError, toggleable]);
 
-  // Quick-add a task to the proposal's "New Tasks" section (#108), mirroring
-  // the Todo-page quick-add. Reuses appendItemToSection + the same optimistic
-  // PUT /nodes/:id persist+revert path as the toggle above, so the added task
-  // is included when the user clicks "Apply changes to my Todo".
-  const handleQuickAddTask = useCallback(() => {
-    const task = quickAddText.trim();
-    if (!toggleable || !nodeId || !task || quickAddSaving) return;
-    const newContent = appendItemToSection(content, 'new task', task, {
-      headingLevel: 3,
-      match: 'includes',
-      itemPrefix: '- ',
-      createTitle: 'New Tasks',
-    });
-    if (newContent === content) return;
-    const prevContent = content;
-    setQuickAddSaving(true);
-    setQuickAddText('');
-    onContentChange(newContent);
-    api.put(`/nodes/${nodeId}`, { content: newContent })
-      .then(() => {
-        // Keep the input open + focused for rapid entry of multiple tasks.
-        if (quickAddInputRef.current) quickAddInputRef.current.focus();
-      })
-      .catch((err) => {
-        console.error('Failed to add proposal task:', err);
-        onContentChange(prevContent);
-        setQuickAddText(task);
-        if (onError) {
-          const reason = err.response?.data?.error || err.response?.statusText || err.message || 'Unknown error';
-          onError(`Couldn't add task — reverted (${reason})`);
-        }
-      })
-      .finally(() => setQuickAddSaving(false));
-  }, [content, nodeId, onContentChange, onError, toggleable, quickAddText, quickAddSaving]);
-
   // Insert a new task immediately below a given "New Tasks" row (the hover "+"),
   // preserving the section's plain-bullet style. Same optimistic+revert path.
   const handleInsertAfter = useCallback((afterItem, newTask) => {
@@ -490,16 +458,6 @@ export default function ProposalInline({
       }
     });
   }, [content, nodeId, onContentChange, onError, toggleable]);
-
-  // Cmd+Return (macOS) / Ctrl+Enter (Win/Linux) submits the quick-add input,
-  // matching the primary-submit shortcut used across the app (#129). Plain
-  // Enter is still handled by the input's onKeyDown below; this just adds the
-  // modifier chord. Enabled mirrors the Add button's disabled state.
-  useSubmitShortcut(
-    quickAddInputRef,
-    handleQuickAddTask,
-    quickAddOpen && !quickAddSaving && !!quickAddText.trim(),
-  );
 
   useEffect(() => {
     if (!toolCallsMeta) return;
@@ -605,114 +563,27 @@ export default function ProposalInline({
             <div style={styles.sectionWrapper}>
               {sectionLabel('Updated from your sharing')}
               {parsed.completed && parseTodoItems(parsed.completed).map((item, i) => (
-                <div key={`done-${i}`} style={styles.row}>
-                  <div
-                    onClick={toggleable
-                      ? () => handleToggleItem(item, 'completed', 'new task', { prepend: true })
-                      : undefined}
-                    title={toggleable ? 'Unmark as done' : undefined}
-                    style={{
-                      ...styles.circleBase,
-                      ...styles.circleCompletedExtra,
-                      cursor: toggleable ? 'pointer' : 'default',
-                    }}
-                  >✓</div>
-                  <div style={{
-                    ...styles.itemText,
-                    textDecoration: 'line-through', opacity: 0.4,
-                  }}>{item}</div>
-                </div>
-              ))}
-              {parsed.newTasks && parseTodoItems(parsed.newTasks).map((item, i) => (
-                <NewTaskRow
-                  key={`new-${i}`}
+                <ProposalTaskRow
+                  key={`done-${i}`}
                   item={item}
                   styles={styles}
                   toggleable={toggleable}
+                  variant="completed"
                   onToggle={handleToggleItem}
                   onInsert={handleInsertAfter}
                 />
               ))}
-              {toggleable && (
-                quickAddOpen ? (
-                  <div style={{
-                    display: 'flex', alignItems: 'center', gap: '8px',
-                    padding: styles.roomy ? '12px 0' : '8px 0',
-                  }}>
-                    <input
-                      ref={quickAddInputRef}
-                      value={quickAddText}
-                      onChange={(e) => setQuickAddText(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
-                          e.preventDefault();
-                          handleQuickAddTask();
-                        } else if (e.key === 'Escape') {
-                          setQuickAddOpen(false);
-                          setQuickAddText('');
-                        }
-                      }}
-                      placeholder="Add a task and press Enter"
-                      disabled={quickAddSaving}
-                      style={{
-                        flex: 1,
-                        background: 'var(--bg-input)',
-                        border: '1px solid var(--border)',
-                        borderRadius: '6px',
-                        color: 'var(--text-primary)',
-                        fontFamily: 'var(--sans)',
-                        fontSize: styles.roomy ? '0.92rem' : '0.85rem',
-                        fontWeight: 300,
-                        padding: '8px 12px',
-                      }}
-                    />
-                    <button
-                      onClick={handleQuickAddTask}
-                      disabled={quickAddSaving || !quickAddText.trim()}
-                      style={{
-                        padding: '8px 16px',
-                        background: 'var(--accent)',
-                        border: 'none',
-                        borderRadius: '6px',
-                        color: 'var(--bg-deep)',
-                        fontFamily: 'var(--sans)',
-                        fontSize: styles.roomy ? '0.85rem' : '0.8rem',
-                        fontWeight: 400,
-                        cursor: (quickAddSaving || !quickAddText.trim()) ? 'not-allowed' : 'pointer',
-                        opacity: (quickAddSaving || !quickAddText.trim()) ? 0.5 : 1,
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {quickAddSaving ? 'Adding…' : 'Add'}
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => {
-                      setQuickAddOpen(true);
-                      setTimeout(() => {
-                        if (quickAddInputRef.current) quickAddInputRef.current.focus();
-                      }, 0);
-                    }}
-                    aria-label="Add a task"
-                    title="Add a task"
-                    style={{
-                      width: styles.roomy ? '24px' : '22px',
-                      height: styles.roomy ? '24px' : '22px',
-                      borderRadius: '50%',
-                      border: '1px dashed var(--border-hover)',
-                      background: 'none',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      cursor: 'pointer', padding: 0,
-                      color: 'var(--text-muted)',
-                      fontFamily: 'var(--sans)', fontWeight: 300,
-                      fontSize: styles.roomy ? '1.1rem' : '1rem', lineHeight: 1,
-                      marginTop: styles.roomy ? '12px' : '8px',
-                      transition: 'all 0.2s ease',
-                    }}
-                  >+</button>
-                )
-              )}
+              {parsed.newTasks && parseTodoItems(parsed.newTasks).map((item, i) => (
+                <ProposalTaskRow
+                  key={`new-${i}`}
+                  item={item}
+                  styles={styles}
+                  toggleable={toggleable}
+                  variant="new"
+                  onToggle={handleToggleItem}
+                  onInsert={handleInsertAfter}
+                />
+              ))}
             </div>
           )}
 

--- a/frontend/src/components/ProposalInline.js
+++ b/frontend/src/components/ProposalInline.js
@@ -333,16 +333,17 @@ function sizeStyles(size) {
 // A single proposal row (Completed or New Tasks) with a hover "+" right after
 // the text that opens an inline input to insert a sibling item below it.
 // Voice + Text modes share this (only `styles` differ via `size`).
-function ProposalTaskRow({ item, styles, toggleable, variant, onToggle, onInsert }) {
+function ProposalTaskRow({ item, styles, toggleable, variant, addingKey, setAddingKey, onToggle, onInsert }) {
   const [hovered, setHovered] = useState(false);
-  const [adding, setAdding] = useState(false);
   const [addText, setAddText] = useState('');
   const completed = variant === 'completed';
+  const rowKey = `${variant}:${item}`;
+  const adding = addingKey === rowKey;
+  const close = () => { setAddingKey(null); setAddText(''); };
   const submit = () => {
     const t = addText.trim();
     if (t) onInsert(item, t);
-    setAdding(false);
-    setAddText('');
+    close();
   };
   return (
     <>
@@ -364,7 +365,8 @@ function ProposalTaskRow({ item, styles, toggleable, variant, onToggle, onInsert
         {toggleable && (
           <button
             type="button"
-            onClick={() => { setAdding(true); setAddText(''); }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => { setAddText(''); setAddingKey(rowKey); }}
             title="Add an item below"
             aria-label="Add an item below"
             style={{
@@ -385,9 +387,9 @@ function ProposalTaskRow({ item, styles, toggleable, variant, onToggle, onInsert
             onChange={(e) => setAddText(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); submit(); }
-              else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
+              else if (e.key === 'Escape') { e.preventDefault(); close(); }
             }}
-            onBlur={() => { if (!addText.trim()) setAdding(false); }}
+            onBlur={() => { if (!addText.trim()) close(); }}
             placeholder="New item…"
             style={{
               flex: 1, minWidth: 0, background: 'var(--bg-input)',
@@ -415,6 +417,10 @@ export default function ProposalInline({
   const hasTodo = parsed.completed || parsed.newTasks || parsed.priority || parsed.note;
   const hasIssue = parsed.issueTitle && parsed.issueDescription;
   const [applyStatus, setApplyStatus] = useState(null);
+  // Which row (if any) currently has its inline add-input open. Lifted here so
+  // opening one row's "+" closes any other — and clicking a second "+" switches
+  // to it instead of just cancelling the first.
+  const [addingKey, setAddingKey] = useState(null);
   const [applyError, setApplyError] = useState(null);
   const [issueApplyStatus, setIssueApplyStatus] = useState(null);
   const [issueApplyError, setIssueApplyError] = useState(null);
@@ -569,6 +575,8 @@ export default function ProposalInline({
                   styles={styles}
                   toggleable={toggleable}
                   variant="completed"
+                  addingKey={addingKey}
+                  setAddingKey={setAddingKey}
                   onToggle={handleToggleItem}
                   onInsert={handleInsertAfter}
                 />
@@ -580,6 +588,8 @@ export default function ProposalInline({
                   styles={styles}
                   toggleable={toggleable}
                   variant="new"
+                  addingKey={addingKey}
+                  setAddingKey={setAddingKey}
                   onToggle={handleToggleItem}
                   onInsert={handleInsertAfter}
                 />

--- a/frontend/src/components/QuotedContent.js
+++ b/frontend/src/components/QuotedContent.js
@@ -21,7 +21,7 @@ const COMBINED_PATTERN = /(\{quote:\d+\}|\{user_(?:profile|todo|recent_raw|recen
  *   contextArtifacts: Object with "profile" and/or "todo" keys containing artifact data
  *   onQuoteClick: Callback when a quote is clicked (receives quote ID)
  */
-const QuotedContent = ({ content, quotes, contextArtifacts, onQuoteClick, onCheckboxToggle }) => {
+const QuotedContent = ({ content, quotes, contextArtifacts, onQuoteClick, onCheckboxToggle, onAddTask }) => {
   if (!content) {
     return null;
   }
@@ -32,7 +32,7 @@ const QuotedContent = ({ content, quotes, contextArtifacts, onQuoteClick, onChec
   // If no special data provided, just render the content as-is with markdown
   if (!hasQuotes && !hasArtifacts && !ARTIFACT_PATTERN.test(content)) {
     return (
-      <MarkdownBody onCheckboxToggle={onCheckboxToggle}>
+      <MarkdownBody onCheckboxToggle={onCheckboxToggle} onAddTask={onAddTask}>
         {content}
       </MarkdownBody>
     );
@@ -69,7 +69,7 @@ const QuotedContent = ({ content, quotes, contextArtifacts, onQuoteClick, onChec
       {segments.map((segment, index) => {
         if (segment.type === 'text') {
           return (
-            <MarkdownBody key={index} onCheckboxToggle={onCheckboxToggle}>
+            <MarkdownBody key={index} onCheckboxToggle={onCheckboxToggle} onAddTask={onAddTask}>
               {segment.content}
             </MarkdownBody>
           );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -198,3 +198,16 @@ code {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--border-hover);
 }
+
+/* Nested task lists rendered by MarkdownBody (#138).
+   Keep the top-level checkbox circles flush-left, but indent each nested
+   level. Controlled in CSS (not inline) because inline padding on the <ul>
+   would override these rules and flatten the tree. */
+.loore-md ul.contains-task-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 4px 0;
+}
+.loore-md ul.contains-task-list ul.contains-task-list {
+  padding-left: 1.5em;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -211,3 +211,15 @@ code {
 .loore-md ul.contains-task-list ul.contains-task-list {
   padding-left: 1.5em;
 }
+
+/* Per-row hover "+" to add a task below a checklist item. The button is
+   scoped to each item's own row (.loore-task-row wraps only the row, not its
+   nested children), so hovering a row reveals only that row's "+". */
+.loore-md .loore-add-task {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.loore-md .loore-task-row:hover .loore-add-task,
+.loore-md .loore-add-task:focus {
+  opacity: 1;
+}

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -96,20 +96,20 @@ function countAllItems(items) {
   return count;
 }
 
-function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
+function TodoItem({ item, onToggle, onInsertAfter, addingKey, setAddingKey, depth = 0 }) {
   const [collapsed, setCollapsed] = useState(true);
   const [hovered, setHovered] = useState(false);
-  const [adding, setAdding] = useState(false);
   const [addText, setAddText] = useState('');
   const hasChildren = item.children && item.children.length > 0;
   const childCount = hasChildren ? countAllItems(item.children) : 0;
   const addable = item.checked !== null && typeof onInsertAfter === 'function';
+  const adding = addingKey === item.text;
+  const closeAdd = () => { setAddingKey(null); setAddText(''); };
 
   const submitAdd = () => {
     const t = addText.trim();
     if (t) onInsertAfter(item, t);
-    setAdding(false);
-    setAddText('');
+    closeAdd();
   };
 
   return (
@@ -182,7 +182,8 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
         {addable && (
           <button
             type="button"
-            onClick={() => { setAdding(true); setAddText(''); }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => { setAddText(''); setAddingKey(item.text); }}
             title="Add an item below"
             aria-label="Add an item below"
             style={{
@@ -191,7 +192,7 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
               background: 'none', border: 'none',
               color: 'var(--accent)', cursor: 'pointer',
               fontSize: '1.2rem', lineHeight: 1, padding: '0 4px',
-              marginTop: '-1px',
+              alignSelf: 'center',
             }}
           >+</button>
         )}
@@ -205,9 +206,9 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
             onChange={(e) => setAddText(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') { e.preventDefault(); submitAdd(); }
-              else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
+              else if (e.key === 'Escape') { e.preventDefault(); closeAdd(); }
             }}
-            onBlur={() => { if (!addText.trim()) setAdding(false); }}
+            onBlur={() => { if (!addText.trim()) closeAdd(); }}
             placeholder="New item…"
             style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text-primary)', fontFamily: 'var(--sans)', fontSize: '0.92rem', padding: '6px 10px' }}
           />
@@ -216,7 +217,7 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
       {hasChildren && !collapsed && (
         <div>
           {item.children.map((child, k) => (
-            <TodoItem key={k} item={child} onToggle={onToggle} onInsertAfter={onInsertAfter} depth={depth + 1} />
+            <TodoItem key={k} item={child} onToggle={onToggle} onInsertAfter={onInsertAfter} addingKey={addingKey} setAddingKey={setAddingKey} depth={depth + 1} />
           ))}
         </div>
       )}
@@ -230,6 +231,10 @@ export default function TodoPage() {
   const [editing, setEditing] = useState(false);
   const [editContent, setEditContent] = useState('');
   const [saving, setSaving] = useState(false);
+
+  // Which per-row "+" inline add-input is open (keyed by item text). Lifted so
+  // opening one closes any other, and clicking a second "+" switches to it.
+  const [addingKey, setAddingKey] = useState(null);
 
   // Quick-add task (#108): reveal a small input that appends to "## Today".
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -491,24 +496,6 @@ export default function TodoPage() {
               padding: '8px 12px',
             }}
           />
-          <button
-            onClick={handleQuickAdd}
-            disabled={quickAddSaving || !quickAddText.trim()}
-            style={{
-              padding: '8px 16px',
-              background: 'var(--accent)',
-              border: 'none',
-              borderRadius: '6px',
-              color: 'var(--bg-deep)',
-              fontFamily: 'var(--sans)',
-              fontSize: '0.85rem',
-              fontWeight: 400,
-              cursor: (quickAddSaving || !quickAddText.trim()) ? 'not-allowed' : 'pointer',
-              opacity: (quickAddSaving || !quickAddText.trim()) ? 0.5 : 1,
-            }}
-          >
-            {quickAddSaving ? 'Adding...' : 'Add'}
-          </button>
         </div>
       )}
 
@@ -635,7 +622,7 @@ export default function TodoPage() {
                 </span>
               </div>
               {section.items.map((item, j) => (
-                <TodoItem key={j} item={item} onToggle={handleToggle} onInsertAfter={handleInsertAfter} />
+                <TodoItem key={j} item={item} onToggle={handleToggle} onInsertAfter={handleInsertAfter} addingKey={addingKey} setAddingKey={setAddingKey} />
               ))}
               {section.items.length === 0 && (
                 <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem', fontStyle: 'italic', padding: '4px 0' }}>

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -183,10 +183,9 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
           <button
             type="button"
             onClick={() => { setAdding(true); setAddText(''); }}
-            title="Add a task below"
-            aria-label="Add a task below"
+            title="Add an item below"
+            aria-label="Add an item below"
             style={{
-              marginLeft: 'auto',
               opacity: hovered ? 1 : 0,
               transition: 'opacity 0.12s ease',
               background: 'none', border: 'none',
@@ -209,7 +208,7 @@ function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
               else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
             }}
             onBlur={() => { if (!addText.trim()) setAdding(false); }}
-            placeholder="New task…"
+            placeholder="New item…"
             style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text-primary)', fontFamily: 'var(--sans)', fontSize: '0.92rem', padding: '6px 10px' }}
           />
         </div>

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import api from '../api';
-import { useCheckboxToggle, appendItemToSection } from '../utils/markdown';
+import { useCheckboxToggle, useTaskInsert, appendItemToSection } from '../utils/markdown';
 import { formatDate } from '../utils/date';
 import VersionHistoryDrawer from '../components/VersionHistoryDrawer';
 import useSubmitShortcut from '../hooks/useSubmitShortcut';
@@ -96,14 +96,27 @@ function countAllItems(items) {
   return count;
 }
 
-function TodoItem({ item, onToggle, depth = 0 }) {
+function TodoItem({ item, onToggle, onInsertAfter, depth = 0 }) {
   const [collapsed, setCollapsed] = useState(true);
+  const [hovered, setHovered] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [addText, setAddText] = useState('');
   const hasChildren = item.children && item.children.length > 0;
   const childCount = hasChildren ? countAllItems(item.children) : 0;
+  const addable = item.checked !== null && typeof onInsertAfter === 'function';
+
+  const submitAdd = () => {
+    const t = addText.trim();
+    if (t) onInsertAfter(item, t);
+    setAdding(false);
+    setAddText('');
+  };
 
   return (
     <div>
       <div
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
         style={{
           display: 'flex',
           alignItems: 'flex-start',
@@ -166,11 +179,45 @@ function TodoItem({ item, onToggle, depth = 0 }) {
             </span>
           </div>
         )}
+        {addable && (
+          <button
+            type="button"
+            onClick={() => { setAdding(true); setAddText(''); }}
+            title="Add a task below"
+            aria-label="Add a task below"
+            style={{
+              marginLeft: 'auto',
+              opacity: hovered ? 1 : 0,
+              transition: 'opacity 0.12s ease',
+              background: 'none', border: 'none',
+              color: 'var(--accent)', cursor: 'pointer',
+              fontSize: '1.2rem', lineHeight: 1, padding: '0 4px',
+              marginTop: '-1px',
+            }}
+          >+</button>
+        )}
       </div>
+      {adding && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '8px 0', paddingLeft: depth * 24 }}>
+          <span style={{ width: '18px', height: '18px', borderRadius: '50%', border: '1.5px dashed var(--border-hover)', flexShrink: 0, opacity: 0.5 }} />
+          <input
+            autoFocus
+            value={addText}
+            onChange={(e) => setAddText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') { e.preventDefault(); submitAdd(); }
+              else if (e.key === 'Escape') { e.preventDefault(); setAdding(false); setAddText(''); }
+            }}
+            onBlur={() => { if (!addText.trim()) setAdding(false); }}
+            placeholder="New task…"
+            style={{ flex: 1, minWidth: 0, background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text-primary)', fontFamily: 'var(--sans)', fontSize: '0.92rem', padding: '6px 10px' }}
+          />
+        </div>
+      )}
       {hasChildren && !collapsed && (
         <div>
           {item.children.map((child, k) => (
-            <TodoItem key={k} item={child} onToggle={onToggle} depth={depth + 1} />
+            <TodoItem key={k} item={child} onToggle={onToggle} onInsertAfter={onInsertAfter} depth={depth + 1} />
           ))}
         </div>
       )}
@@ -216,17 +263,20 @@ export default function TodoPage() {
     fetchTodo();
   }, [fetchTodo]);
 
-  const checkboxToggle = useCheckboxToggle(
-    useCallback(() => todo?.content, [todo]),
-    useCallback((newContent) => {
-      setTodo(prev => prev ? { ...prev, content: newContent } : prev);
-      setEditContent(newContent);
-    }, []),
-    useCallback((newContent) => api.patch('/todo', { content: newContent }), []),
-  );
+  const getTodoContent = useCallback(() => todo?.content, [todo]);
+  const setTodoContent = useCallback((newContent) => {
+    setTodo(prev => prev ? { ...prev, content: newContent } : prev);
+    setEditContent(newContent);
+  }, []);
+  const saveTodoContent = useCallback((newContent) => api.patch('/todo', { content: newContent }), []);
+  const checkboxToggle = useCheckboxToggle(getTodoContent, setTodoContent, saveTodoContent);
+  const taskInsert = useTaskInsert(getTodoContent, setTodoContent, saveTodoContent);
 
   const handleToggle = (item) => {
     checkboxToggle(item.text, item.checked);
+  };
+  const handleInsertAfter = (item, text) => {
+    taskInsert(item.text, text);
   };
 
   const handleSave = async () => {
@@ -586,7 +636,7 @@ export default function TodoPage() {
                 </span>
               </div>
               {section.items.map((item, j) => (
-                <TodoItem key={j} item={item} onToggle={handleToggle} />
+                <TodoItem key={j} item={item} onToggle={handleToggle} onInsertAfter={handleInsertAfter} />
               ))}
               {section.items.length === 0 && (
                 <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem', fontStyle: 'italic', padding: '4px 0' }}>

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -303,7 +303,7 @@ export default function TodoPage() {
     const task = quickAddText.trim();
     if (!task || quickAddSaving || !todo) return;
     const prevContent = todo.content;
-    const newContent = appendItemToSection(prevContent, 'Today', task);
+    const newContent = appendItemToSection(prevContent, 'Today', task, { createAtStart: true });
     setQuickAddSaving(true);
     // Optimistic update so the new task appears immediately.
     setTodo(prev => prev ? { ...prev, content: newContent } : prev);

--- a/frontend/src/pages/TodoPage.js
+++ b/frontend/src/pages/TodoPage.js
@@ -182,7 +182,7 @@ function TodoItem({ item, onToggle, onInsertAfter, addingKey, setAddingKey, dept
         {addable && (
           <button
             type="button"
-            onMouseDown={(e) => e.preventDefault()}
+            onMouseDown={(e) => { e.preventDefault(); setAddText(''); setAddingKey(item.text); }}
             onClick={() => { setAddText(''); setAddingKey(item.text); }}
             title="Add an item below"
             aria-label="Add an item below"

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -103,6 +103,9 @@ export function insertItemAfter(content, afterItemText, newText) {
  *   createTitle  — heading text used when the section must be created
  *                  (defaults to `sectionTitle`; useful when `match` is a
  *                  lowercase search term but the heading should be cased).
+ *   createAtStart — when the section doesn't exist, create it at the TOP of
+ *                  the content instead of appending at the end (e.g. `## Today`
+ *                  should be the first todo section).
  */
 export function appendItemToSection(content, sectionTitle, task, options = {}) {
   const {
@@ -110,6 +113,7 @@ export function appendItemToSection(content, sectionTitle, task, options = {}) {
     match = 'exact',
     itemPrefix = '- [ ] ',
     createTitle = sectionTitle,
+    createAtStart = false,
   } = options;
 
   const cleanTask = (task || '').trim();
@@ -137,10 +141,15 @@ export function appendItemToSection(content, sectionTitle, task, options = {}) {
     }
   }
 
-  // Section not present — append a fresh section at the end.
+  // Section not present — create a fresh one.
   if (headingIdx === -1) {
+    const newSection = `${hashes} ${createTitle}\n\n${newItem}\n`;
+    if (createAtStart) {
+      const body = base.trim();
+      return body ? `${newSection}\n${body}\n` : newSection;
+    }
     const sep = base.length && !base.endsWith('\n') ? '\n\n' : (base.endsWith('\n\n') ? '' : '\n');
-    return `${base}${sep}${hashes} ${createTitle}\n\n${newItem}\n`;
+    return `${base}${sep}${newSection}`;
   }
 
   // Find where this section ends: the next same-or-higher heading, or EOF.

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -38,6 +38,52 @@ export function toggleCheckbox(content, itemText, currentChecked) {
 }
 
 /**
+ * Insert a new list item immediately after the item whose text matches
+ * `afterItemText` (and after that item's nested subtree), preserving the
+ * matched item's bullet style ("- " plain vs "- [ ] " checkbox) and
+ * indentation. Powers the per-row "+" quick-add across Todo, proposals, and
+ * MarkdownBody checklists. Returns the content unchanged if no line matches.
+ */
+export function insertItemAfter(content, afterItemText, newText) {
+  const text = (newText || '').trim();
+  if (!text) return content;
+  const lines = (content || '').split('\n');
+  // indent | bullet | optional checkbox | label
+  const lineRe = /^(\s*)([-*])\s+(\[[ xX]\]\s+)?(.*)$/;
+
+  let idx = -1;
+  let indent = '';
+  let bullet = '-';
+  let checkbox = '';
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(lineRe);
+    if (m && stripInlineMarkdown(m[4]).trim() === afterItemText) {
+      idx = i;
+      indent = m[1];
+      bullet = m[2];
+      checkbox = m[3] ? '[ ] ' : '';
+      break;
+    }
+  }
+  if (idx === -1) return content;
+
+  // Skip past the item's nested subtree (deeper-indented lines) so the new
+  // sibling lands after the item's children, not in the middle of them.
+  let insertAt = idx + 1;
+  for (let i = idx + 1; i < lines.length; i++) {
+    const lead = (lines[i].match(/^(\s*)/)[1] || '');
+    if (lines[i].trim() !== '' && lead.length > indent.length) {
+      insertAt = i + 1;
+    } else {
+      break;
+    }
+  }
+
+  lines.splice(insertAt, 0, `${indent}${bullet} ${checkbox}${text}`);
+  return lines.join('\n');
+}
+
+/**
  * Append a new list item to the END of a named markdown section in `content`.
  *
  * Shared by the Todo page quick-add (`## Today`, issue #108) and the
@@ -150,6 +196,39 @@ export function useCheckboxToggle(getContent, setContent, save) {
         || err.message
         || 'Unknown error';
       addToast(`Couldn't save change — reverted (${reason})`);
+    });
+  }, [getContent, setContent, save, addToast]);
+}
+
+/**
+ * Hook for optimistic per-row task insertion (the hover "+" quick-add).
+ * Same getContent/setContent/save contract as useCheckboxToggle.
+ *
+ * Returns: (afterItemText: string, newText: string) => void — inserts a new
+ * item right after the matched row (and its subtree), optimistically, then
+ * persists; reverts and toasts on failure.
+ */
+export function useTaskInsert(getContent, setContent, save) {
+  const prevContentRef = useRef(null);
+  const { addToast } = useToast();
+
+  return useCallback((afterItemText, newText) => {
+    const content = getContent();
+    if (content == null) return;
+    const newContent = insertItemAfter(content, afterItemText, newText);
+    if (newContent === content) return;
+    prevContentRef.current = content;
+    setContent(newContent);
+    save(newContent).catch((err) => {
+      console.error('Failed to insert task:', err);
+      if (prevContentRef.current !== null) {
+        setContent(prevContentRef.current);
+      }
+      const reason = err.response?.data?.error
+        || err.response?.statusText
+        || err.message
+        || 'Unknown error';
+      addToast(`Couldn't add task — reverted (${reason})`);
     });
   }, [getContent, setContent, save, addToast]);
 }


### PR DESCRIPTION
## #138 — Markdown rendering, nested task lists, and per-row quick-add

### 1. Canonical markdown styling (original #138)
Missing `MarkdownBody` overrides — serif h1–h6 hierarchy, blockquote, `strong`/`em`/`del`, card code blocks, responsive `img` — inline CSS vars, light/dark safe. Headings render `{children}` + `img` `alt` for CI `jsx-a11y`.

### 2. Nested task lists + clickability (issue-comment gap)
Indentation moved to CSS (`.loore-md ul.contains-task-list`: top flush, nested +1.5em); `extractText`/`replaceCheckboxes` stop at nested lists so each `<li>` owns its label + checkbox.

### 3. Per-row hover "+" quick-add (feature)
A hover "+" right after each task's text opens an inline input **below that row**, inserting a sibling at that position (after the row's subtree), across all three renderers:
- **node markdown checklists** (`MarkdownBody`, opt-in `onAddTask`)
- **TodoPage** (`TodoItem`) — keeps its existing bottom "+" too
- **Voice + Text todo-update proposals** (`ProposalInline` → shared `ProposalTaskRow`, on **both** Completed and New-Tasks rows) — the old bottom "+" is **removed** here

Shared `insertItemAfter()` + `useTaskInsert()` (`utils/markdown.js`) preserve each item's bullet style (`- ` vs `- [ ] `) and indentation, with the toggle's optimistic-save+revert path. Input placeholder "New item…". Also: `BubbleKebabMenu` z-index 5→1000 so the kebab dropdown overshadows row "+" controls (was clickable-through onto Edit/Delete).

**Verified on staging:** markdown renders dark+light; nested lists indent + every checkbox toggles its own line; hover-"+" inserts at the correct position on node checklists (top-level after subtree + nested at indent), TodoPage, and proposals (New-Tasks **and** Completed, plain-bullet format) — each persisted; kebab menu renders opaque over the rows. Voice-mode proposals share `ProposalTaskRow` (same code; live-tested in Text mode).

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
