### PR TITLE
Fix: trim leading/trailing margins so a markdown heading sits flush in its bubble

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -212,6 +212,17 @@ code {
   padding-left: 1.5em;
 }
 
+/* Trim the outer margins of MarkdownBody content so the first/last block sits
+   flush within its container (the bubble/card already provides the padding).
+   Without this a leading "# Heading" pushes down by its large top margin. The
+   !important overrides the inline element margins MarkdownBody sets. */
+.loore-md > *:first-child {
+  margin-top: 0 !important;
+}
+.loore-md > *:last-child {
+  margin-bottom: 0 !important;
+}
+
 /* Per-row hover "+" to add a task below a checklist item. The button is
    scoped to each item's own row (.loore-task-row wraps only the row, not its
    nested children), so hovering a row reveals only that row's "+". */


### PR DESCRIPTION
## Fix: leading markdown heading has too much space above it

A node whose content starts with a heading (e.g. `# Loore`) rendered with a large gap above the title inside its bubble. Cause: the #138 `MarkdownBody` heading overrides set `margin: '1.2em 0 0.4em'`, and since `em` is relative to the heading's own (2.2em) font size, the top margin is ~42px — correct *between* blocks, but excessive when the heading is the **first** element.

Fix: trim the outer margins of `MarkdownBody` content — zero the top margin of the first block and the bottom margin of the last block (the bubble/card already provides the padding). One CSS rule in `index.css` (`.loore-md > *:first-child` / `:last-child`); `!important` is needed to override the inline element margins.

**Verified on staging:** a node starting with `# Loore` now renders the title flush at the top of the bubble (computed `margin-top` on the leading `<h1>` is `0px`, was ~42px); mid-content headings keep their spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
