### PR TITLE
Fix automatic profile-update pipeline: eligibility, recursion crash, resumable regen

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from flask_login import UserMixin
+from sqlalchemy import or_
 from backend.extensions import db
 from backend.utils.encryption import encrypt_content, decrypt_content
 
@@ -79,6 +80,24 @@ class User(db.Model, UserMixin):
 
     def get_id(self):
         return str(self.id)
+
+    @classmethod
+    def profile_eligible_query(cls):
+        """Users eligible for automatic profile / recent-context updates:
+        anyone on a Voice-Mode plan, minus the synthetic ``llm-<model>``
+        placeholder accounts.
+
+        The placeholder exclusion MUST keep users whose ``twitter_id`` is
+        NULL (email / magic-link signups). A bare ``~twitter_id.like('llm-%')``
+        silently drops them: in SQL ``NULL NOT LIKE x`` evaluates to NULL —
+        not TRUE — so the row fails the WHERE clause. That bug starved every
+        non-Twitter signup of automatic profile updates, which is why this
+        is a single shared helper rather than an inline filter.
+        """
+        return cls.query.filter(
+            cls.plan.in_(list(cls.VOICE_MODE_PLANS)),
+            or_(cls.twitter_id.is_(None), ~cls.twitter_id.like("llm-%")),
+        )
 
 class Node(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -84,17 +84,27 @@ class User(db.Model, UserMixin):
     @classmethod
     def profile_eligible_query(cls):
         """Users eligible for automatic profile / recent-context updates:
-        anyone on a Voice-Mode plan, minus the synthetic ``llm-<model>``
-        placeholder accounts.
+        approved, active accounts on a Voice-Mode plan, minus the synthetic
+        ``llm-<model>`` placeholder accounts.
 
-        The placeholder exclusion MUST keep users whose ``twitter_id`` is
-        NULL (email / magic-link signups). A bare ``~twitter_id.like('llm-%')``
-        silently drops them: in SQL ``NULL NOT LIKE x`` evaluates to NULL —
-        not TRUE — so the row fails the WHERE clause. That bug starved every
-        non-Twitter signup of automatic profile updates, which is why this
-        is a single shared helper rather than an inline filter.
+        Two non-obvious guards:
+
+        * ``approved`` gates all access (login + terms) and is flipped to
+          ``False`` by admin deactivation. Excluding non-approved users
+          stops us spending LLM budget building profiles nobody can open —
+          and makes deactivation an effective "pause this user" switch.
+
+        * The placeholder exclusion MUST keep users whose ``twitter_id`` is
+          NULL (email / magic-link signups). A bare ``~twitter_id.like('llm-%')``
+          silently drops them: in SQL ``NULL NOT LIKE x`` evaluates to NULL —
+          not TRUE — so the row fails the WHERE clause. That bug starved
+          every non-Twitter signup of automatic profile updates.
+
+        Shared helper (not an inline filter) so the profile and
+        recent-context tasks can't drift apart again.
         """
         return cls.query.filter(
+            cls.approved.is_(True),
             cls.plan.in_(list(cls.VOICE_MODE_PLANS)),
             or_(cls.twitter_id.is_(None), ~cls.twitter_id.like("llm-%")),
         )

--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -417,43 +417,54 @@ def format_node_tree(
 def _collect_all_nodes_in_tree(node, filter_ai_usage=False, created_before=None,
                                collected=None, user_id=None):
     """
-    Recursively collect all accessible nodes in a tree.
+    Collect all accessible nodes in a tree, in pre-order.
+
+    Iterative (explicit stack) rather than recursive: a recursive walk
+    overflowed Python's call-stack limit on users with very deep reply
+    chains — each level also lazy-loads ``node.children``, multiplying the
+    frames per level — which crashed full profile regeneration before any
+    LLM call. An explicit stack bounds depth by the heap instead.
 
     Args:
         node: Root node of the tree
         filter_ai_usage: If True, only include nodes where ai_usage is 'chat' or 'train'
         created_before: Optional datetime filter
-        collected: Set of already collected node IDs (to avoid duplicates)
-        user_id: If provided, skip inaccessible nodes but still recurse
+        collected: Set of already collected node IDs (dedupe + cycle guard)
+        user_id: If provided, skip inaccessible nodes but still descend
                 into their children (which may be accessible).
 
     Returns:
-        List of Node objects in the tree
+        List of Node objects in the tree, pre-order (parent before children,
+        children left-to-right) — identical ordering to the previous
+        recursive implementation.
     """
     if collected is None:
         collected = set()
 
-    if node.id in collected:
-        return []
+    result = []
+    # LIFO stack; push children reversed so they pop left-to-right, giving
+    # the same pre-order the recursive version produced.
+    stack = [node]
+    while stack:
+        current = stack.pop()
 
-    collected.add(node.id)
+        if current.id in collected:
+            continue
+        collected.add(current.id)
 
-    # Only include the node itself if it's accessible (or no user_id check)
-    if user_id and not can_user_access_node(node, user_id):
-        result = []
-    else:
-        result = [node]
+        # Include the node only if it's accessible (or no user_id check);
+        # descend into children regardless — they may be accessible.
+        if not (user_id and not can_user_access_node(current, user_id)):
+            result.append(current)
 
-    children = node.children
-    if filter_ai_usage:
-        children = [c for c in children if c.ai_usage in AI_ALLOWED]
-    if created_before:
-        children = [c for c in children if c.created_at < created_before]
+        children = current.children
+        if filter_ai_usage:
+            children = [c for c in children if c.ai_usage in AI_ALLOWED]
+        if created_before:
+            children = [c for c in children if c.created_at < created_before]
 
-    for child in children:
-        result.extend(_collect_all_nodes_in_tree(
-            child, filter_ai_usage, created_before, collected, user_id
-        ))
+        for child in reversed(children):
+            stack.append(child)
 
     return result
 

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -1110,12 +1110,11 @@ def maybe_trigger_incremental_profile_update(user):
 def check_pending_profile_updates():
     """Periodic task: check all eligible users for pending profile updates."""
     with flask_app.app_context():
-        # Exclude LLM bot accounts (created by create_llm_placeholder
-        # with twitter_id="llm-{model_id}") — no need for profiles.
-        users = User.query.filter(
-            User.plan.in_(list(User.VOICE_MODE_PLANS)),
-            ~User.twitter_id.like("llm-%"),
-        ).all()
+        # Voice-Mode users minus the llm-<model> placeholder accounts.
+        # Shared helper keeps NULL-twitter_id (email signup) users in —
+        # a bare NOT LIKE drops them (NULL NOT LIKE = NULL). See
+        # User.profile_eligible_query.
+        users = User.profile_eligible_query().all()
         for user in users:
             try:
                 maybe_trigger_incremental_profile_update(user)

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -860,6 +860,20 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         current_profile_id = profile.id
         current_cutoff = latest_ts
 
+        # After the first committed chunk, a from-scratch full regen is no
+        # longer needed: chunk 1 is the oldest data, so the chronological
+        # rebuild is anchored, and a later timeout can resume incrementally
+        # from this chunk instead of restarting from zero next heartbeat.
+        # (No-op for incremental updates, where the flag is already False.)
+        if chunk_num == 1 and user.profile_needs_full_regen:
+            user.profile_needs_full_regen = False
+            db.session.commit()
+            logger.info(
+                f"User {user.id}: cleared profile_needs_full_regen after "
+                f"first chunk (profile {profile.id}) — any later timeout "
+                f"resumes incrementally"
+            )
+
         logger.info(
             f"User {user.id}: chunk {chunk_num} done — "
             f"profile {profile.id}, {chunk_tokens_est} formatted tokens, "

--- a/backend/tasks/recent_context.py
+++ b/backend/tasks/recent_context.py
@@ -165,12 +165,11 @@ def _should_generate_recent_context(user):
 def check_pending_recent_context_updates():
     """Periodic task: check all eligible users for pending recent context updates."""
     with flask_app.app_context():
-        # Exclude LLM bot accounts (created by create_llm_placeholder
-        # with twitter_id="llm-{model_id}") — no need for profiles/summaries.
-        users = User.query.filter(
-            User.plan.in_(list(User.VOICE_MODE_PLANS)),
-            ~User.twitter_id.like("llm-%"),
-        ).all()
+        # Voice-Mode users minus the llm-<model> placeholder accounts.
+        # Shared helper keeps NULL-twitter_id (email signup) users in —
+        # a bare NOT LIKE drops them (NULL NOT LIKE = NULL). See
+        # User.profile_eligible_query.
+        users = User.profile_eligible_query().all()
         triggered = 0
         for user in users:
             try:

--- a/backend/tests/test_exports_incremental.py
+++ b/backend/tests/test_exports_incremental.py
@@ -942,3 +942,62 @@ class TestEngagedThreadsStrategy:
         assert "bob april public reply marker" in content
         assert "alice april reply marker" in content
         assert {bob_post.id, alice_post.id}.issubset(result["node_ids"])
+
+
+# ── 16. _collect_all_nodes_in_tree: deep chain (recursion regression) ────
+
+class TestCollectAllNodesDeepChain:
+    def test_deep_chain_does_not_overflow(self, app):
+        """A reply chain far deeper than Python's recursion limit must be
+        collected without RecursionError — the bug that crashed full
+        profile regen for the deepest-thread user before any LLM call."""
+        from backend.routes.export_data import _collect_all_nodes_in_tree
+
+        alice = _make_user("alice")
+        _db.session.commit()
+
+        depth = 1500  # comfortably past the default recursion limit (1000)
+        parent_id = None
+        for i in range(depth):
+            n = _make_node(
+                alice, parent_id=parent_id, content=f"link {i}",
+                ai_usage="chat", token_count=1,
+                created_at=DEC_15 + timedelta(seconds=i),
+            )
+            parent_id = n.id
+        _db.session.commit()
+
+        root = Node.query.filter_by(
+            user_id=alice.id, parent_id=None
+        ).first()
+        collected = _collect_all_nodes_in_tree(root, filter_ai_usage=True)
+        assert len(collected) == depth
+
+    def test_preorder_parent_before_descendants(self, app):
+        """Pre-order preserved: a parent precedes all its descendants, and
+        a child's whole subtree precedes the next sibling — same ordering
+        the recursive implementation produced."""
+        from backend.routes.export_data import _collect_all_nodes_in_tree
+
+        alice = _make_user("alice")
+        _db.session.commit()
+
+        root = _make_node(alice, content="root", ai_usage="chat",
+                          token_count=1, created_at=DEC_15)
+        a = _make_node(alice, parent_id=root.id, content="A",
+                       ai_usage="chat", token_count=1,
+                       created_at=DEC_15 + timedelta(hours=1))
+        b = _make_node(alice, parent_id=root.id, content="B",
+                       ai_usage="chat", token_count=1,
+                       created_at=DEC_15 + timedelta(hours=2))
+        a1 = _make_node(alice, parent_id=a.id, content="A1",
+                        ai_usage="chat", token_count=1,
+                        created_at=DEC_15 + timedelta(hours=3))
+        _db.session.commit()
+
+        order = [n.id for n in
+                 _collect_all_nodes_in_tree(root, filter_ai_usage=True)]
+        assert set(order) == {root.id, a.id, b.id, a1.id}
+        # root before A before A1; A's subtree (incl. A1) before sibling B
+        assert order.index(root.id) < order.index(a.id) < order.index(a1.id)
+        assert order.index(a1.id) < order.index(b.id)

--- a/backend/tests/test_profile_eligible_query.py
+++ b/backend/tests/test_profile_eligible_query.py
@@ -1,0 +1,87 @@
+"""Regression test for User.profile_eligible_query (the user-selection
+filter feeding the hourly profile / recent-context update tasks).
+
+Bug: ``~User.twitter_id.like("llm-%")`` was meant to exclude only the
+synthetic ``llm-<model>`` placeholder accounts, but in SQL
+``NULL NOT LIKE x`` evaluates to NULL (not TRUE), so it silently dropped
+every user whose ``twitter_id`` is NULL — i.e. all email / magic-link
+signups. Those users never received automatic profile updates.
+
+These tests pin the corrected behavior: NULL-twitter_id Voice-Mode users
+are included; ``llm-`` placeholders and free-plan users are excluded.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+# ── Environment (mirror the lightweight setup used by other model tests) ─
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+# models.py doesn't import celery, but a sibling test may have stubbed it.
+sys.modules.setdefault("celery", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+# If a sibling test left backend.models/extensions mocked, drop the stubs
+# so we import the real models.
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db  # noqa: E402
+from backend.models import User    # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _make_user(username, plan, twitter_id):
+    u = User(username=username, plan=plan, twitter_id=twitter_id,
+             approved=True)
+    db.session.add(u)
+    db.session.flush()
+    return u
+
+
+def test_null_twitter_id_voice_user_is_included(app):
+    """The core regression: an alpha user with no twitter_id (email
+    signup) must be eligible — this is exactly what was being dropped."""
+    email_user = _make_user("email_alpha", "alpha", None)
+    db.session.commit()
+
+    eligible = {u.id for u in User.profile_eligible_query().all()}
+    assert email_user.id in eligible
+
+
+def test_filter_includes_and_excludes_the_right_cohorts(app):
+    email_alpha = _make_user("email_alpha", "alpha", None)      # NULL -> in
+    email_pro = _make_user("email_pro", "pro", None)            # NULL -> in
+    twitter_alpha = _make_user("tw_alpha", "alpha", "12345")    # real -> in
+    llm_bot = _make_user("gpt-5", "alpha", "llm-gpt-5")         # bot  -> out
+    free_email = _make_user("free_email", "free", None)         # free -> out
+    db.session.commit()
+
+    eligible = {u.id for u in User.profile_eligible_query().all()}
+
+    assert email_alpha.id in eligible
+    assert email_pro.id in eligible
+    assert twitter_alpha.id in eligible
+    assert llm_bot.id not in eligible      # placeholder bots stay excluded
+    assert free_email.id not in eligible   # free plan is not Voice-Mode

--- a/backend/tests/test_profile_eligible_query.py
+++ b/backend/tests/test_profile_eligible_query.py
@@ -52,9 +52,10 @@ def app():
         db.drop_all()
 
 
-def _make_user(username, plan, twitter_id):
+def _make_user(username, plan, twitter_id, approved=True,
+               deactivated_at=None):
     u = User(username=username, plan=plan, twitter_id=twitter_id,
-             approved=True)
+             approved=approved, deactivated_at=deactivated_at)
     db.session.add(u)
     db.session.flush()
     return u
@@ -85,3 +86,26 @@ def test_filter_includes_and_excludes_the_right_cohorts(app):
     assert twitter_alpha.id in eligible
     assert llm_bot.id not in eligible      # placeholder bots stay excluded
     assert free_email.id not in eligible   # free plan is not Voice-Mode
+
+
+def test_deactivated_and_unapproved_users_are_excluded(app):
+    """Deactivated (approved=False, deactivated_at set) and never-approved
+    users must NOT receive background profile generation — otherwise
+    deactivating a user wouldn't stop LLM spend on their profile."""
+    from datetime import datetime
+
+    active = _make_user("active_alpha", "alpha", None, approved=True)
+    deactivated = _make_user(
+        "deactivated_alpha", "alpha", None,
+        approved=False, deactivated_at=datetime(2026, 6, 1, 0, 0, 0),
+    )
+    never_approved = _make_user(
+        "pending_alpha", "alpha", None, approved=False,
+    )
+    db.session.commit()
+
+    eligible = {u.id for u in User.profile_eligible_query().all()}
+
+    assert active.id in eligible
+    assert deactivated.id not in eligible     # the user-44 hold-off case
+    assert never_approved.id not in eligible

--- a/backend/tests/test_profile_regen_resume.py
+++ b/backend/tests/test_profile_regen_resume.py
@@ -1,0 +1,103 @@
+"""Regression test for fix 2b: a from-scratch full profile regen clears
+``profile_needs_full_regen`` after the FIRST committed chunk.
+
+Why it matters: full regen rebuilds the profile in chronological ~90k-token
+chunks, each committed independently. If the run later times out, the flag
+must already be off so the next heartbeat resumes *incrementally* from the
+last saved chunk instead of restarting the whole rebuild from zero (the
+behavior that made user 44 burn cost forever without finishing).
+
+Patterned after the other task tests: in-memory SQLite, ENCRYPTION_DISABLED,
+celery mocked so the module imports. Only ``@celery.task`` entry points
+become mocks — the plain helper ``_chunked_profile_loop`` under test stays
+real, with its LLM / export calls monkeypatched.
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db          # noqa: E402
+from backend.models import User, UserProfile      # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    # _save_profile -> calculate_llm_cost_microdollars reads this; empty
+    # dict makes the unknown model cost 0 without a KeyError.
+    app.config["SUPPORTED_MODELS"] = {}
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+
+def test_full_regen_clears_flag_after_first_chunk(app, monkeypatch):
+    # Importing here (inside the app context) keeps the celery-mock + create_app
+    # side effects scoped, matching the other task tests.
+    import backend.tasks.exports as exports
+
+    user = User(username="deep_user", plan="alpha", twitter_id=None,
+                approved=True, profile_needs_full_regen=True)
+    _db.session.add(user)
+    _db.session.commit()
+
+    # One chunk of source data, then the export is exhausted. The user has
+    # no nodes, so the loop's has_more check also stops it after chunk 1.
+    chunk = {
+        "content": "the user's oldest writing",
+        "token_count": 90000,
+        "latest_node_created_at": datetime(2025, 2, 11, 10, 26, 14),
+    }
+    monkeypatch.setattr(exports, "build_user_export_content",
+                        MagicMock(side_effect=[chunk, None]))
+    monkeypatch.setattr(exports, "_call_llm_with_retries",
+                        MagicMock(return_value={
+                            "content": "PROFILE v1",
+                            "input_tokens": 1000,
+                            "output_tokens": 500,
+                            "total_tokens": 1500,
+                        }))
+
+    fake_task = MagicMock()  # supplies .update_state(...)
+
+    profile_id, chunk_num, _ = exports._chunked_profile_loop(
+        fake_task, user, "gpt-5.5", update_template="{new_data}",
+        api_keys={},
+        first_chunk_prompt_fn=lambda c: "GEN PROMPT",
+        initial_profile_content=None,
+        generation_type="iterative",
+    )
+
+    # The whole point of fix 2b: flag is off after the first committed chunk.
+    assert user.profile_needs_full_regen is False
+    # And that first chunk really was persisted (so a resume has an anchor).
+    assert chunk_num == 1
+    saved = UserProfile.query.get(profile_id)
+    assert saved is not None
+    assert saved.generation_type == "iterative"


### PR DESCRIPTION
## Why

Investigating a report that **user 50's profile hadn't auto-updated in a long time** uncovered a chain of bugs in the automatic profile-update pipeline. None were in the trigger thresholds, the concurrency guard, or celery-beat — those are healthy. The bugs were in *who* gets considered and *what happens* when generation runs on large/deep data.

This PR is **four focused correctness fixes**. It does **not** include the cost work (Batch API / prompt caching) — that's tracked separately in #173 and is best built on top of these fixes (see "Follow-ups").

## The fixes

### 1. Include NULL-`twitter_id` users in the eligibility query (the user-50 bug)
The hourly `check_pending_profile_updates` / `check_pending_recent_context_updates` selected users with `~User.twitter_id.like("llm-%")`, meant to skip the synthetic `llm-<model>` placeholder bots. But in SQL **`NULL NOT LIKE x` is `NULL`, not `TRUE`**, so every user with a NULL `twitter_id` (email / magic-link signups) was silently dropped.

Prod impact at time of diagnosis: of 37 real Voice-Mode users, **only 18 were ever eligible — 19 were silently starved**, user 50 among them. Extracted the selection into a single shared helper `User.profile_eligible_query()` (so the two tasks can't drift) and kept NULL-`twitter_id` users via `or_(twitter_id.is_(None), ~twitter_id.like("llm-%"))`.

### 2. Skip deactivated / unapproved users in eligibility
`profile_eligible_query()` now also requires `approved == True`. `approved` is the access gate (`backend/__init__.py:68`, `terms.py:23`) and admin deactivation flips it to `False`. Without this, deactivating a user blocks their login but **not** their background profile generation — so it doubles as a "pause this user's LLM spend" switch.

> ⚠️ **Pre-merge sanity check (prod):** confirm no *active* Voice-Mode user sits at `approved=False` (there shouldn't be — unapproved = no access). If that's a concern, the narrower gate is `deactivated_at.is_(None)`.

### 3. Make `_collect_all_nodes_in_tree` iterative (recursion-overflow crash)
The export tree-collector recursed on `node.children` — one Python stack frame per thread-depth level (plus the frames SQLAlchemy burns lazy-loading children each level). A user with a deep enough reply chain overflowed the ~1000-frame recursion limit, raising `RecursionError` inside `build_user_export_content` and **crashing full profile regeneration before any LLM call** — every hour, in a loop (observed on the highest-volume user). Rewritten as an iterative pre-order traversal with an explicit stack (depth bounded by heap), keeping the `collected` cycle-guard and identical output ordering.

### 4. Clear `profile_needs_full_regen` after the first committed chunk (resumable regen)
Full regen rebuilds in chronological ~90k-token chunks, each committed independently. The flag previously cleared only on full success, so a mid-run timeout left it set — and since initial generation always restarts from `cutoff=None`, the next heartbeat redid the whole rebuild from scratch, never finishing. Now the flag clears right after the first committed chunk (chunk 1 = oldest data, so the chronological foundation is anchored); a later timeout resumes incrementally from the last saved chunk via the SQL-CTE path. No-op for incremental updates. **`profile_needs_full_regen` itself is unchanged as a feature** — it's still how an import of pre-Loore-dated data forces a time-consistent rebuild.

## Testing
- New/updated tests: `test_profile_eligible_query.py` (NULL-twitter included; deactivated/unapproved/free/bot excluded), `test_exports_incremental.py` (1500-deep chain doesn't overflow; pre-order preserved), `test_profile_regen_resume.py` (flag cleared after first chunk; chunk persisted).
- Full backend suite: **355 passed**. flake8 E9/F-codes: clean.

## Follow-ups (not in this PR)
- **#173 (cost)** — Batch API for profile gen + prompt caching for Voice/Text. The right next PR, built on these fixes. Note: our regen chunks are *sequential* (chunk N's prompt embeds chunk N-1's output), so a single user's catch-up can't be parallel-batched — the batchable unit is one call per user across the hourly cohort (great for single-pass; iterative catch-ups stay sync). I'll capture that design note on the issue.
- **User 44** — deepest-thread user, inactive for months. Fix 3 unblocks his regen, but it'd cost ~$40–50 for a profile nobody may see. Plan: deactivate (fix 2 then prevents the spend), ping on Twitter, only spend if he confirms a return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
