### PR TITLE
feat(#85): Anthropic API spend monitoring with threshold alerts

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -51,6 +51,11 @@ celery.conf.update(
             'task': 'backend.tasks.profile_batch.poll_profile_batches',
             'schedule': 60.0,  # ~1 min — batches typically finish in 1-5 min
         },
+        # No-op unless ANTHROPIC_SPEND_LIMIT_USD is set (issue #85).
+        'check-api-spend': {
+            'task': 'backend.tasks.spend_monitor.check_api_spend',
+            'schedule': 3600.0,  # hourly
+        },
     },
 )
 
@@ -73,3 +78,4 @@ from backend.tasks import voice_todo_merge  # noqa: F401
 from backend.tasks import recent_context  # noqa: F401
 from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
+from backend.tasks import spend_monitor  # noqa: F401

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,6 +24,18 @@ class Config:
     # Default model (for backward compatibility and fallback)
     DEFAULT_LLM_MODEL = os.environ.get("LLM_NAME", "claude-opus-4.6")
 
+    # --- API spend monitoring (issue #85) ---
+    # Monthly Anthropic spend cap in USD. 0 (default) disables the check.
+    ANTHROPIC_SPEND_LIMIT_USD = float(
+        os.environ.get("ANTHROPIC_SPEND_LIMIT_USD", "0") or "0"
+    )
+    # Comma-separated fractions of the limit at which to alert.
+    SPEND_ALERT_THRESHOLDS = os.environ.get(
+        "SPEND_ALERT_THRESHOLDS", "0.5,0.8,0.95"
+    )
+    # Recipient for spend alerts (admin inbox also used for signup notices).
+    SPEND_ALERT_EMAIL = os.environ.get("SPEND_ALERT_EMAIL", "signup@loore.org")
+
     # --- Profile-generation batch processing (issue #173, Part A) ---
     # A user takes the Batch API path if the global switch is on OR their id
     # is in the canary allowlist. Both default off → batch ships dark.

--- a/backend/models.py
+++ b/backend/models.py
@@ -647,6 +647,27 @@ class APICostLog(db.Model):
     user = db.relationship("User", backref="api_cost_logs")
 
 
+class SpendAlert(db.Model):
+    """Dedupe record for API spend-limit alerts (issue #85).
+
+    One row per (provider, month, threshold) that has already been
+    alerted, so the hourly check never re-sends the same alert within
+    a calendar month.
+    """
+    __tablename__ = "spend_alert"
+    id = db.Column(db.Integer, primary_key=True)
+    provider = db.Column(db.String(32), nullable=False)
+    month = db.Column(db.String(7), nullable=False)  # "YYYY-MM" (UTC)
+    threshold = db.Column(db.Float, nullable=False)  # fraction of limit, e.g. 0.8
+    spend_usd = db.Column(db.Float, nullable=False)  # spend at alert time
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint("provider", "month", "threshold",
+                            name="uq_spend_alert_provider_month_threshold"),
+    )
+
+
 class TTSChunk(db.Model):
     """
     Stores individual TTS audio chunk URLs for streaming TTS playback.

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -182,3 +182,46 @@ def activate_and_welcome(user_id):
         "approved": True,
         "email_sent": True,
     }), 200
+
+
+@admin_bp.route("/spend", methods=["GET"])
+@login_required
+@admin_required
+def spend_status():
+    """Month-to-date API spend + limit status (issue #85)."""
+    from backend.models import SpendAlert
+    from backend.utils.spend import (
+        get_month_spend_microdollars, parse_thresholds,
+    )
+
+    config = current_app.config
+    now = datetime.utcnow()
+    month = now.strftime("%Y-%m")
+
+    total = get_month_spend_microdollars(config, now=now)
+    anthropic = get_month_spend_microdollars(config, provider="anthropic", now=now)
+    openai = get_month_spend_microdollars(config, provider="openai", now=now)
+
+    limit_usd = config.get("ANTHROPIC_SPEND_LIMIT_USD") or 0
+    alerts = SpendAlert.query.filter_by(month=month).order_by(
+        SpendAlert.threshold).all()
+
+    return jsonify({
+        "month": month,
+        "total_usd": total / 1_000_000,
+        "anthropic_usd": anthropic / 1_000_000,
+        "openai_usd": openai / 1_000_000,
+        "limit_usd": limit_usd,
+        "limit_fraction_used": (
+            (anthropic / 1_000_000) / limit_usd if limit_usd > 0 else None
+        ),
+        "thresholds": parse_thresholds(config.get("SPEND_ALERT_THRESHOLDS")),
+        "alerts_fired": [
+            {
+                "threshold": a.threshold,
+                "spend_usd": a.spend_usd,
+                "at": iso_utc(a.created_at),
+            }
+            for a in alerts
+        ],
+    }), 200

--- a/backend/tasks/spend_monitor.py
+++ b/backend/tasks/spend_monitor.py
@@ -1,0 +1,22 @@
+"""Hourly Celery beat task for API spend monitoring (issue #85).
+
+Thin wrapper — the testable logic lives in backend/utils/spend.py.
+Disabled unless ANTHROPIC_SPEND_LIMIT_USD is set to a positive value.
+"""
+from celery.utils.log import get_task_logger
+
+from backend.celery_app import celery, flask_app
+from backend.utils.spend import check_and_alert
+
+logger = get_task_logger(__name__)
+
+
+@celery.task(name='backend.tasks.spend_monitor.check_api_spend')
+def check_api_spend():
+    with flask_app.app_context():
+        result = check_and_alert(flask_app.config)
+        if result.get("fired"):
+            logger.warning("Spend alert(s) fired: %s", result)
+        else:
+            logger.info("Spend check: %s", result)
+        return result

--- a/backend/tests/test_spend_monitor.py
+++ b/backend/tests/test_spend_monitor.py
@@ -1,0 +1,186 @@
+"""Tests for API spend monitoring (issue #85).
+
+Covers month-to-date aggregation with provider attribution, threshold
+parsing, alert firing + per-month dedupe, email-failure retry semantics,
+and the disabled-by-default behavior.
+
+Patterned after test_tts_invalidation.py: sqlite in-memory, minimal
+Flask app, no celery import (logic lives in backend/utils/spend.py).
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, APICostLog, SpendAlert  # noqa: E402
+from backend.utils.spend import (  # noqa: E402
+    check_and_alert, get_month_spend_microdollars, parse_thresholds,
+)
+
+SUPPORTED_MODELS = {
+    "claude-opus-4.6": {"provider": "anthropic"},
+    "gpt-5.5": {"provider": "openai"},
+}
+
+
+def _base_config(limit=100.0, thresholds="0.5,0.8,0.95"):
+    return {
+        "SUPPORTED_MODELS": SUPPORTED_MODELS,
+        "ANTHROPIC_SPEND_LIMIT_USD": limit,
+        "SPEND_ALERT_THRESHOLDS": thresholds,
+        "SPEND_ALERT_EMAIL": "alerts@example.com",
+    }
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _log_cost(user_id, model_id, usd, created_at=None):
+    row = APICostLog(
+        user_id=user_id,
+        model_id=model_id,
+        request_type="llm",
+        cost_microdollars=int(usd * 1_000_000),
+    )
+    if created_at is not None:
+        row.created_at = created_at
+    _db.session.add(row)
+    _db.session.commit()
+    return row
+
+
+NOW = datetime(2026, 6, 10, 3, 0, 0)
+
+
+def test_parse_thresholds():
+    assert parse_thresholds("0.5,0.8,0.95") == [0.5, 0.8, 0.95]
+    assert parse_thresholds(" 0.8 , bogus, 1.5, 0.5 ") == [0.5, 0.8]
+    assert parse_thresholds("") == []
+    assert parse_thresholds(None) == []
+
+
+def test_month_spend_provider_attribution(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 10.0, NOW)
+        _log_cost(user_id, "claude-fable-5", 5.0, NOW)  # prefix fallback
+        _log_cost(user_id, "gpt-5.5", 3.0, NOW)
+        _log_cost(user_id, "gpt-4o-transcribe", 1.0, NOW)
+        # Previous month — excluded.
+        _log_cost(user_id, "claude-opus-4.6", 99.0, datetime(2026, 5, 31))
+
+        config = _base_config()
+        total = get_month_spend_microdollars(config, now=NOW)
+        anthropic = get_month_spend_microdollars(
+            config, provider="anthropic", now=NOW)
+        openai = get_month_spend_microdollars(
+            config, provider="openai", now=NOW)
+
+        assert total == 19_000_000
+        assert anthropic == 15_000_000
+        assert openai == 4_000_000
+
+
+def test_disabled_when_no_limit(app):
+    with app.app_context():
+        result = check_and_alert(_base_config(limit=0), now=NOW)
+        assert result == {"status": "disabled"}
+
+
+def test_alerts_fire_once_per_month(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 85.0, NOW)  # 85% of $100
+
+        sent = []
+
+        def fake_send(**kwargs):
+            sent.append(kwargs)
+
+        config = _base_config()
+        result = check_and_alert(config, now=NOW, send_email=fake_send)
+        # 0.5 and 0.8 crossed; 0.95 not.
+        assert result["fired"] == [0.5, 0.8]
+        assert len(sent) == 2
+        assert sent[0]["to_email"] == "alerts@example.com"
+        assert sent[0]["limit_usd"] == 100.0
+
+        # Second run: nothing new fires.
+        result2 = check_and_alert(config, now=NOW, send_email=fake_send)
+        assert result2["fired"] == []
+        assert len(sent) == 2
+
+        # Spend grows past 95% → only the new threshold fires.
+        _log_cost(user_id, "claude-opus-4.6", 11.0, NOW)
+        result3 = check_and_alert(config, now=NOW, send_email=fake_send)
+        assert result3["fired"] == [0.95]
+        assert len(sent) == 3
+
+        assert SpendAlert.query.count() == 3
+
+
+def test_openai_spend_does_not_trigger_anthropic_alerts(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "gpt-5.5", 95.0, NOW)
+
+        sent = []
+        result = check_and_alert(
+            _base_config(), now=NOW,
+            send_email=lambda **kw: sent.append(kw))
+        assert result["fired"] == []
+        assert sent == []
+
+
+def test_email_failure_retries_next_run(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 60.0, NOW)
+
+        def broken_send(**kwargs):
+            raise RuntimeError("smtp down")
+
+        config = _base_config()
+        result = check_and_alert(config, now=NOW, send_email=broken_send)
+        assert result["fired"] == []
+        assert SpendAlert.query.count() == 0
+
+        # SMTP recovers → alert goes out on the next run.
+        sent = []
+        result2 = check_and_alert(
+            config, now=NOW, send_email=lambda **kw: sent.append(kw))
+        assert result2["fired"] == [0.5]
+        assert len(sent) == 1

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -147,6 +147,77 @@ def send_welcome_email(to_email, magic_link_url):
         raise
 
 
+def send_spend_alert_email(to_email, provider, spend_usd, limit_usd, threshold):
+    """Alert the admin that month-to-date API spend crossed a threshold
+    of the configured limit (issue #85)."""
+    config = current_app.config
+    sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")
+    percent = int(round(threshold * 100))
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = (
+        f"Loore spend alert: {provider} at {percent}% of monthly limit"
+    )
+    msg["From"] = sender
+    msg["To"] = to_email
+
+    text_body = (
+        f"API spend alert\n\n"
+        f"Provider: {provider}\n"
+        f"Month-to-date spend: ${spend_usd:,.2f}\n"
+        f"Monthly limit: ${limit_usd:,.2f}\n"
+        f"Threshold crossed: {percent}%\n\n"
+        f"Review usage in the admin dashboard: https://loore.org/admin\n"
+    )
+
+    html_body = f"""\
+<html>
+<body style="font-family: 'Outfit', -apple-system, sans-serif; background: #0e0d0b; color: #ede8dd; padding: 40px 20px; margin: 0;">
+  <div style="max-width: 460px; margin: 0 auto; background: #181714; border-radius: 10px; border: 1px solid #302c27; padding: 48px 40px;">
+    <div style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-size: 14px; font-weight: 300; text-transform: uppercase; letter-spacing: 0.3em; color: #736b5f; margin-bottom: 32px;">
+      Loore
+    </div>
+    <h2 style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-weight: 300; font-size: 28px; color: #ede8dd; margin: 0 0 12px 0;">
+      Spend alert: {percent}%
+    </h2>
+    <p style="font-size: 15px; font-weight: 300; color: #a89f91; margin: 0 0 8px 0; line-height: 1.6;">
+      <strong style="color: #ede8dd;">{provider}</strong> month-to-date spend is
+      <strong style="color: #c4956a;">${spend_usd:,.2f}</strong>
+      of the <strong style="color: #ede8dd;">${limit_usd:,.2f}</strong> monthly limit.
+    </p>
+    <a href="https://loore.org/admin"
+       style="display: inline-block; margin-top: 20px; padding: 12px 32px; background: transparent; color: #c4956a;
+              text-decoration: none; border-radius: 6px; border: 1px solid #c4956a;
+              font-family: 'Outfit', -apple-system, sans-serif; font-size: 14px; font-weight: 400;
+              letter-spacing: 0.04em;">
+      Open admin dashboard
+    </a>
+  </div>
+</body>
+</html>"""
+
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    server = config.get("MAIL_SERVER", "localhost")
+    port = config.get("MAIL_PORT", 587)
+    use_tls = config.get("MAIL_USE_TLS", True)
+    username = config.get("MAIL_USERNAME")
+    password = config.get("MAIL_PASSWORD")
+
+    try:
+        with smtplib.SMTP(server, port) as smtp:
+            if use_tls:
+                smtp.starttls()
+            if username and password:
+                smtp.login(username, password)
+            smtp.sendmail(sender, to_email, msg.as_string())
+        logger.info(f"Spend alert email sent to {to_email} ({percent}%)")
+    except Exception:
+        logger.exception(f"Failed to send spend alert email to {to_email}")
+        raise
+
+
 def send_admin_signup_notification(username, user_email):
     config = current_app.config
     sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")

--- a/backend/utils/spend.py
+++ b/backend/utils/spend.py
@@ -1,0 +1,124 @@
+"""Month-to-date API spend aggregation + spend-limit alerting (issue #85).
+
+Core logic lives here (plain functions, app context assumed active) so it
+is unit-testable without importing the Celery app. The hourly beat task in
+backend/tasks/spend_monitor.py is a thin wrapper around check_and_alert().
+
+Spend source of truth is APICostLog (cost_microdollars), which every
+LLM/transcription/TTS task already writes. Provider attribution derives
+from SUPPORTED_MODELS config with a "claude*" prefix fallback so rows for
+models that have since been removed from config still count correctly.
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import func, or_
+
+from backend.extensions import db
+from backend.models import APICostLog, SpendAlert
+
+logger = logging.getLogger(__name__)
+
+
+def month_start(now=None):
+    now = now or datetime.utcnow()
+    return datetime(now.year, now.month, 1)
+
+
+def _anthropic_filter(config):
+    ids = {
+        model_id
+        for model_id, cfg in (config.get("SUPPORTED_MODELS") or {}).items()
+        if cfg.get("provider") == "anthropic"
+    }
+    return or_(APICostLog.model_id.in_(ids),
+               APICostLog.model_id.like("claude%"))
+
+
+def get_month_spend_microdollars(config, provider=None, now=None):
+    """Month-to-date spend in microdollars, optionally filtered by provider
+    ("anthropic" / "openai")."""
+    q = db.session.query(
+        func.coalesce(func.sum(APICostLog.cost_microdollars), 0)
+    ).filter(APICostLog.created_at >= month_start(now))
+    if provider == "anthropic":
+        q = q.filter(_anthropic_filter(config))
+    elif provider == "openai":
+        q = q.filter(~_anthropic_filter(config))
+    return int(q.scalar() or 0)
+
+
+def parse_thresholds(raw):
+    """Parse "0.5,0.8,0.95" into a sorted list of floats in (0, 1]."""
+    thresholds = []
+    for part in (raw or "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            value = float(part)
+        except ValueError:
+            logger.warning("Ignoring invalid spend threshold %r", part)
+            continue
+        if 0 < value <= 1:
+            thresholds.append(value)
+    return sorted(set(thresholds))
+
+
+def check_and_alert(config, now=None, send_email=None):
+    """Compare month-to-date Anthropic spend against the configured limit
+    and alert once per (month, threshold) crossed.
+
+    Returns a dict summary (also useful as the Celery task result).
+    `send_email` is injectable for tests; defaults to the real sender.
+    """
+    limit_usd = config.get("ANTHROPIC_SPEND_LIMIT_USD") or 0
+    if limit_usd <= 0:
+        return {"status": "disabled"}
+
+    if send_email is None:
+        from backend.utils.email import send_spend_alert_email
+        send_email = send_spend_alert_email
+
+    now = now or datetime.utcnow()
+    month = now.strftime("%Y-%m")
+    spend_usd = get_month_spend_microdollars(
+        config, provider="anthropic", now=now) / 1_000_000
+    thresholds = parse_thresholds(config.get("SPEND_ALERT_THRESHOLDS"))
+
+    fired = []
+    for threshold in thresholds:
+        if spend_usd < limit_usd * threshold:
+            continue
+        already = SpendAlert.query.filter_by(
+            provider="anthropic", month=month, threshold=threshold
+        ).first()
+        if already:
+            continue
+        try:
+            send_email(
+                to_email=config.get("SPEND_ALERT_EMAIL"),
+                provider="anthropic",
+                spend_usd=spend_usd,
+                limit_usd=limit_usd,
+                threshold=threshold,
+            )
+        except Exception:
+            # Don't record the alert as sent — retry next run.
+            logger.exception(
+                "Failed to send spend alert (threshold %.2f)", threshold)
+            continue
+        db.session.add(SpendAlert(
+            provider="anthropic", month=month,
+            threshold=threshold, spend_usd=spend_usd,
+        ))
+        db.session.commit()
+        fired.append(threshold)
+
+    return {
+        "status": "ok",
+        "month": month,
+        "spend_usd": round(spend_usd, 4),
+        "limit_usd": limit_usd,
+        "fired": fired,
+    }


### PR DESCRIPTION
## Summary
Closes #85. Month-to-date spend (from APICostLog) is checked hourly by a celery-beat task against `ANTHROPIC_SPEND_LIMIT_USD`; alert emails fire at configurable thresholds (default 50/80/95%), deduped per calendar month via the new `SpendAlert` table. `GET /api/admin/spend` shows month-to-date totals per provider, limit fraction, and fired alerts.

**Ships dark** — limit defaults to 0 (disabled). To activate, set on prod:
- `ANTHROPIC_SPEND_LIMIT_USD` (e.g. `200`)
- `SPEND_ALERT_THRESHOLDS` (default `0.5,0.8,0.95`)
- `SPEND_ALERT_EMAIL` (default signup@loore.org)

## Notes
- Provider attribution: SUPPORTED_MODELS config + `claude*` prefix fallback for removed models.
- Email failure → alert not recorded → retried next hour.
- New SpendAlert model auto-migrates on deploy (no manual migration).

## Tests
6 new tests (aggregation/attribution, threshold parsing, once-per-month dedupe, email-failure retry, disabled default). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)