### PR TITLE
feat: Sentry error monitoring + /health and /ready endpoints

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,9 @@ jobs:
         env:
           REACT_APP_BACKEND_URL: https://loore.org
           REACT_APP_API_URL: https://loore.org/api
+          # Baked into the prod bundle so @sentry/react initializes. Public by
+          # design (ships in the browser); empty secret → Sentry stays dark.
+          REACT_APP_SENTRY_DSN: ${{ secrets.REACT_APP_SENTRY_DSN }}
         run: npm run build
 
       - name: Upload build artifact

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -26,6 +26,17 @@ from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 def create_app():
+    # Error monitoring (roadmap Phase 0). No-op unless SENTRY_DSN is set.
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+    if sentry_dsn:
+        import sentry_sdk
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+            send_default_pii=False,   # never attach user content/PII
+            traces_sample_rate=0.0,   # errors only, no perf tracing
+        )
+
     app = Flask(__name__)
     app.config.from_object(Config)
 
@@ -172,6 +183,15 @@ def create_app():
                 "alpha. It resets at the start of next month."
             ),
         }), 402
+
+    # --------------------------------------------------------------------
+    # Health checks – liveness/readiness for monitoring (no auth).
+    # --------------------------------------------------------------------
+    from backend.routes.health import health_bp
+    app.register_blueprint(health_bp)
+    # Also under /api so the checks are reachable through the public
+    # nginx proxy (which only forwards /api, /auth, /media to Flask).
+    app.register_blueprint(health_bp, url_prefix="/api", name="health_api_bp")
 
     # Register CLI commands
     from backend.init_db import (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ redis==5.0.1
 ffmpeg-python==0.2.0
 google-cloud-kms>=2.0.0
 cryptography>=41.0.0
+sentry-sdk[flask]>=2.0.0

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,0 +1,58 @@
+"""Liveness and readiness endpoints (roadmap Phase 0).
+
+/health — liveness: the process is up and serving requests. Always 200.
+/ready  — readiness: critical dependencies reachable. 200 when DB and
+          Redis both respond, 503 otherwise (load balancers / monitors
+          should route away on 503).
+
+Unauthenticated by design — they expose only component up/down booleans.
+"""
+import logging
+
+from flask import Blueprint, current_app, jsonify
+from sqlalchemy import text
+
+from backend.extensions import db
+
+logger = logging.getLogger(__name__)
+
+health_bp = Blueprint("health_bp", __name__)
+
+
+def _check_db():
+    try:
+        db.session.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        logger.exception("Readiness check: database unreachable")
+        return False
+
+
+def _check_redis():
+    try:
+        import redis
+        url = current_app.config.get(
+            "CELERY_BROKER_URL", "redis://localhost:6379/0")
+        client = redis.Redis.from_url(
+            url, socket_connect_timeout=2, socket_timeout=2)
+        return bool(client.ping())
+    except Exception:
+        logger.exception("Readiness check: redis unreachable")
+        return False
+
+
+@health_bp.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok"}), 200
+
+
+@health_bp.route("/ready", methods=["GET"])
+def ready():
+    db_ok = _check_db()
+    redis_ok = _check_redis()
+    ready_ok = db_ok and redis_ok
+    return jsonify({
+        "status": "ready" if ready_ok else "not_ready",
+        "database": db_ok,
+        "redis": redis_ok,
+    }), (200 if ready_ok else 503)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,80 @@
+"""Tests for /health and /ready endpoints (roadmap Phase 0).
+
+Minimal Flask app + sqlite in-memory; redis reachability is monkeypatched
+(no real Redis in the test environment).
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+import backend.routes.health as health_module  # noqa: E402
+from backend.routes.health import health_bp  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    app.register_blueprint(health_bp)
+    app.register_blueprint(health_bp, url_prefix="/api", name="health_api_bp")
+    with app.app_context():
+        _db.create_all()
+        yield app.test_client()
+
+
+def test_health_always_ok(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_health_under_api_prefix(client):
+    assert client.get("/api/health").status_code == 200
+
+
+def test_ready_ok_when_deps_up(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: True)
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ready"
+    assert body["database"] is True
+    assert body["redis"] is True
+
+
+def test_ready_503_when_redis_down(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: False)
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    body = resp.get_json()
+    assert body["status"] == "not_ready"
+    assert body["redis"] is False
+
+
+def test_ready_503_when_db_down(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: True)
+    monkeypatch.setattr(health_module, "_check_db", lambda: False)
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.get_json()["database"] is False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.57.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -3206,6 +3207,97 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
+      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
+      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
+      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
+      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
+      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry-internal/feedback": "10.57.0",
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry-internal/replay-canvas": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
+      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "proxy": "http://localhost:5010",
   "dependencies": {
+    "@sentry/react": "^10.57.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,11 +1,21 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import * as Sentry from "@sentry/react";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import { UserProvider } from "./contexts/UserContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
+
+// Error monitoring — no-op unless REACT_APP_SENTRY_DSN is set at build time.
+if (process.env.REACT_APP_SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.REACT_APP_SENTRY_DSN,
+    environment: process.env.REACT_APP_SENTRY_ENVIRONMENT || "production",
+    sendDefaultPii: false,
+  });
+}
 
 const container = document.getElementById("root");
 const root = createRoot(container);


### PR DESCRIPTION
## Summary
Roadmap Phase 0 (A.2) — alpha-expansion blocker.

- **Sentry backend**: `sentry_sdk` init in `create_app` gated on `SENTRY_DSN` env (errors only, `send_default_pii=False`, no tracing). Covers Flask and Celery via the shared app factory.
- **Sentry frontend**: `@sentry/react` init gated on `REACT_APP_SENTRY_DSN` (build-time).
- **Health checks**: `/health` (liveness, always 200) and `/ready` (DB + Redis, 503 when either is down). Registered at both `/` (direct gunicorn checks) and `/api/*` (through the public nginx proxy).

**Ships dark** — both DSNs unset means no-op. To activate, create a Sentry project and set `SENTRY_DSN` (backend env) + `REACT_APP_SENTRY_DSN` (CI build env).

## Tests
5 new tests (liveness, /api prefix, ready-ok, 503 on redis/db down). Full suite green; frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)