### PR TITLE
feat(#189): OpenAI prompt_cache_key + cached-input cost accounting

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -92,6 +92,8 @@ class Config:
             "context_window": 1050000,
             "input_price_per_mtok": 5.00,
             "output_price_per_mtok": 30.00,
+            # OpenAI auto-cache discount (#189): GPT-5.5 caches at 75% off
+            "cached_input_multiplier": 0.25,
             "long_context_threshold": 272000,
             "long_context_input_multiplier": 2.0,
             "long_context_output_multiplier": 1.5,

--- a/backend/llm_providers.py
+++ b/backend/llm_providers.py
@@ -35,7 +35,8 @@ class LLMProvider:
 
     @staticmethod
     def get_completion(model_id: str, messages: list, api_keys: dict,
-                       max_tokens: int = None, tools: list = None) -> dict:
+                       max_tokens: int = None, tools: list = None,
+                       prompt_cache_key: str = None) -> dict:
         """
         Generate a completion using the specified model.
 
@@ -71,7 +72,7 @@ class LLMProvider:
         if provider == "openai":
             return LLMProvider._call_openai(
                 api_model, messages, api_keys["openai"], max_tokens,
-                tools=tools)
+                tools=tools, prompt_cache_key=prompt_cache_key)
         elif provider == "anthropic":
             return LLMProvider._call_anthropic(
                 api_model, messages, api_keys["anthropic"], max_tokens,
@@ -81,7 +82,8 @@ class LLMProvider:
 
     @staticmethod
     def _call_openai(model: str, messages: list, api_key: str,
-                     max_tokens: int = None, tools: list = None) -> dict:
+                     max_tokens: int = None, tools: list = None,
+                     prompt_cache_key: str = None) -> dict:
         """
         Call OpenAI API with the given model and messages.
 
@@ -102,6 +104,10 @@ class LLMProvider:
             temperature=1,
             max_completion_tokens=max_tokens or DEFAULT_MAX_OUTPUT_TOKENS,
         )
+        # #189: a stable per-conversation key improves OpenAI's automatic
+        # prefix-cache routing (best-effort; no behavior change otherwise).
+        if prompt_cache_key:
+            kwargs["prompt_cache_key"] = prompt_cache_key
 
         # Convert Anthropic-format tools to OpenAI format
         if tools:
@@ -148,11 +154,22 @@ class LLMProvider:
         if truncated:
             logger.warning(f"OpenAI response truncated (max_tokens reached): model={model}, output_tokens={response.usage.completion_tokens}")
 
+        # #189: OpenAI auto-caches >=1024-token prefixes; cached_tokens is
+        # the cached SUBSET of prompt_tokens (unlike Anthropic's disjoint
+        # counters) and is billed at a discount we must account for.
+        details = getattr(response.usage, "prompt_tokens_details", None)
+        cached_tokens = getattr(details, "cached_tokens", 0) or 0
+        if cached_tokens:
+            logger.info(
+                f"OpenAI prompt cache: cached={cached_tokens} of "
+                f"{response.usage.prompt_tokens} prompt tokens")
+
         return {
             "content": message.content or "",
             "total_tokens": response.usage.total_tokens,
             "input_tokens": response.usage.prompt_tokens,
             "output_tokens": response.usage.completion_tokens,
+            "cached_tokens": cached_tokens,
             "tool_calls": tool_calls,
             "truncated": truncated,
         }

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -54,27 +54,32 @@ def list_users():
         APICostLog.user_id).all()
     month_map = {row.user_id: row.month_microdollars for row in month_rows}
 
-    # Prompt-cache read/write totals per user (#187). Hit-rate = reads /
-    # (reads + writes): reads are the stable prefix served from cache, writes
-    # are the misses that populated it (first turn / after the 5-min TTL).
-    # Non-cached calls contribute 0. NULLs (pre-#187 rows) are ignored by SUM.
+    # Prompt-cache hit-rate per user, over conversation turns (#187/#189).
+    # Unified across providers: cache_read_tokens holds the input SERVED from
+    # cache — Anthropic cache reads AND OpenAI cached_tokens — and input_tokens
+    # is the full prompt size, so hit-rate = served / total prompt input works
+    # for both (OpenAI has no separate "write" concept). Scoped to
+    # request_type='conversation' so embeddings/transcription/profile/warm
+    # don't dilute the denominator. NULLs are ignored by SUM.
     cache_rows = db.session.query(
         APICostLog.user_id,
-        func.sum(APICostLog.cache_read_tokens).label("reads"),
-        func.sum(APICostLog.cache_write_tokens).label("writes"),
+        func.sum(APICostLog.cache_read_tokens).label("served"),
+        func.sum(APICostLog.input_tokens).label("prompt_input"),
+    ).filter(
+        APICostLog.request_type == "conversation"
     ).group_by(APICostLog.user_id).all()
     cache_map = {
-        row.user_id: (row.reads or 0, row.writes or 0) for row in cache_rows
+        row.user_id: (row.served or 0, row.prompt_input or 0)
+        for row in cache_rows
     }
 
     user_list = []
     for user in users:
         total_microdollars = spending_map.get(user.id, 0) or 0
         month_microdollars = month_map.get(user.id, 0) or 0
-        cache_read, cache_write = cache_map.get(user.id, (0, 0))
-        cache_cacheable = cache_read + cache_write
+        cache_served, prompt_input = cache_map.get(user.id, (0, 0))
         cache_hit_rate = (
-            cache_read / cache_cacheable if cache_cacheable > 0 else None
+            cache_served / prompt_input if prompt_input > 0 else None
         )
         user_list.append({
             "id": user.id,
@@ -89,12 +94,12 @@ def list_users():
             "deactivated_at": iso_utc(user.deactivated_at),
             "total_spending_usd": total_microdollars / 1_000_000,
             "current_month_spending_usd": month_microdollars / 1_000_000,
-            # Prompt-cache hit-rate (all-time): null when the user has no
-            # cacheable Anthropic traffic yet. Raw token sums included so the
-            # UI can show the breakdown on hover.
+            # Prompt-cache hit-rate over conversation turns (all-time): null
+            # when the user has no conversation prompt input yet. Raw sums
+            # included so the UI can show the breakdown on hover.
             "cache_hit_rate": cache_hit_rate,
-            "cache_read_tokens": cache_read,
-            "cache_write_tokens": cache_write,
+            "cache_served_tokens": cache_served,
+            "cache_input_tokens": prompt_input,
             # Effective cap (per-user override if set, else the global default),
             # pre-fills the editable input. `spend_limit_is_override` lets the UI
             # distinguish a custom value from the inherited default.

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -2045,10 +2045,17 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                     user_id=user_id,
                     model_id=model_id,
                     request_type="conversation",
+                    # input_tokens = full prompt size. For Anthropic, in_toks
+                    # is the uncached portion so read+write complete it; for
+                    # OpenAI in_toks is already the full prompt (read/write 0).
                     input_tokens=(in_toks + cache_read_toks
                                   + cache_write_toks),
                     output_tokens=out_toks,
-                    cache_read_tokens=cache_read_toks,
+                    # cache_read_tokens = input SERVED from cache, unified
+                    # across providers: Anthropic cache reads + OpenAI
+                    # cached_tokens (one of the two is always 0). Drives the
+                    # admin hit-rate (served / full prompt input).
+                    cache_read_tokens=(cache_read_toks + cached_input_toks),
                     cache_write_tokens=cache_write_toks,
                     cost_microdollars=cost,
                 ))

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -1984,9 +1984,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 logger.info(f"Calling LLM API: model_id={model_id}, api_model={api_model}, provider={provider}, key_type={key_type}, estimated_tokens={estimated_tokens}, total_chars={len(total_content)}")
 
                 try:
+                    # #189: stable per-thread key improves OpenAI's
+                    # automatic prefix-cache routing.
+                    thread_root_id = (node_chain[0].id if node_chain
+                                      else parent_node_id)
                     response = LLMProvider.get_completion(
                         model_id, messages, api_keys,
                         tools=agentic_tools,
+                        prompt_cache_key=f"loore-t{thread_root_id}",
                     )
                     break  # Success
                 except PromptTooLongError as e:
@@ -2010,21 +2015,32 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 Cache-aware (#187): cache reads price at 0.1x and writes at
                 1.25x; the logged input_tokens is the full prompt size
                 (uncached + cached reads + cache writes) for visibility, while
-                pricing is already accounted in the cost above."""
+                pricing is already accounted in the cost above.
+
+                OpenAI (#189): cached_tokens is the cached SUBSET of
+                input_tokens (auto prefix-cache) — billed at the model's
+                cached_input_multiplier, fixing the prior full-price
+                over-count."""
                 in_toks = resp.get("input_tokens", 0)
                 out_toks = resp.get("output_tokens", 0)
                 cache_read_toks = resp.get("cache_read_input_tokens", 0)
                 cache_write_toks = resp.get(
                     "cache_creation_input_tokens", 0)
+                cached_input_toks = resp.get("cached_tokens", 0)
                 cost = calculate_llm_cost_microdollars(
                     model_id, in_toks, out_toks,
                     cache_read_tokens=cache_read_toks,
                     cache_write_tokens=cache_write_toks,
+                    cached_input_tokens=cached_input_toks,
                 )
                 if cache_read_toks or cache_write_toks:
                     logger.info(
                         "Prompt cache usage: read=%d write=%d uncached=%d",
                         cache_read_toks, cache_write_toks, in_toks)
+                if cached_input_toks:
+                    logger.info(
+                        "OpenAI prompt cache: %d/%d input tokens cached",
+                        cached_input_toks, in_toks)
                 db.session.add(APICostLog(
                     user_id=user_id,
                     model_id=model_id,
@@ -2367,6 +2383,9 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         response = LLMProvider.get_completion(
                             model_id, messages, api_keys,
                             tools=agentic_tools,
+                            # #189: same per-thread key as the first call so
+                            # loop continuations route to the same OpenAI cache.
+                            prompt_cache_key=f"loore-t{thread_root_id}",
                         )
                     except PromptTooLongError:
                         logger.warning(
@@ -2389,6 +2408,9 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         response = LLMProvider.get_completion(
                             model_id, messages, api_keys,
                             tools=agentic_tools,
+                            # #189: same per-thread key as the first call so
+                            # loop continuations route to the same OpenAI cache.
+                            prompt_cache_key=f"loore-t{thread_root_id}",
                         )
                     continue
 

--- a/backend/tests/test_admin_access.py
+++ b/backend/tests/test_admin_access.py
@@ -132,22 +132,28 @@ class TestAdminRequired:
 
 
 class TestCacheHitRate:
-    """#187: /admin/users reports a per-user prompt-cache hit-rate
-    (reads / (reads + writes)) plus the raw token sums."""
+    """#187/#189: /admin/users reports a per-user prompt-cache hit-rate over
+    conversation turns — input served from cache / total prompt input —
+    unified across Anthropic (cache reads) and OpenAI (cached_tokens)."""
 
-    def test_hit_rate_computed_from_cache_tokens(self, app, users):
+    def test_hit_rate_served_over_prompt_input(self, app, users):
         admin = users["renamed_admin"]
         other = users["impostor"]
         with app.app_context():
-            # 900k reads + 100k writes → 90% hit-rate.
             _db.session.add_all([
+                # Anthropic: input_tokens is the full prompt; cache_read_tokens
+                # holds the served portion. 900k of 1M served → 90%.
                 APICostLog(user_id=admin.id, model_id="claude-opus-4.6",
                            request_type="conversation", input_tokens=1_000_000,
                            cache_read_tokens=900_000, cache_write_tokens=100_000,
                            cost_microdollars=1),
-                # A non-cached row contributes 0/0, not noise.
+                # Non-conversation rows must NOT dilute the denominator.
                 APICostLog(user_id=admin.id, model_id="gpt-4o-transcribe",
-                           request_type="transcription", cost_microdollars=1),
+                           request_type="transcription", input_tokens=500_000,
+                           cost_microdollars=1),
+                APICostLog(user_id=admin.id, model_id="text-embedding-3-small",
+                           request_type="embedding", input_tokens=2_000_000,
+                           cost_microdollars=1),
             ])
             _db.session.commit()
 
@@ -155,9 +161,25 @@ class TestCacheHitRate:
         _login(client, admin.id)
         rows = {u["id"]: u for u in client.get("/api/admin/users").get_json()["users"]}
 
-        assert rows[admin.id]["cache_hit_rate"] == 0.9
-        assert rows[admin.id]["cache_read_tokens"] == 900_000
-        assert rows[admin.id]["cache_write_tokens"] == 100_000
-        # No cacheable traffic → null (UI renders "—"), not 0 (which would
-        # read as a real 0% hit-rate).
+        assert rows[admin.id]["cache_hit_rate"] == 0.9   # 900k / 1M, not diluted
+        assert rows[admin.id]["cache_served_tokens"] == 900_000
+        assert rows[admin.id]["cache_input_tokens"] == 1_000_000
+        # No conversation prompt input → null (UI renders "—").
         assert rows[other.id]["cache_hit_rate"] is None
+
+    def test_openai_cached_counts_as_served(self, app, users):
+        # OpenAI: cached_tokens is recorded in cache_read_tokens (served), with
+        # input_tokens the FULL prompt (incl. cached). 7808 of 7993 → ~97.7%.
+        admin = users["renamed_admin"]
+        with app.app_context():
+            _db.session.add(APICostLog(
+                user_id=admin.id, model_id="gpt-5.5",
+                request_type="conversation", input_tokens=7_993,
+                cache_read_tokens=7_808, cache_write_tokens=0,
+                cost_microdollars=1))
+            _db.session.commit()
+
+        client = app.test_client()
+        _login(client, admin.id)
+        rows = {u["id"]: u for u in client.get("/api/admin/users").get_json()["users"]}
+        assert abs(rows[admin.id]["cache_hit_rate"] - 7_808 / 7_993) < 1e-9

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -283,3 +283,30 @@ def test_call_anthropic_preserves_blocks_and_cache_usage(app, monkeypatch):
     assert result["cache_read_input_tokens"] == 5000
     assert result["cache_creation_input_tokens"] == 300
     assert result["input_tokens"] == 100
+
+
+# ── OpenAI cached-input pricing (#189) ───────────────────────────────────
+
+def test_openai_cached_input_discount(app):
+    app.config["SUPPORTED_MODELS"]["gpt-5.5"] = {
+        "provider": "openai", "api_model": "gpt-5.5",
+        "input_price_per_mtok": 5.00, "output_price_per_mtok": 30.00,
+        "cached_input_multiplier": 0.25,
+    }
+    with app.app_context():
+        # 1M prompt tokens, 800k of them cached at 0.25x
+        cost = calculate_llm_cost_microdollars(
+            "gpt-5.5", 1_000_000, 0, cached_input_tokens=800_000)
+        assert cost == round(200_000 * 5 + 800_000 * 5 * 0.25)
+        # Default multiplier (0.5) when model doesn't specify one
+        app.config["SUPPORTED_MODELS"]["gpt-5.4"] = {
+            "provider": "openai", "api_model": "gpt-5.4",
+            "input_price_per_mtok": 2.50, "output_price_per_mtok": 15.00,
+        }
+        cost54 = calculate_llm_cost_microdollars(
+            "gpt-5.4", 1_000_000, 0, cached_input_tokens=1_000_000)
+        assert cost54 == round(1_000_000 * 2.5 * 0.5)
+        # cached subset can never exceed input_tokens
+        capped = calculate_llm_cost_microdollars(
+            "gpt-5.5", 100, 0, cached_input_tokens=10_000)
+        assert capped == round(100 * 5 * 0.25)

--- a/backend/tests/test_retrieval_loop.py
+++ b/backend/tests/test_retrieval_loop.py
@@ -58,7 +58,8 @@ class _ScriptedProvider:
         cls.calls = []
 
     @classmethod
-    def get_completion(cls, model_id, messages, api_keys, tools=None):
+    def get_completion(cls, model_id, messages, api_keys, tools=None,
+                       prompt_cache_key=None, **kwargs):
         # Deep-copy the message texts so later mutation of `messages` in the
         # task doesn't retroactively change what we captured.
         cls.calls.append({

--- a/backend/utils/cost.py
+++ b/backend/utils/cost.py
@@ -15,16 +15,22 @@ CACHE_WRITE_MULTIPLIER = 1.25
 
 def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
                                     batch=False, cache_read_tokens=0,
-                                    cache_write_tokens=0):
+                                    cache_write_tokens=0,
+                                    cached_input_tokens=0):
     """
     Calculate LLM API cost in microdollars.
 
     Formula: input_tokens * input_price_per_mtok + output_tokens * output_price_per_mtok
     (the million factors in microdollars and per-million-token pricing cancel out)
 
-    input_tokens must be the UNCACHED portion (what the provider reports in
-    usage.input_tokens); cache reads/writes are passed separately and billed
-    at their multipliers (#187).
+    Anthropic (#187): input_tokens must be the UNCACHED portion (what the
+    provider reports in usage.input_tokens); cache reads/writes are passed
+    separately and billed at their multipliers.
+
+    OpenAI (#189): cached_input_tokens is the cached SUBSET of
+    input_tokens (usage.prompt_tokens_details.cached_tokens), billed at
+    the model's cached_input_multiplier (default 0.5). Fixes the prior
+    over-count where the auto-cache discount was ignored.
 
     batch=True applies the Batch API discount (~50% of synchronous pricing,
     issue #173). Long-context multipliers still apply to the per-call input
@@ -40,7 +46,10 @@ def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
     if threshold and total_prompt > threshold:
         input_price *= config.get("long_context_input_multiplier", 1)
         output_price *= config.get("long_context_output_multiplier", 1)
-    cost = (input_tokens * input_price
+    cached_subset = min(cached_input_tokens or 0, input_tokens)
+    cached_multiplier = config.get("cached_input_multiplier", 0.5)
+    cost = ((input_tokens - cached_subset) * input_price
+            + cached_subset * input_price * cached_multiplier
             + cache_read_tokens * input_price * CACHE_READ_MULTIPLIER
             + cache_write_tokens * input_price * CACHE_WRITE_MULTIPLIER
             + output_tokens * output_price)

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -273,7 +273,7 @@ function AdminPanel() {
             <th style={{ border: "1px solid var(--border)", padding: "8px", width: "85px", whiteSpace: "nowrap" }}>Limit ($)</th>
             <th
               style={{ border: "1px solid var(--border)", padding: "8px", width: "85px", whiteSpace: "nowrap" }}
-              title="Prompt-cache hit-rate (all-time): cache reads ÷ (reads + writes). Higher = more of the stable prefix served from cache."
+              title="Prompt-cache hit-rate over conversation turns (all-time): input tokens served from cache ÷ total prompt input. Covers both Anthropic and OpenAI caching."
             >
               Cache
             </th>
@@ -340,8 +340,8 @@ function AdminPanel() {
                 style={{ border: "1px solid var(--border)", padding: "8px", width: "85px", whiteSpace: "nowrap" }}
                 title={
                   u.cache_hit_rate == null
-                    ? "No cacheable Anthropic traffic yet"
-                    : `reads ${(u.cache_read_tokens || 0).toLocaleString()} · writes ${(u.cache_write_tokens || 0).toLocaleString()} tokens`
+                    ? "No conversation prompt input yet"
+                    : `${(u.cache_served_tokens || 0).toLocaleString()} of ${(u.cache_input_tokens || 0).toLocaleString()} prompt-input tokens served from cache`
                 }
               >
                 {u.cache_hit_rate == null


### PR DESCRIPTION
## ⚠️ Stacked PR — merge AFTER #198 (#187/#192)
Same-file stack on the caching branch.

## Summary
Closes #189 (sans the optional best-effort OpenAI pre-warm, explicitly flagged optional in the issue).

- Stable per-thread `prompt_cache_key` (`loore-t<thread_root>`) passed to OpenAI for better cache routing.
- `usage.prompt_tokens_details.cached_tokens` read and billed at the model's `cached_input_multiplier` (0.25 for GPT-5.5 per its 75% discount, 0.5 default).
- **Fixes a live cost over-count**: OpenAI has been auto-caching our ≥1024-token prefixes and billing the discount, while APICostLog charged every input token at full price.

## Verification
Cost tests incl. discount math, default multiplier, and cached-subset capping. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)