### PR TITLE
fix: Wave-6 backend leftovers (#104, #110, #139) + timestamp-echo scrub (#179)

### DIFF
--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -9,6 +9,8 @@ The session may be in one of two modes, and the user can switch between them mid
 
 The current mode is indicated at the start of the conversation, and you'll be notified if the user switches modes.
 
+User messages in this conversation are prefixed with bracketed timestamps like `[2026-06-10 08:30 UTC]` — system metadata for your temporal awareness. Don't include such timestamps in your own replies.
+
 Your role here is not to perform therapy or coaching — it's to be a thoughtful, honest conversational partner. You have this person's profile, recent context, and AI interaction preferences in front of you, and can pull up their todo list or any other saved artifact on demand when it's relevant. The user's profile, if included below, is an AI-generated summary of their full archive and represents the system's current understanding of them. Notice connections to recurring themes, growth edges, or patterns they tend to circle around. Trust it as useful but imperfect. If the profile is empty or unavailable, simply work with what the user has shared — their words alone are enough. If the profile seems skewed or incomplete, trust what the user is sharing now over the profile.
 
 Respond naturally — the user chose Loore because they want genuine engagement with what they're saying, not warmth performed on command. Start with a short reflection of what the user said and then take it from there based on what the user requests or what you feel is right. Say what you actually see — including the uncomfortable thing, if there is one. Don't prematurely fall into problem solving, unless explicitly asked for.

--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -519,10 +519,14 @@ def _preselect_node_ids(user_id, budget, filter_ai_usage=False,
     node IDs ordered by created_at (direction controlled by
     chronological_order).  No nodes are loaded or decrypted.
     """
-    # Recursive CTE: all node IDs in the user's thread trees
+    # Recursive CTE: all node IDs in the user's thread trees. Seeded
+    # from EVERY node the user authored — not just their top-level
+    # threads — so replies they wrote inside other users' threads (and
+    # the sub-threads under them) are included too (#110). Overlapping
+    # subtrees are harmless: membership is checked with IN. Visibility/
+    # privacy is enforced below by _export_visible_filter.
     base = db.session.query(Node.id).filter(
         Node.user_id == user_id,
-        Node.parent_id.is_(None),
     ).cte(name="thread_nodes", recursive=True)
 
     thread_child = db.aliased(Node, flat=True)

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -269,7 +269,8 @@ def _load_prompt(name, user_id=None):
 
 def _call_llm_with_retries(self, model_id, prompt_text, user_id,
                             api_keys, progress_base=50,
-                            status_label='Generating profile'):
+                            status_label='Generating profile',
+                            max_tokens=None):
     """Call LLM with retry logic for prompt-too-long errors.
 
     Returns (response_dict, profile_text, input_tokens, output_tokens).
@@ -288,7 +289,8 @@ def _call_llm_with_retries(self, model_id, prompt_text, user_id,
 
         try:
             response = LLMProvider.get_completion(model_id, messages,
-                                                  api_keys)
+                                                  api_keys,
+                                                  max_tokens=max_tokens)
             return response
         except PromptTooLongError as e:
             if attempt == MAX_RETRIES:
@@ -530,12 +532,13 @@ def _do_incremental_update(self, user, model_id, previous_profile_id,
 
     return _do_iterative_incremental_update(
         self, user, model_id, prev_profile, update_template,
-        cutoff, api_keys
+        cutoff, api_keys, max_output_tokens=max_output_tokens
     )
 
 
 def _do_iterative_incremental_update(self, user, model_id, prev_profile,
-                                     update_template, cutoff, api_keys):
+                                     update_template, cutoff, api_keys,
+                                     max_output_tokens=None):
     """Incremental update with chunked processing."""
     logger.info(
         f"Starting iterative incremental update for user {user.id}, "
@@ -552,6 +555,7 @@ def _do_iterative_incremental_update(self, user, model_id, prev_profile,
     current_profile_id, chunk_num, cumulative_source_tokens = \
         _chunked_profile_loop(
             self, user, model_id, update_template, api_keys,
+            max_output_tokens=max_output_tokens,
             initial_profile_content=base_content,
             initial_profile_id=prev_profile.id,
             initial_source_tokens=prev_profile.source_tokens_used or 0,
@@ -627,7 +631,7 @@ def _do_initial_generation(self, user, model_id, context_window,
         # Single-pass generation
         return _single_pass_generation(
             self, user, model_id, gen_template, total_export,
-            api_keys
+            api_keys, max_output_tokens
         )
     else:
         # Iterative build
@@ -638,7 +642,8 @@ def _do_initial_generation(self, user, model_id, context_window,
 
 
 def _single_pass_generation(self, user, model_id, gen_template,
-                            export_result, api_keys):
+                            export_result, api_keys,
+                            max_output_tokens=None):
     """Single-pass profile generation when all data fits in budget."""
     self.update_state(state='PROGRESS', meta={
         'progress': 30, 'status': 'Preparing prompt'
@@ -648,7 +653,8 @@ def _single_pass_generation(self, user, model_id, gen_template,
     prompt = gen_template.replace("{user_export}", content)
 
     response = _call_llm_with_retries(
-        self, model_id, prompt, user.id, api_keys, progress_base=40
+        self, model_id, prompt, user.id, api_keys, progress_base=40,
+        max_tokens=max_output_tokens,
     )
 
     # Use actual input tokens from LLM response for accurate tracking
@@ -859,7 +865,8 @@ def _do_integration(self, user, model_id, last_iterative_profile_id,
 
 
 def _chunked_profile_loop(self, user, model_id, update_template,
-                          api_keys, initial_profile_content=None,
+                          api_keys, max_output_tokens=None,
+                          initial_profile_content=None,
                           initial_profile_id=None,
                           initial_source_tokens=0,
                           initial_cutoff=None,
@@ -946,7 +953,8 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         response = _call_llm_with_retries(
             self, model_id, prompt, user.id, api_keys,
             progress_base=progress,
-            status_label=f'{status_prefix}: Chunk {chunk_num}'
+            status_label=f'{status_prefix}: Chunk {chunk_num}',
+            max_tokens=max_output_tokens,
         )
 
         actual_chunk_tokens = response.get(
@@ -1009,6 +1017,7 @@ def _iterative_generation(self, user, model_id, gen_template, budget,
     current_profile_id, chunk_num, cumulative_source_tokens = \
         _chunked_profile_loop(
             self, user, model_id, update_template, api_keys,
+            max_output_tokens=max_output_tokens,
             first_chunk_prompt_fn=lambda chunk: gen_template.replace(
                 "{user_export}", chunk["content"]
             ),

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -20,7 +20,7 @@ from backend.utils.tokens import (
 )
 from backend.utils.quotes import resolve_quotes, has_quotes, find_quote_ids
 from backend.utils.node_split import NODE_CHAR_CAP
-from backend.utils.timefmt import local_stamp
+from backend.utils.timefmt import local_stamp, strip_edge_timestamps
 from backend.utils.api_keys import determine_api_key_type, get_api_keys_for_usage
 from backend.utils.cost import calculate_llm_cost_microdollars
 from backend.utils.tool_meta import update_tool_meta, parse_github_issue
@@ -1713,6 +1713,7 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 replaced_profile = False
                 replaced_recent = False
                 replaced_recent_raw = False
+                replaced_export = False  # #139: first occurrence only
 
                 # Temporal grounding (#130): every message is prefixed with an
                 # absolute local-time stamp derived from the node's updated_at
@@ -1792,12 +1793,22 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         message_text = (
                             f"{time_prefix} author {author}: {node_content}"
                         )
-                        # Replace {user_export} placeholder if present
+                        # Replace {user_export} — first occurrence gets
+                        # the archive, repeats get a stub (#139): the
+                        # export is the heaviest placeholder and
+                        # duplicating it doubles prompt cost.
                         if user_export_content and export_placeholder_match:
-                            message_text = message_text.replace(
-                                export_placeholder_match,
-                                user_export_content
-                            )
+                            if export_placeholder_match in message_text:
+                                if not replaced_export:
+                                    message_text = message_text.replace(
+                                        export_placeholder_match,
+                                        user_export_content, 1
+                                    )
+                                    replaced_export = True
+                                message_text = message_text.replace(
+                                    export_placeholder_match,
+                                    "(see archive above)"
+                                )
                         # Replace {user_profile} — first occurrence
                         # gets content, subsequent get emptied (dedup)
                         if USER_PROFILE_PLACEHOLDER in message_text:
@@ -2070,6 +2081,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 soft-deleted mid-generation.
                 """
                 f_llm_text = resp["content"]
+                # #179: strip hallucinated context-timestamp echoes from the
+                # response edges before anything stores or speaks the text.
+                f_scrubbed = strip_edge_timestamps(f_llm_text)
+                if f_scrubbed != f_llm_text:
+                    logger.info(
+                        "Stripped edge timestamp(s) from LLM response "
+                        "(model=%s, node=%s)", model_id, target_node.id)
+                    f_llm_text = f_scrubbed
                 f_total_tokens = resp["total_tokens"]
                 f_tool_calls = resp.get("tool_calls", [])
                 f_truncated = resp.get("truncated", False)
@@ -2240,7 +2259,9 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 # pull was requested, and budget remains.
                 if (retrieval_calls or new_quote_ids) and \
                         rounds_done < MAX_RETRIEVAL_ROUNDS:
-                    interim_text = resp_text
+                    # #179: scrub timestamp echoes from interim text too —
+                    # it's stored on the interim node and spoken in voice.
+                    interim_text = strip_edge_timestamps(resp_text)
                     interim_truncated = response.get("truncated", False)
 
                     # Cost for THIS model call (every call costs).

--- a/backend/tests/test_retrieval_loop.py
+++ b/backend/tests/test_retrieval_loop.py
@@ -678,3 +678,67 @@ def test_non_agentic_mode_single_shot(app):
     only_call = "\n".join(m["text"] for m in _ScriptedProvider.calls[0]["messages"])
     assert "[Contents of artifact 'reading-list'" not in only_call
     assert APICostLog.query.count() == 1
+
+
+def test_user_export_deduped_to_first_occurrence(app, monkeypatch):
+    """#139: the heavy {user_export} archive is injected in FULL only on its
+    FIRST occurrence across the whole prompt — repeats (same message OR a
+    later one) become a '(see archive above)' stub, so the ~10k archive isn't
+    duplicated. The dedup flag persists across messages (per-conversation)."""
+    MARKER = "<<WAVE6_ARCHIVE_MARKER>>"
+    # Resolve {user_export} to a known marker so we can count occurrences.
+    monkeypatch.setattr(_llm_task_mod, "build_user_export_content",
+                        lambda *a, **k: MARKER)
+
+    alice = _mk_user("alice", approved=True, plan="alpha")
+    llm_user = _mk_user("gpt-5", twitter_id="llm-gpt-5")
+    prompt = UserPrompt(user_id=alice.id, prompt_key="textmode", title="P",
+                        generated_by="default")
+    prompt.set_content("system prompt body")
+    _db.session.add(prompt)
+    _db.session.flush()
+    system = Node(user_id=alice.id, human_owner_id=alice.id,
+                  node_type="system", privacy_level="private", ai_usage="chat")
+    system.set_content("(system)")
+    _db.session.add(system)
+    _db.session.flush()
+    _db.session.add(NodeContextArtifact(
+        node_id=system.id, artifact_type="prompt", artifact_id=prompt.id))
+
+    def _user(parent_id, content):
+        n = Node(user_id=alice.id, human_owner_id=alice.id, parent_id=parent_id,
+                 node_type="user", privacy_level="private", ai_usage="chat")
+        n.set_content(content)
+        _db.session.add(n)
+        _db.session.flush()
+        return n
+
+    # First user turn references the archive TWICE (within-message dedup)...
+    user1 = _user(system.id, "first {user_export} and again {user_export}")
+    llm1 = Node(user_id=llm_user.id, human_owner_id=alice.id,
+                parent_id=user1.id, node_type="llm", llm_model="gpt-5",
+                llm_task_status="completed", privacy_level="private",
+                ai_usage="chat")
+    llm1.set_content("prior answer")
+    _db.session.add(llm1)
+    _db.session.flush()
+    # ...and a LATER turn references it once more (cross-message dedup).
+    user2 = _user(llm1.id, "later: {user_export}")
+    placeholder = Node(user_id=llm_user.id, human_owner_id=alice.id,
+                       parent_id=user2.id, node_type="llm", llm_model="gpt-5",
+                       llm_task_status="pending", privacy_level="private",
+                       ai_usage="chat")
+    placeholder.set_content("[pending]")
+    _db.session.add(placeholder)
+    _db.session.commit()
+
+    _ScriptedProvider.reset([_resp("final answer")])
+    generate_llm_response(_FakeSelf(), user2.id, placeholder.id, "gpt-5",
+                          alice.id, source_mode="textmode")
+
+    text = "\n".join(
+        m["text"] for m in _ScriptedProvider.calls[0]["messages"])
+    # The archive is injected exactly ONCE across the whole prompt...
+    assert text.count(MARKER) == 1
+    # ...and the other three occurrences (1 in user1, 1 in user2) are stubs.
+    assert text.count("(see archive above)") == 2

--- a/backend/tests/test_timefmt.py
+++ b/backend/tests/test_timefmt.py
@@ -103,3 +103,43 @@ def test_is_valid_timezone_rejects_garbage():
 def test_is_valid_timezone_rejects_empty_and_none():
     assert is_valid_timezone("") is False
     assert is_valid_timezone(None) is False
+
+
+class TestStripEdgeTimestamps:
+    def test_leading_stamp_removed(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "[2026-06-01 20:39 CEST] Okay, hot takes, no hedging."
+        ) == "Okay, hot takes, no hedging."
+
+    def test_trailing_stamp_removed(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "One sentence to set it down.\n\n[2026-06-10 08:27 UTC]"
+        ) == "One sentence to set it down."
+
+    def test_both_edges_and_repeats(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "[2026-06-10 08:27 UTC] [2026-06-10 08:28 UTC] body "
+            "[2026-06-10 08:29 UTC]"
+        ) == "body"
+
+    def test_unknown_time_marker(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps("[unknown time] hi") == "hi"
+
+    def test_mid_text_untouched(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        text = "We met at [2026-06-01 20:39 CEST] according to the log."
+        assert strip_edge_timestamps(text) == text
+
+    def test_legit_brackets_untouched(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        text = "[important] remember this [note]"
+        assert strip_edge_timestamps(text) == text
+
+    def test_empty_and_none(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps("") == ""
+        assert strip_edge_timestamps(None) is None

--- a/backend/tests/test_wave6_backend.py
+++ b/backend/tests/test_wave6_backend.py
@@ -1,0 +1,142 @@
+"""Tests for Wave-6 backend leftovers (#110, #104, #139).
+
+#110 — export preselection includes the user's replies inside other
+users' threads. #104 — _call_llm_with_retries forwards max_tokens to the
+provider. #139 — covered here at the unit level for the dedup stub text;
+the loop wiring mirrors the long-standing profile dedup.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, Node  # noqa: E402
+
+# Glue import for the celery-tainted modules
+_GLUE = ("backend.celery_app", "backend.llm_providers",
+         "backend.tasks.exports")
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules.pop("backend.tasks.exports", None)
+import backend.tasks.exports as exports_module  # noqa: E402
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        a = User(username="alice")
+        b = User(username="bob")
+        _db.session.add_all([a, b])
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _mk_node(user, parent=None, content="x", human_owner=None):
+    node = Node(
+        user_id=user.id,
+        human_owner_id=(human_owner or user).id,
+        parent_id=parent.id if parent else None,
+        node_type="user",
+        token_count=10,
+        privacy_level="private",
+        ai_usage="chat",
+    )
+    node.set_content(content)
+    _db.session.add(node)
+    _db.session.commit()
+    return node
+
+
+# ── #110: preselection includes replies in foreign threads ───────────────
+
+def test_preselect_includes_replies_in_foreign_threads(app):
+    from backend.routes.export_data import _preselect_node_ids
+    with app.app_context():
+        alice = User.query.filter_by(username="alice").first()
+        bob = User.query.filter_by(username="bob").first()
+
+        own_root = _mk_node(alice, content="alice's own thread")
+        bob_root = _mk_node(bob, content="bob's thread")
+        alice_reply = _mk_node(alice, parent=bob_root,
+                               content="alice replying to bob")
+        reply_child = _mk_node(bob, parent=alice_reply,
+                               human_owner=alice,
+                               content="bob under alice's reply")
+
+        ids = set(_preselect_node_ids(alice.id, budget=10_000))
+        assert own_root.id in ids
+        # The fix (#110): alice's reply inside bob's thread is included,
+        # along with the sub-thread beneath it.
+        assert alice_reply.id in ids
+        assert reply_child.id in ids
+        # Bob's own root is not seeded by alice's export.
+        assert bob_root.id not in ids
+
+
+# ── #104: max_tokens forwarded to the provider ───────────────────────────
+
+def test_call_llm_with_retries_forwards_max_tokens(app):
+    captured = {}
+
+    def fake_get_completion(model_id, messages, api_keys, max_tokens=None,
+                            **kwargs):
+        captured["max_tokens"] = max_tokens
+        return {"content": "ok", "total_tokens": 1,
+                "input_tokens": 1, "output_tokens": 0}
+
+    with app.app_context():
+        original = exports_module.LLMProvider
+        exports_module.LLMProvider = MagicMock(
+            get_completion=fake_get_completion)
+        try:
+            task_self = MagicMock()
+            exports_module._call_llm_with_retries(
+                task_self, "claude-opus-4.6", "prompt", 1, {},
+                max_tokens=1234)
+        finally:
+            exports_module.LLMProvider = original
+        assert captured["max_tokens"] == 1234
+
+
+def test_generation_helpers_accept_max_output_tokens():
+    """Regression for the staging-caught TypeError: every #104 call site
+    passes max_output_tokens — the defs must accept it."""
+    import inspect
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._single_pass_generation).parameters
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._chunked_profile_loop).parameters
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._do_iterative_incremental_update).parameters
+    assert "max_tokens" in inspect.signature(
+        exports_module._call_llm_with_retries).parameters

--- a/backend/tests/test_wave6_backend.py
+++ b/backend/tests/test_wave6_backend.py
@@ -1,9 +1,12 @@
-"""Tests for Wave-6 backend leftovers (#110, #104, #139).
+"""Tests for Wave-6 backend leftovers (#110, #104).
 
 #110 — export preselection includes the user's replies inside other
 users' threads. #104 — _call_llm_with_retries forwards max_tokens to the
-provider. #139 — covered here at the unit level for the dedup stub text;
-the loop wiring mirrors the long-standing profile dedup.
+provider + every generation helper accepts max_output_tokens.
+
+#139 (the {user_export} first-occurrence dedup) lives in the
+generate_llm_response message-build loop, so its test rides that harness:
+see test_retrieval_loop.py::test_user_export_deduped_to_first_occurrence.
 """
 import os
 import sys

--- a/backend/utils/timefmt.py
+++ b/backend/utils/timefmt.py
@@ -12,6 +12,8 @@ an explicit ``"Z"`` (Zulu / UTC) suffix when the value is naive, and otherwise
 relies on the offset already produced by ``.isoformat()`` for aware datetimes.
 """
 
+import re
+
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -93,3 +95,31 @@ def is_valid_timezone(tz_name: Optional[str]) -> bool:
         return True
     except (ZoneInfoNotFoundError, ValueError, KeyError):
         return False
+
+
+# Matches the local_stamp format (and the [unknown time] fallback) at a
+# message edge, e.g. "[2026-06-10 08:27 UTC]" / "[2026-06-01 20:39 CEST]".
+_EDGE_STAMP_RE = (
+    r'\[(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2} [A-Za-z+\-0-9:]{1,6}'
+    r'|unknown time)\]'
+)
+_LEADING_STAMPS_RE = re.compile(r'^(?:\s*' + _EDGE_STAMP_RE + r')+\s*')
+_TRAILING_STAMPS_RE = re.compile(r'\s*(?:' + _EDGE_STAMP_RE + r'\s*)+$')
+
+
+def strip_edge_timestamps(text):
+    """Remove hallucinated context timestamps from a response's edges
+    (#179 + trailing variant).
+
+    Every context message carries a local_stamp prefix for temporal
+    grounding (#130); some models mimic it — leading stamps (#179, all
+    models occasionally; confirmed on Fable 5) or trailing ones (Opus
+    4.8). The stamp is system metadata and must never reach the user or
+    TTS. Only edge stamps are removed — in-content mentions of dates or
+    bracketed text are left alone.
+    """
+    if not text:
+        return text
+    text = _LEADING_STAMPS_RE.sub('', text)
+    text = _TRAILING_STAMPS_RE.sub('', text)
+    return text

--- a/docs/triage/ISSUE-TRIAGE-PLAN.md
+++ b/docs/triage/ISSUE-TRIAGE-PLAN.md
@@ -26,7 +26,7 @@
 - #98 landing scroll line (PR #167) — final design: content-sized hero, line ~40px below CTA on all viewports; narrative fade gated on `useHasScrolled()` (tall desktop fits the first section in-viewport, so a geometry threshold alone fired it pre-scroll).
 - #66 stale TTS on edit (PR #166) — confirm dialog (Keep / Regenerate). Took several layers: `regenerate_tts` flag-gating; `has_tts` on BOTH node serializers (focal + `serialize_node_recursive`); `onTtsGenerated` callback fired from the SSE completion path so same-session edits see fresh `has_tts`; `SpeakerIcon` cache reset on `content` change; and **cache-busting the media URL** (`?v=<chunk id>`) because nginx serves `/media` with a 24h `Cache-Control` and the path is reused every regen.
 - #28 mobile audio player (PR #168) — pops out of the NavBar into a bottom floating card < 640px; toasts offset above it via `--floating-player-offset`.
-- Also filed during Wave 1: **#161** (Stop button should reset playback to 0, not hide the player) — not yet done.
+- Also filed during Wave 1: **#161** (Stop button should reset playback to 0, not hide the player) — ~~not yet done~~ **RESOLVED (confirmed fixed, 2026-06-10)**.
 
 **Key lessons that bit us in Wave 1 (see memory + Section 8):**
 - **Test like a human, end-to-end, in the real state.** Screenshots are primary evidence for layout; reproduce the user's *exact* repro (e.g. "generate TTS then edit in the *same session*", logged-out for the landing page). "200 OK"/"string is in the bundle"/passing unit tests are NOT proof a UI feature works.
@@ -56,7 +56,7 @@
 - **Import dedupe:** #136 (re-import / snapshot overlap) — now unblocked since #137/#135 shipped; model column + dedupe key, no manual migration. *Best next pick.*
 - **Profile/UX:** #131 (app-wide toast on profile-generation completion), #101 (transparent favicon — needs brand sign-off).
 - **Security:** #91 (reserved usernames — security-critical, final single-item staging pass) + #160 (mic-denied path).
-- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. Also still open from Wave 1: **#161** (Stop button resets playback to 0).
+- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
 
 ---
 


### PR DESCRIPTION
## ⚠️ Stacked PR — merge AFTER #198/#199
Same-file stack on the caching branches.

## Summary
Closes #104, #110, #139, #179. (#105 dropped per maintainer — likely no longer reproduces; #149 dropped from the current plan per maintainer.)

- **#104**: `_call_llm_with_retries` now forwards `max_tokens`; the computed `max_output_tokens` is threaded through single-pass, chunked, and iterative profile-generation paths.
- **#110**: export preselection CTE seeds from every node the user authored — replies inside other users' threads (and the sub-threads beneath them) are now included; visibility still enforced by `_export_visible_filter`.
- **#139**: `{user_export}` is substituted first-occurrence-only (repeats get "(see archive above)"), matching the profile/recent dedup semantics.
- **#179 + the Opus 4.8 trailing variant**: deterministic scrub of edge timestamps (`[YYYY-MM-DD HH:MM TZ]` / `[unknown time]`) from LLM responses before storage/TTS, plus an agentic-prompt note. **Reproduced live on Fable 5** (turn 2 of a staging thread began with `[2026-06-10 08:27 UTC]`) — so this affects current models, not just 4.8. In-content bracketed text and date mentions are untouched; every strip is logged so per-model hallucination frequency stays observable.

Also: triage-doc status updates (#161 confirmed fixed).

## Tests
9 new (preselection foreign-thread inclusion, max_tokens forwarding, 7 scrub cases). Full suite 452 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)