### PR TITLE
feat(#131): app-wide toast when profile generation completes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,6 +25,7 @@ import TodoPage from "./pages/TodoPage";
 import ImportPage from "./pages/ImportPage";
 import AccountPage from "./pages/AccountPage";
 import ArtifactsPage from "./pages/ArtifactsPage";
+import ProfileGenerationWatcher from "./components/ProfileGenerationWatcher";
 import PromptsPage from "./pages/PromptsPage";
 import PromptDetailPage from "./pages/PromptDetailPage";
 import SearchModal from "./components/SearchModal";
@@ -113,6 +114,7 @@ function App() {
         />
       )}
 
+        <ProfileGenerationWatcher />
         <Routes>
           <Route path="/" element={<RootRoute />} />
           <Route path="/landing" element={<LandingPage />} />

--- a/frontend/src/components/ProfileGenerationWatcher.js
+++ b/frontend/src/components/ProfileGenerationWatcher.js
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
+import { useToast } from '../contexts/ToastContext';
+import { useUser } from '../contexts/UserContext';
+
+/**
+ * App-wide watcher for profile generation (#131).
+ *
+ * The single poller for /export/profile-status — mounted in App so the
+ * user is notified wherever they are when generation finishes (before
+ * this, completion was only visible while ProfilePage was open).
+ * Broadcasts progress via the 'loore_profile_progress' CustomEvent
+ * (ProfilePage renders its inline indicator from it) and the existing
+ * 'loore_profile_done' event on terminal states. Renders nothing.
+ */
+export default function ProfileGenerationWatcher() {
+  const { addToast } = useToast();
+  const { user } = useUser();
+  const [taskId, setTaskId] = useState(
+    () => localStorage.getItem('loore_profile_task_id')
+  );
+
+  // Pick up task ID from backend if localStorage doesn't have it
+  // (cross-browser continuation).
+  useEffect(() => {
+    if (!taskId && user && user.profile_generation_task_id) {
+      localStorage.setItem(
+        'loore_profile_task_id', user.profile_generation_task_id);
+      setTaskId(user.profile_generation_task_id);
+    }
+  }, [user, taskId]);
+
+  // Generation started from NavBar or ProfilePage.
+  useEffect(() => {
+    const handler = (e) => {
+      const startedId = e.detail?.taskId
+        || localStorage.getItem('loore_profile_task_id');
+      if (startedId) setTaskId(startedId);
+    };
+    window.addEventListener('loore_profile_started', handler);
+    return () => window.removeEventListener('loore_profile_started', handler);
+  }, []);
+
+  const { status, progress, data } = useAsyncTaskPolling(
+    taskId ? `/export/profile-status/${taskId}` : null,
+    { interval: 3000, enabled: !!taskId }
+  );
+
+  // Broadcast progress so ProfilePage can render its inline indicator
+  // without running a second poller.
+  useEffect(() => {
+    if (!taskId || !status) return;
+    window.dispatchEvent(new CustomEvent('loore_profile_progress', {
+      detail: { status, progress, message: data?.message },
+    }));
+  }, [taskId, status, progress, data]);
+
+  useEffect(() => {
+    if (status === 'completed') {
+      localStorage.removeItem('loore_profile_task_id');
+      setTaskId(null);
+      window.dispatchEvent(new Event('loore_profile_done'));
+      addToast('Your profile has been updated ✓', 6000);
+    } else if (status === 'failed') {
+      localStorage.removeItem('loore_profile_task_id');
+      setTaskId(null);
+      window.dispatchEvent(new Event('loore_profile_done'));
+      addToast('Profile generation failed');
+    }
+  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -5,7 +5,6 @@ import VersionHistoryDrawer from '../components/VersionHistoryDrawer';
 import ArtifactsNav from '../components/ArtifactsNav';
 import SpeakerIcon from '../components/SpeakerIcon';
 import RegenerateTtsDialog from '../components/RegenerateTtsDialog';
-import { useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
 import { useUser } from '../contexts/UserContext';
 import useSubmitShortcut from '../hooks/useSubmitShortcut';
 import useEscapeKey from '../hooks/useEscapeKey';
@@ -55,29 +54,10 @@ export default function ProfilePage() {
     return () => window.removeEventListener('loore_profile_started', handler);
   }, []);
 
-  const pollingEndpoint = generationTaskId
-    ? `/export/profile-status/${generationTaskId}` : null;
-
-  const { status: genStatus, progress: genProgress, data: genData } = useAsyncTaskPolling(
-    pollingEndpoint,
-    { interval: 3000, enabled: !!generationTaskId }
-  );
-
-  // React to polling status changes
-  useEffect(() => {
-    if (genStatus === 'completed') {
-      localStorage.removeItem('loore_profile_task_id');
-      setGenerationTaskId(null);
-      window.dispatchEvent(new Event('loore_profile_done'));
-      fetchProfile();
-    } else if (genStatus === 'failed') {
-      localStorage.removeItem('loore_profile_task_id');
-      setGenerationTaskId(null);
-      window.dispatchEvent(new Event('loore_profile_done'));
-      setFailMessage('Generation failed');
-      setTimeout(() => setFailMessage(''), 5000);
-    }
-  }, [genStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Progress + completion arrive from the app-wide
+  // ProfileGenerationWatcher (#131) — this page no longer polls.
+  const [genProgress, setGenProgress] = useState(0);
+  const [genData, setGenData] = useState(null);
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -93,6 +73,29 @@ export default function ProfilePage() {
       setLoading(false);
     }
   }, []);
+
+  useEffect(() => {
+    const onProgress = (e) => {
+      setGenProgress(e.detail?.progress || 0);
+      setGenData(e.detail?.message ? { message: e.detail.message } : null);
+      if (e.detail?.status === 'failed') {
+        setFailMessage('Generation failed');
+        setTimeout(() => setFailMessage(''), 5000);
+      }
+    };
+    const onDone = () => {
+      setGenerationTaskId(null);
+      setGenProgress(0);
+      setGenData(null);
+      fetchProfile();
+    };
+    window.addEventListener('loore_profile_progress', onProgress);
+    window.addEventListener('loore_profile_done', onDone);
+    return () => {
+      window.removeEventListener('loore_profile_progress', onProgress);
+      window.removeEventListener('loore_profile_done', onDone);
+    };
+  }, [fetchProfile]);
 
   useEffect(() => {
     fetchProfile();


### PR DESCRIPTION
## ⚠️ Stacked PR — merge AFTER #200
Branched from the wave-6 batch line.

## Summary
Closes #131. A single global poller (`ProfileGenerationWatcher`, mounted in App) watches `/export/profile-status/<task_id>` and toasts on completion/failure wherever the user is. ProfilePage no longer runs its own poller — it renders the inline progress indicator from the watcher's `loore_profile_progress` CustomEvents and refreshes on the existing `loore_profile_done` event, satisfying the triage dedupe requirement (one poller, no double notification).

## Verification
Frontend builds clean. Staging: start a profile regen from NavBar, navigate to Log, observe the toast on completion (or stub the status endpoint per the triage plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)