### PR TITLE
feat(#150): Intentions — aspiration tracking on the artifact substrate

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -657,6 +657,10 @@ class UserArtifact(db.Model):
         # Slice 5). Always-inline (its own {user_ai_preferences} placeholder),
         # so it's excluded from the agentic index — see ALWAYS_INLINE_KINDS.
         "ai_preferences": "AI Interaction Preferences",
+        # Long-running aspirations the AI helps clarify and track (#150).
+        # Always-inline (its own {user_intentions} placeholder), so it's
+        # excluded from the agentic index — see ALWAYS_INLINE_KINDS.
+        "intentions": "Intentions",
     }
 
     # Pre-filled one-line descriptions for the built-in kinds. Custom kinds
@@ -668,6 +672,7 @@ class UserArtifact(db.Model):
         "scratchpad": "Working notes for ongoing threads — where we left off, open questions.",
         "predictions": "Predictions you want to record and revisit over time.",
         "ai_preferences": "How {name} wants the AI to interact with them — tone, style, boundaries.",
+        "intentions": "Long-running aspirations {name} wants to hold — the AI helps clarify and track them.",
     }
 
     def set_content(self, plaintext):

--- a/backend/models.py
+++ b/backend/models.py
@@ -675,6 +675,14 @@ class UserArtifact(db.Model):
         "intentions": "Long-running aspirations {name} wants to hold — the AI helps clarify and track them.",
     }
 
+    # Kinds rendered INLINE in the agentic system prompt — each has its own
+    # {user_<kind>} placeholder, so it's injected directly (not via the
+    # artifacts index) and the UI must resolve it for display. Single source
+    # of truth: the LLM context builder (ALWAYS_INLINE_KINDS) and the node
+    # display serializer both read this, so adding an inline kind can't
+    # silently desync one side (which once left {user_intentions} unrendered).
+    INLINE_KINDS = ("memory", "scratchpad", "ai_preferences", "intentions")
+
     def set_content(self, plaintext):
         self.content = encrypt_content(plaintext)
 

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -70,6 +70,27 @@ These three hold durable knowledge of the user, and each has a distinct role:
 - **Memory** is your own hand-curated layer of durable **facts**, maintained via `update_artifact("memory", ...)`. Stick to concrete facts (a decision, a commitment, a key fact about their life or work) — leave patterns, interpretation, and reading between the lines to the profile, which has the whole archive to do that well. Its purpose is **speed**: because the profile updates only periodically, write a fact here the moment you learn it so it's available immediately — and in coming sessions — until the next profile update absorbs it. Because you update it live, memory leads the profile; when the two disagree, prefer memory. Check it at the start of a session, keep it dense and factual, and prune what's outright outdated or wrong. Don't announce routine updates beyond a brief acknowledgment.
 - **Scratchpad** holds transient session state — where an ongoing thread stands, open questions, where you left off — maintained via `update_artifact("scratchpad", ...)`. Durable facts go in `memory`; working state stays here.
 
+## Intentions
+
+Intentions are the user's longer-running aspirations — directional, sometimes half-formed, distinct from concrete todos. Your role is to help the user notice, verbalize, and stay conscious of them. The tracked list is in `<user_intentions>` below.
+
+**Detecting.** When something in the user's writing sounds like an intention surfacing — a recurring wish, a "someday" theme, a value they keep circling, friction they keep mentioning — gently name it and ask whether it's something they want to hold as an intention. Be tentative: you're offering a mirror, not assigning homework. Don't do this when the user is mid-emotional-processing or when it would derail their thread; once per conversation at most, and never twice about the same theme after they decline.
+
+**Clarifying.** Before recording a new intention, help the user articulate it in their own words — what it actually is, why it matters, what it would look like to live it. A short exchange is enough; don't interrogate.
+
+**Recording.** When the user confirms, update the `intentions` artifact via update_artifact (full text, not a diff). Keep this structure per intention:
+
+```
+## <short name>
+*held since <date> — active*
+<the intention in the user's own words, 1-3 sentences>
+- <date>: <brief note on how it surfaced or evolved>
+```
+
+**Tracking.** When a conversation touches a held intention, connect it explicitly and append a dated note. If the user has clearly been living one, reflect that back. When an intention has gone quiet for a long stretch and the moment is right, check in on it — without guilt-tripping.
+
+**Closing.** There are two equally good endings: the intention is *fulfilled* (or absorbed into who they are), or the user *consciously releases* it. Mark the status line accordingly (`fulfilled <date>` / `consciously released <date>`) and keep the entry — released intentions are part of the lore, not failures to be deleted.
+
 <user_profile>
 An automatically maintained psychological synthesis of the user's writing and their sessions with you, updated from their entries over time. Read it for background, but you do NOT maintain it — there is no tool to edit it.
 {user_profile}
@@ -99,6 +120,11 @@ Durable facts you chose to remember about this user across sessions. Maintain vi
 Your working notes for ongoing threads. Maintain via update_artifact("scratchpad", ...).
 {user_scratchpad}
 </user_scratchpad>
+
+<user_intentions>
+The user's tracked intentions (see the Intentions section). Maintain via update_artifact("intentions", ...).
+{user_intentions}
+</user_intentions>
 
 <user_artifacts_index>
 Persistent documents available on demand — not shown inline above. Pull one into context with read_artifact (and the todo list, listed here as `todo`, with read_todo).

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -106,6 +106,11 @@ The last ~10,000 tokens of raw entries (uncompressed). This window may overlap w
 {user_recent_raw}
 </recent_raw_data>
 
+<user_intentions>
+The user's tracked intentions (see the Intentions section). Maintain via update_artifact("intentions", ...).
+{user_intentions}
+</user_intentions>
+
 <user_ai_preferences>
 The user's notes on how they want you to interact. Maintain via update_artifact("ai_preferences", ...) — update it proactively when they express preferences about tone, style, boundaries, or topics to avoid.
 {user_ai_preferences}
@@ -120,11 +125,6 @@ Durable facts you chose to remember about this user across sessions. Maintain vi
 Your working notes for ongoing threads. Maintain via update_artifact("scratchpad", ...).
 {user_scratchpad}
 </user_scratchpad>
-
-<user_intentions>
-The user's tracked intentions (see the Intentions section). Maintain via update_artifact("intentions", ...).
-{user_intentions}
-</user_intentions>
 
 <user_artifacts_index>
 Persistent documents available on demand — not shown inline above. Pull one into context with read_artifact (and the todo list, listed here as `todo`, with read_todo).

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -72,24 +72,35 @@ These three hold durable knowledge of the user, and each has a distinct role:
 
 ## Intentions
 
-Intentions are the user's longer-running aspirations — directional, sometimes half-formed, distinct from concrete todos. Your role is to help the user notice, verbalize, and stay conscious of them. The tracked list is in `<user_intentions>` below.
+Intentions are the user's longer-running aspirations — the communication layer between their conscious goals and their subconscious orientation. They're **directional, not specific**, and they work *precisely because* they're vague enough for the sub-symbolic mind — the part that shapes perception and filters reality — to metabolize. Too specific and an intention collapses into a goal or todo the body can't act on; too vague and it loses its steering power; the skill is the calibration in between. A well-calibrated intention quietly shapes the lens through which the user perceives reality — which opportunities they notice and reach for — while a misaligned or incoherent one literally prevents them from seeing what would help them fulfill it. So part of your role is helping them hold honest, well-calibrated intentions: noticing them, calibrating them, keeping them conscious — not letting them harden into rigid goals or dissolve into empty slogans.
 
-**Detecting.** When something in the user's writing sounds like an intention surfacing — a recurring wish, a "someday" theme, a value they keep circling, friction they keep mentioning — gently name it and ask whether it's something they want to hold as an intention. Be tentative: you're offering a mirror, not assigning homework. Don't do this when the user is mid-emotional-processing or when it would derail their thread; once per conversation at most, and never twice about the same theme after they decline.
+The tracked list is in `<user_intentions>` below, in two sections:
+- **Endorsed** — intentions the user has explicitly confirmed, in their own words.
+- **Inferred** — patterns that *might* be intentions, not yet confirmed. Hypotheses, not facts.
 
-**Clarifying.** Before recording a new intention, help the user articulate it in their own words — what it actually is, why it matters, what it would look like to live it. A short exchange is enough; don't interrogate.
+**Inferred entries can appear without a conversation.** Besides what you notice in dialogue, a background process (the kind that builds the user's profile) reads their whole archive and may add inferred intentions on its own. So you may find inferred entries you didn't write. These are not idle guesses — each is there for a reason, grounded in real signal across the user's writing, and is a meaningful read on their orientation in its own right. Treat it as a genuine, important data point even though the user hasn't endorsed it, and let it inform how you understand them. Just hold it as their *likely* orientation, not their stated one — never treat an inferred intention as confirmed until the user says so, and don't assume each one came from something they told you directly.
 
-**Recording.** When the user confirms, update the `intentions` artifact via update_artifact (full text, not a diff). Keep this structure per intention:
+**Noticing → Inferred.** When the user's writing reads like an intention surfacing — a direction they keep gravitating toward, a way of being they reach for, who they seem to be growing into, a value their choices keep orienting around — you can record it under **Inferred**, phrased tentatively and grounded in what you actually saw. (Aspirations, not appetites: an intention is a direction of becoming, not a passing want or wish.) Recording it there is non-intrusive: you don't have to interrupt the user to do it.
+
+**Validating (Inferred → Endorsed).** When the moment is right and it won't derail or intrude, mirror an inferred intention back — "I've been noticing X; does that feel like something you're actually oriented toward?" If the user confirms, help them phrase it in their own words and move it to **Endorsed**. Only the user's confirmation promotes an intention — never silently. Don't push: skip it mid-emotional-processing, at most once per conversation, never re-raise one they've declined. (A user can also state an intention outright — clarify it briefly, then record it straight into **Endorsed**.)
+
+**Recording.** Update the `intentions` artifact via update_artifact (full text, not a diff). Structure:
 
 ```
+# Endorsed
 ## <short name>
 *held since <date> — active*
 <the intention in the user's own words, 1-3 sentences>
 - <date>: <brief note on how it surfaced or evolved>
+
+# Inferred
+## <short name>
+*noticed <date> — inferred, unconfirmed*
+<the candidate intention, tentative, grounded in what was observed>
+- <date>: noticed from <what suggested it>
 ```
 
-**Tracking.** When a conversation touches a held intention, connect it explicitly and append a dated note. If the user has clearly been living one, reflect that back. When an intention has gone quiet for a long stretch and the moment is right, check in on it — without guilt-tripping.
-
-**Closing.** There are two equally good endings: the intention is *fulfilled* (or absorbed into who they are), or the user *consciously releases* it. Mark the status line accordingly (`fulfilled <date>` / `consciously released <date>`) and keep the entry — released intentions are part of the lore, not failures to be deleted.
+**Tracking & closing.** When a conversation touches an endorsed intention, connect it and append a dated note; reflect it back when they've clearly been living one; check in on a long-quiet one when the moment's right, without guilt-tripping. An endorsed intention ends two equally good ways — *fulfilled* (or absorbed into who they are) or *consciously released*; mark the status line (`fulfilled <date>` / `consciously released <date>`) and keep the entry (released ones are lore, not failures to delete). An inferred one that proves wrong can simply be dropped.
 
 <user_profile>
 An automatically maintained psychological synthesis of the user's writing and their sessions with you, updated from their entries over time. Read it for background, but you do NOT maintain it — there is no tool to edit it.
@@ -107,7 +118,7 @@ The last ~10,000 tokens of raw entries (uncompressed). This window may overlap w
 </recent_raw_data>
 
 <user_intentions>
-The user's tracked intentions (see the Intentions section). Maintain via update_artifact("intentions", ...).
+The user's tracked intentions (see the Intentions section above). Maintain via update_artifact("intentions", ...).
 {user_intentions}
 </user_intentions>
 

--- a/backend/prompts/intentions_detection.txt
+++ b/backend/prompts/intentions_detection.txt
@@ -1,0 +1,55 @@
+You are reading one person's personal archive — their journal entries, reflections, voice notes, and conversations — to surface the **intentions** running underneath it.
+
+# What an intention is
+
+An intention is one of the person's longer-running aspirations — the communication layer between their conscious goals and their subconscious orientation. Intentions are **directional, not specific**. They work *precisely because* they're vague enough for the sub-symbolic mind — the part that shapes perception and filters reality — to metabolize. Too specific and an intention collapses into a goal or a task the body can't act on; too vague and it loses its steering power. A well-calibrated intention quietly shapes the lens through which the person perceives reality — which opportunities they notice and reach for; a misaligned or incoherent one literally prevents them from seeing what would help them fulfill it.
+
+Intentions are **aspirations, not appetites** — directions of becoming, not passing wants. Look for:
+- a direction they keep gravitating toward
+- a way of being they reach for
+- who they seem to be growing into
+- a value their choices keep orienting around
+- a tension between how they're living and how they sense they want to be living
+
+These are NOT intentions:
+- concrete goals, tasks, or todos ("finish the renovation", "reply to X") — too specific
+- momentary moods, complaints, or one-off desires — not directional
+- isolated events with no through-line across the archive
+
+# Your job
+
+Read the whole archive and identify the person's load-bearing intentions — the directions their life and writing keep circling. Sort each into one of two groups:
+
+- **Endorsed** — intentions the person has **articulated themselves** in their own words: a first-person statement of what they want to become, what they're committed to, or what they're orienting their life toward — *"I want to…"*, *"I'm committed to…"*, *"what I'm orienting toward is…"* — that you can point to and quote. Default to Endorsed whenever such a quote exists; reserve Inferred for directions with no such self-articulation, and do not under-file a quotable self-stated aspiration even if it conflicts with another.
+- **Inferred** — the directions their writing keeps circling that they have **not** explicitly named as intentions. Your honest read from patterns, recurring concerns, and through-lines. Hypotheses, never presented as confirmed.
+
+Be selective overall. Surface the genuinely durable, recurring ones — typically 6–14 across both groups — not every passing theme. Each must be:
+- **distinct** — no two that are the same intention reworded
+- **grounded** — real, recurring evidence across the archive, not a single passage
+- **in or near their own language** — use their words, metaphors, and frames; never impose generic self-help phrasing
+- **calibrated** — a direction of becoming, not a task; a living orientation, not a slogan
+
+Do not fabricate or pad. If the archive is thin on a theme, leave it out. Where an intention shows tension or ambivalence, say so plainly — that ambivalence is often the signal. Ambivalence does not demote an intention to Inferred: an intention can be Endorsed *and* conflicted — name the conflict inside the Endorsed block.
+
+# Output format
+
+Output **only** the text below — no preamble, no commentary, no code fences. It will be saved verbatim as the person's Intentions artifact.
+
+# Endorsed
+## <short name, in their own words/frame, ~3–8 words>
+*active* / *fulfilled*
+<1–3 sentences stating the intention directionally, in their own language>
+- in their words: <a short quote or close paraphrase of where they explicitly articulated this as their own intention or aspiration>
+
+# Inferred
+## <short name, in their own words/frame, ~3–8 words>
+*inferred, unconfirmed*
+<1–3 sentences stating the intention tentatively and directionally, grounded in what you actually observed>
+- noticed from <the specific, recurring evidence across the archive: the themes, repeated concerns, and through-line>
+
+Repeat the `## …` block for each intention under the correct header. Use each header (`# Endorsed`, `# Inferred`) at most once, Endorsed first.
+
+# The archive
+<user_archive>
+{user_export?keep=newest&max_export_tokens=1000000}
+</user_archive>

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -388,18 +388,19 @@ def _context_artifact_fields(n):
                     "content": rc.get_content(),
                 }
         elif row.artifact_type == "user_artifact":
-            # ai_preferences is folded into UserArtifact (#158 Slice 5) and
-            # pinned as a user_artifact row — surface it under the
-            # "ai_preferences" key so the {user_ai_preferences} inline section
-            # resolves. Other kinds (memory/scratchpad/...) have no inline
-            # placeholder in QuotedContent, so they're skipped here.
+            # Inline UserArtifact kinds (memory/scratchpad/ai_preferences/
+            # intentions — UserArtifact.INLINE_KINDS) each have a
+            # {user_<kind>} placeholder in the agentic prompt, so surface the
+            # pinned content under the kind key for QuotedContent to resolve.
+            # Non-inline kinds reach the model via the artifacts index / tools
+            # and have no inline placeholder, so they're skipped here.
             art = UserArtifact.query.get(row.artifact_id)
-            if art and art.kind == "ai_preferences":
-                artifacts["ai_preferences"] = {
+            if art and art.kind in UserArtifact.INLINE_KINDS:
+                artifacts[art.kind] = {
                     "id": art.id,
                     "version_number": UserArtifact.query.filter(
                         UserArtifact.user_id == art.user_id,
-                        UserArtifact.kind == "ai_preferences",
+                        UserArtifact.kind == art.kind,
                         UserArtifact.created_at <= art.created_at,
                     ).count(),
                     "content": art.get_content(),

--- a/backend/scripts/backfill_intentions.py
+++ b/backend/scripts/backfill_intentions.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+One-time backfill: generate each user's Intentions artifact from their archive,
+using the `intentions_detection.txt` prompt.
+
+Mirrors profile generation (backend/tasks/exports.py:generate_user_profile):
+it builds the {user_export} via the same engaged-threads topology, runs a
+single LLM completion with the same prompt-too-long retry/shrink loop, and
+saves the result as a NEW version of the user's `intentions` UserArtifact —
+with the same metadata profile generation records:
+  * model        -> UserArtifact.generated_by
+  * LLM tokens   -> UserArtifact.tokens_used (total input+output)
+  * date         -> UserArtifact.created_at
+plus an APICostLog row (request_type="intentions_backfill").
+
+Non-destructive: each run creates a new artifact version; prior content stays
+in the artifact's history.
+
+Privacy: any selected user who has globally opted out of AI usage
+(default_ai_usage='none') is skipped entirely — their data is never sent to an
+LLM.
+
+Model per user: their `preferred_model` if set and supported, else Opus 4.8
+(override for all with --model).
+
+The {user_export?...} params (keep, max_export_tokens) are read straight from
+the prompt file, so the prompt is the single source of truth. With
+max_export_tokens=1000000 the first attempt may overflow the model's context;
+the retry loop catches the provider's PromptTooLongError and shrinks the budget
+proportionally (reduce_export_tokens) until it fits — up to 3 retries.
+
+Usage:
+    python backend/scripts/backfill_intentions.py                  # just user 1 (operator)
+    python backend/scripts/backfill_intentions.py 46 27 1 33 50 31 42 45
+    python backend/scripts/backfill_intentions.py --model claude-opus-4.8 1 27
+    python backend/scripts/backfill_intentions.py --dry-run 1      # build export, skip LLM + save
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from backend.app import create_app  # noqa: E402
+from backend.extensions import db  # noqa: E402
+from backend.models import User, UserArtifact, APICostLog  # noqa: E402
+from backend.routes.export_data import build_user_export_content  # noqa: E402
+from backend.utils.api_keys import get_api_keys_for_usage  # noqa: E402
+from backend.utils.cost import calculate_llm_cost_microdollars  # noqa: E402
+from backend.utils.privacy import AI_ALLOWED  # noqa: E402
+from backend.utils.placeholders import (  # noqa: E402
+    USER_EXPORT_PATTERN, parse_placeholder_params, parse_max_export_tokens,
+)
+from backend.utils.tokens import (  # noqa: E402
+    approximate_token_count, reduce_export_tokens,
+)
+from backend.llm_providers import LLMProvider, PromptTooLongError  # noqa: E402
+
+DEFAULT_MODEL = "claude-opus-4.8"
+PROMPT_FILE = "intentions_detection.txt"
+KIND = "intentions"
+MAX_RETRIES = 3
+
+
+def _resolve_model(app, user, override):
+    if override:
+        return override
+    pref = user.preferred_model
+    if pref and pref in app.config["SUPPORTED_MODELS"]:
+        return pref
+    return DEFAULT_MODEL
+
+
+def _load_template(app):
+    path = os.path.join(app.root_path, "prompts", PROMPT_FILE)
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def backfill_user(app, user, template, model_id, dry_run=False):
+    # Privacy gate: if the user has globally opted out of AI usage
+    # (default_ai_usage='none'), do not send their data to an LLM at all —
+    # skip before building the export or calling the model.
+    if user.default_ai_usage not in AI_ALLOWED:
+        print(f"  - user {user.id}: default_ai_usage='{user.default_ai_usage}' "
+              f"(opted out) — skipping, not sending data to any LLM")
+        return
+    if model_id not in app.config["SUPPORTED_MODELS"]:
+        print(f"  ! user {user.id}: unsupported model '{model_id}', skipping")
+        return
+
+    # The prompt owns the export params (keep / max_export_tokens).
+    m = USER_EXPORT_PATTERN.search(template)
+    if not m:
+        print("  ! prompt has no {user_export} placeholder, aborting")
+        return
+    params = parse_placeholder_params(m.group(1) or "")
+    max_export_tokens = parse_max_export_tokens(params.get("max_export_tokens"))
+    chronological = params.get("keep") == "oldest"
+
+    api_keys = get_api_keys_for_usage(app.config, "chat")
+
+    response = None
+    for attempt in range(MAX_RETRIES + 1):
+        # Same scope as the {user_export} placeholder: engaged-threads
+        # topology, AI-readable nodes only (ai_usage in {chat, train}).
+        export = build_user_export_content(
+            user,
+            max_tokens=max_export_tokens,
+            filter_ai_usage=True,
+            chronological_order=chronological,
+            include_strategy="engaged_threads",
+        )
+        if not export:
+            print(f"  ! user {user.id}: no AI-readable archive, skipping")
+            return
+        export_tokens = approximate_token_count(export)
+        final_prompt = USER_EXPORT_PATTERN.sub(lambda _m: export, template, count=1)
+        print(f"  user {user.id}: model={model_id}, export ~{export_tokens} tokens "
+              f"(attempt {attempt + 1}, budget={max_export_tokens})")
+        if dry_run:
+            print("    [dry-run] skipping LLM call + save")
+            return
+
+        messages = [{"role": "user",
+                     "content": [{"type": "text", "text": final_prompt}]}]
+        try:
+            response = LLMProvider.get_completion(model_id, messages, api_keys)
+            break
+        except PromptTooLongError as e:
+            if attempt == MAX_RETRIES:
+                raise
+            max_export_tokens = reduce_export_tokens(
+                max_export_tokens, e.actual_tokens, e.max_tokens,
+                export_content=export,
+            )
+            print(f"    prompt too long ({e.actual_tokens} > {e.max_tokens}); "
+                  f"retry with budget={max_export_tokens}")
+
+    content = response["content"]
+    total_tokens = response["total_tokens"]
+    input_tokens = response.get("input_tokens", 0)
+    output_tokens = response.get("output_tokens", 0)
+
+    # Cost log — same shape as profile generation.
+    cost = calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens)
+    db.session.add(APICostLog(
+        user_id=user.id, model_id=model_id, request_type="intentions_backfill",
+        input_tokens=input_tokens, output_tokens=output_tokens,
+        cost_microdollars=cost,
+    ))
+
+    # New artifact version (non-destructive). ai_usage follows the user's
+    # global default (like profile generation); privacy stays "private" (the
+    # UserArtifact default). Metadata mirrors the profile: generated_by=model,
+    # tokens_used=LLM total, created_at=now.
+    artifact = UserArtifact(
+        user_id=user.id,
+        kind=KIND,
+        title=UserArtifact.DEFAULT_KINDS.get(KIND, "Intentions"),
+        generated_by=model_id,
+        tokens_used=total_tokens,
+        ai_usage=user.default_ai_usage,
+    )
+    artifact.set_content(content)
+    db.session.add(artifact)
+    db.session.commit()
+
+    version = UserArtifact.query.filter_by(user_id=user.id, kind=KIND).count()
+    print(f"  ✓ user {user.id}: saved intentions v{version} "
+          f"({len(content)} chars, model={model_id}, "
+          f"llm_tokens={total_tokens}, cost=${cost / 1e6:.4f})")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="One-time backfill of users' Intentions artifacts.")
+    ap.add_argument("user_ids", nargs="*", type=int,
+                    help="User IDs to backfill (default: 1, the operator).")
+    ap.add_argument("--model", default=None,
+                    help="Force this model for all users (default: each user's "
+                         f"preferred_model, else {DEFAULT_MODEL}).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Build the export and stop before the LLM call + save.")
+    args = ap.parse_args()
+
+    user_ids = args.user_ids or [1]
+
+    app = create_app()
+    with app.app_context():
+        template = _load_template(app)
+        print(f"Backfilling intentions for users: {user_ids}"
+              + (" [DRY RUN]" if args.dry_run else ""))
+        for uid in user_ids:
+            user = User.query.get(uid)
+            if not user:
+                print(f"  ! user {uid} not found, skipping")
+                continue
+            model_id = _resolve_model(app, user, args.model)
+            try:
+                backfill_user(app, user, template, model_id, dry_run=args.dry_run)
+            except Exception as e:  # noqa: BLE001 — one user's failure mustn't abort the rest
+                db.session.rollback()
+                print(f"  ✗ user {uid}: FAILED — {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -49,6 +49,7 @@ USER_AI_PREFERENCES_PLACEHOLDER = "{user_ai_preferences}"
 # Placeholders for user artifacts — LLM memory/scratchpad + index (#158)
 USER_MEMORY_PLACEHOLDER = "{user_memory}"
 USER_SCRATCHPAD_PLACEHOLDER = "{user_scratchpad}"
+USER_INTENTIONS_PLACEHOLDER = "{user_intentions}"
 USER_ARTIFACTS_INDEX_PLACEHOLDER = "{user_artifacts_index}"
 
 # Within-turn retrieval loop (#158, text mode only). When the model calls one
@@ -126,8 +127,11 @@ VOICE_TOOLS = [
             "documents that survive across sessions. Built-in kinds: "
             "'memory' (durable facts and observations about the user "
             "worth remembering long-term — write here whenever you learn "
-            "something that future sessions should know) and 'scratchpad' "
-            "(your working notes for ongoing threads of work). You can "
+            "something that future sessions should know), 'scratchpad' "
+            "(your working notes for ongoing threads of work), and "
+            "'intentions' (the user's long-running aspirations you help "
+            "them clarify and track — see the Intentions section of your "
+            "instructions). You can "
             "also create new kinds for the user on request (e.g. "
             "'reading-list'). The updated_content must be the FULL new "
             "text of the artifact (not a diff) — it replaces the previous "
@@ -295,9 +299,9 @@ _ARTIFACT_KIND_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,47}$')
 # its own placeholder/tag) and therefore must be EXCLUDED from the artifacts
 # index — otherwise they'd appear both inline and in the index. Single source
 # of truth for both index-exclusion spots in get_user_artifacts_context.
-# (#202 intentions joins this when it lands — it has an ambient
-# {user_intentions} placeholder too.)
-ALWAYS_INLINE_KINDS = ("memory", "scratchpad", "ai_preferences")
+# intentions (#150/#202) has an ambient {user_intentions} placeholder, so it
+# belongs here too.
+ALWAYS_INLINE_KINDS = ("memory", "scratchpad", "ai_preferences", "intentions")
 
 # Kinds that are NOT UserArtifacts — they're separate single-row models or
 # system-managed, so update_artifact must refuse them. Without this guard the
@@ -360,8 +364,10 @@ def get_user_artifacts_context(user_id, pinned_node=None):
 
     memory = artifacts.get("memory")
     scratchpad = artifacts.get("scratchpad")
+    intentions = artifacts.get("intentions")
     memory_content = memory.get_content() if memory else ""
     scratchpad_content = scratchpad.get_content() if scratchpad else ""
+    intentions_content = intentions.get_content() if intentions else ""
 
     index_lines = []
     # Todo first — it's a curated logistics surface, not a freeform artifact.
@@ -388,7 +394,7 @@ def get_user_artifacts_context(user_id, pinned_node=None):
         desc_part = f": {desc}" if desc else ""
         index_lines.append(f"- {kind} — \"{title}\"{desc_part} (empty)")
     index_text = "\n".join(index_lines) if index_lines else "(none)"
-    return memory_content, scratchpad_content, index_text
+    return memory_content, scratchpad_content, intentions_content, index_text
 
 
 def get_user_ai_preferences_content(user_id, pinned_node=None):
@@ -1262,11 +1268,13 @@ def render_system_message(system_node, user_id):
                 user_id, pinned_node=system_node) or "")
     if (USER_MEMORY_PLACEHOLDER in text
             or USER_SCRATCHPAD_PLACEHOLDER in text
+            or USER_INTENTIONS_PLACEHOLDER in text
             or USER_ARTIFACTS_INDEX_PLACEHOLDER in text):
-        memory, scratchpad, index = get_user_artifacts_context(
+        memory, scratchpad, intentions, index = get_user_artifacts_context(
             user_id, pinned_node=system_node)
         text = text.replace(USER_MEMORY_PLACEHOLDER, memory or "")
         text = text.replace(USER_SCRATCHPAD_PLACEHOLDER, scratchpad or "")
+        text = text.replace(USER_INTENTIONS_PLACEHOLDER, intentions or "")
         text = text.replace(
             USER_ARTIFACTS_INDEX_PLACEHOLDER, index or "(none)")
     return text
@@ -1533,11 +1541,13 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             artifacts_node = (
                 _placeholder_node(USER_MEMORY_PLACEHOLDER)
                 or _placeholder_node(USER_SCRATCHPAD_PLACEHOLDER)
+                or _placeholder_node(USER_INTENTIONS_PLACEHOLDER)
                 or _placeholder_node(USER_ARTIFACTS_INDEX_PLACEHOLDER)
             )
             needs_artifacts = artifacts_node is not None
             user_memory_content = None
             user_scratchpad_content = None
+            user_intentions_content = None
             user_artifacts_index = None
 
             # Check if any node contains {quote:ID} placeholders
@@ -1589,6 +1599,7 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
 
             if needs_artifacts:
                 (user_memory_content, user_scratchpad_content,
+                 user_intentions_content,
                  user_artifacts_index) = get_user_artifacts_context(
                     user_id, pinned_node=artifacts_node
                 )
@@ -1871,6 +1882,11 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                             message_text = message_text.replace(
                                 USER_SCRATCHPAD_PLACEHOLDER,
                                 user_scratchpad_content or ""
+                            )
+                        if USER_INTENTIONS_PLACEHOLDER in message_text:
+                            message_text = message_text.replace(
+                                USER_INTENTIONS_PLACEHOLDER,
+                                user_intentions_content or ""
                             )
                         if USER_ARTIFACTS_INDEX_PLACEHOLDER in message_text:
                             message_text = message_text.replace(

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -301,7 +301,7 @@ _ARTIFACT_KIND_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,47}$')
 # of truth for both index-exclusion spots in get_user_artifacts_context.
 # intentions (#150/#202) has an ambient {user_intentions} placeholder, so it
 # belongs here too.
-ALWAYS_INLINE_KINDS = ("memory", "scratchpad", "ai_preferences", "intentions")
+ALWAYS_INLINE_KINDS = UserArtifact.INLINE_KINDS
 
 # Kinds that are NOT UserArtifacts — they're separate single-row models or
 # system-managed, so update_artifact must refuse them. Without this guard the

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -157,7 +157,7 @@ def test_list_includes_empty_defaults(app, client):
     resp = client.get("/api/artifacts/")
     assert resp.status_code == 200
     kinds = {a["kind"] for a in resp.get_json()["artifacts"]}
-    assert {"memory", "scratchpad"} <= kinds
+    assert {"memory", "scratchpad", "intentions"} <= kinds
 
 
 def test_put_creates_versions_and_get_returns_latest(app, client):
@@ -734,13 +734,14 @@ def test_artifacts_context_resolution_pinned_vs_latest(app):
         _db.session.commit()
 
         # Pinned: only memory v1 (the node binding wins)
-        memory, scratchpad, index = get_user_artifacts_context(
+        memory, scratchpad, intentions, index = get_user_artifacts_context(
             uid, pinned_node=node)
         assert memory == "mem-v1"
         assert scratchpad == ""
+        assert intentions == ""
 
         # Fallback (no pinned node): latest of everything
-        memory, scratchpad, index = get_user_artifacts_context(uid)
+        memory, scratchpad, intentions, index = get_user_artifacts_context(uid)
         assert memory == "mem-v1"
         assert scratchpad == "pad-v1"
         assert "reading-list" in index
@@ -751,7 +752,7 @@ def test_index_includes_description(app):
         uid = User.query.first().id
         _mk_artifact(uid, "reading-list", "books", title="Reading List",
                      description="Books to read")
-        _, _, index = get_user_artifacts_context(uid)
+        _, _, _, index = get_user_artifacts_context(uid)
         assert "reading-list" in index
         assert "Books to read" in index
 
@@ -762,7 +763,7 @@ def test_index_includes_todo_with_content(app):
     with app.app_context():
         uid = User.query.first().id
         _mk_todo(uid, "task one\ntask two")
-        _, _, index = get_user_artifacts_context(uid)
+        _, _, _, index = get_user_artifacts_context(uid)
         assert "todo" in index
         assert "read_todo" in index
         # No raw todo content leaks into the index line.
@@ -775,7 +776,7 @@ def test_index_lists_empty_todo(app):
     """A user with no todo row still sees the surface listed as empty."""
     with app.app_context():
         uid = User.query.first().id
-        _, _, index = get_user_artifacts_context(uid)
+        _, _, _, index = get_user_artifacts_context(uid)
         assert "todo" in index
         assert "(empty)" in index
 
@@ -785,7 +786,7 @@ def test_index_omits_ai_blocked_todo(app):
     with app.app_context():
         uid = User.query.first().id
         _mk_todo(uid, "private tasks", ai_usage="none")
-        _, _, index = get_user_artifacts_context(uid)
+        _, _, _, index = get_user_artifacts_context(uid)
         assert "read_todo" not in index
 
 
@@ -798,7 +799,7 @@ def test_index_excludes_ai_preferences(app):
         uid = User.query.first().id
         _mk_artifact(uid, "ai_preferences", "be concise",
                      title="AI Interaction Preferences")
-        _, _, index = get_user_artifacts_context(uid)
+        _, _, _, index = get_user_artifacts_context(uid)
         assert "ai_preferences" not in index
 
 
@@ -884,3 +885,30 @@ def test_backfill_ai_preferences_script(app):
         assert mod.run_backfill(execute=True) == (0, 0, 0)
         assert UserArtifact.query.filter_by(
             user_id=uid, kind="ai_preferences").count() == 2
+
+
+def test_intentions_ambient_not_in_index(app):
+    """Intentions (#150) resolve via their own placeholder and stay out
+    of the read_artifact index, like memory/scratchpad."""
+    with app.app_context():
+        uid = User.query.first().id
+        _mk_artifact(uid, "intentions",
+                     "## Write daily\n*held since 2026-06-10 — active*")
+        memory, scratchpad, intentions, index = \
+            get_user_artifacts_context(uid)
+        assert "Write daily" in intentions
+        assert "intentions" not in index
+
+
+def test_update_artifact_tool_handles_intentions(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r = _run_tool(app, "update_artifact", {
+            "kind": "intentions",
+            "updated_content": "## Morning pages\n*held since "
+                               "2026-06-10 — active*\nWrite 3 pages.",
+        }, uid)
+        assert r["status"] == "success"
+        latest = UserArtifact.latest_for(uid, "intentions")
+        assert latest.title == "Intentions"
+        assert "Morning pages" in latest.get_content()

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -717,6 +717,32 @@ def test_attach_pins_multiple_artifact_kinds(app):
             "memory", "scratchpad", "reading-list"}
 
 
+def test_inline_kinds_surface_in_node_display(app):
+    # Regression (#202): every INLINE_KIND has a {user_<kind>} placeholder in
+    # the agentic prompt, so each must surface in the node's context_artifacts
+    # for the UI to render it. The display path used to special-case
+    # ai_preferences only, leaving {user_intentions} (and memory/scratchpad)
+    # pinned + sent to the LLM but shown unrendered in the system-prompt UI.
+    from backend.utils.context_artifacts import attach_context_artifacts
+    from backend.routes.nodes import _context_artifact_fields
+    with app.app_context():
+        uid = User.query.first().id
+        for kind in UserArtifact.INLINE_KINDS:
+            _mk_artifact(uid, kind, f"{kind}-body")
+        node = Node(user_id=uid, node_type="system")
+        node.set_content(
+            "".join("{user_%s}" % k for k in UserArtifact.INLINE_KINDS))
+        _db.session.add(node)
+        _db.session.flush()
+        attach_context_artifacts(node.id, uid)
+        _db.session.commit()
+
+        fields = _context_artifact_fields(node)
+        for kind in UserArtifact.INLINE_KINDS:
+            assert kind in fields, f"{kind} missing from display fields"
+            assert fields[kind]["content"] == f"{kind}-body"
+
+
 def test_artifacts_context_resolution_pinned_vs_latest(app):
     with app.app_context():
         uid = User.query.first().id

--- a/backend/utils/context_artifacts.py
+++ b/backend/utils/context_artifacts.py
@@ -18,6 +18,7 @@ PLACEHOLDER_TO_ARTIFACT = {
     'user_ai_preferences': 'user_artifact',
     'user_memory': 'user_artifact',
     'user_scratchpad': 'user_artifact',
+    'user_intentions': 'user_artifact',
     'user_artifacts_index': 'user_artifact',
 }
 

--- a/docs/triage/ISSUE-TRIAGE-PLAN.md
+++ b/docs/triage/ISSUE-TRIAGE-PLAN.md
@@ -18,6 +18,8 @@
 
 ## 0. PROGRESS LOG (read this first)
 
+> **GitHub state snapshot (2026-06-10, reconciled against live issues):** closed-completed among triaged issues — #28, #62, #63, #66, #94, #98, #108, #128, #129, #130, #134, #135, #137, **#138**, #142, **#160**, #161, #191; closed-won't-implement — #93. In-flight PRs (NOT merged): #174 (#136), #175 (#91), #194–#201 (overnight+morning batch 2026-06-10: #85, Sentry/health, #158, #155, #187/#192, #189, Wave-6 #104/#110/#139/#179, #131). #105 and #149 dropped from the plan per maintainer (2026-06-10).
+
 **✅ Wave 1 — COMPLETE & merged to `main`/prod (2026-05-29).** All 7 issues shipped via separate PRs, each verified on staging:
 - #142 nginx Server header (PR #162) — required a manual `server_tokens off` + reload on the **VM edge nginx** (the deploy only updates the container config); done on the VM, confirmed `Server: nginx`.
 - #62 disabled-button tooltips (PR #163) — the working fix wraps the disabled button in a non-disabled `<span title=…>` (a `title` on a `disabled` element never shows).
@@ -55,8 +57,8 @@
 - ~~**Todo polish** (#94, #93)~~ — **RESOLVED 2026-05-29:** #94 fixed & closed completed; #93 closed won't-implement. Todo cluster fully closed out.
 - **Import dedupe:** #136 (re-import / snapshot overlap) — now unblocked since #137/#135 shipped; model column + dedupe key, no manual migration. *Best next pick.*
 - **Profile/UX:** #131 (app-wide toast on profile-generation completion), #101 (transparent favicon — needs brand sign-off).
-- **Security:** #91 (reserved usernames — security-critical, final single-item staging pass) + #160 (mic-denied path).
-- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
+- **Security:** #91 (reserved usernames — PR #175 open). ~~#160 (mic-denied path)~~ — **#160 CLOSED completed** (shipped as `438406c`, 2026-06-04).
+- Then the keyword cluster (#139→#149, #105) and ~~#138 (markdown rendering, isolated)~~ — **#138 CLOSED completed** (2026-06-10). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
 
 ---
 
@@ -286,7 +288,7 @@ Principle: front-load XS/S high-confidence wins, sequence shared-plumbing, isola
 **Final single-item pass:** before merging **#91** to `main`, do a dedicated single-item staging push + Chrome re-check (security-critical; a batch sibling must not mask a regression).
 **Merge:** green PRs → `main`.
 
-### Wave 7 (optional, isolated) — high-regression / decision-gated
+### Wave 7 (optional, isolated) — high-regression / decision-gated — ◐ #138 CLOSED completed (2026-06-10)
 **Issues:** #138 (markdown rendering — touches a component consumed by Feed/NodeDetail/Profile; isolate so a regression is easy to spot), and any unblocked profile-policy verification (#65 verify-and-close-or-fix-by-#32).
 **Why isolated:** #138 has broad consumer surface and theme interactions; give it its own staging cycle. Note: the todo list itself renders via `TodoItem`, not MarkdownBody, so #138's checkbox-construct changes do not affect TodoPage directly — but verify any shared markdown styling.
 **Chrome test cycle:** Seed a node exercising all markdown constructs → assert styled headings/blockquote/table/hr/lists/code in NodeDetail, Feed, Profile; toggle light/dark and re-verify; confirm checkbox-construct rendering still works where MarkdownBody is used.

--- a/docs/triage/ISSUE-TRIAGE-VERDICTS.md
+++ b/docs/triage/ISSUE-TRIAGE-VERDICTS.md
@@ -3,6 +3,7 @@
 > **Status (2026-05-29):** This file is the static triage analysis. For live progress see Section 0 of `ISSUE-TRIAGE-PLAN.md`.
 > **Shipped to prod so far:** Wave 1 — #142, #62, #63, #134, #98, #66, #28. Wave 2 (reprioritized batch) — #108, #128, #129, #130, #135, #137. (All closed as completed on GitHub.)
 > **Closed without us shipping:** #94 (toggle ~1s delay) — completed/fixed; **#93 (hit target too small) — closed WON'T-IMPLEMENT** (maintainer decision). The whole todo cluster is now resolved.
+> **State sync (2026-06-10):** also closed since: #108, #128, #129, #130, #134, #135, #137, #138, #142, #160, #161, #191. See the PLAN Section 0 snapshot for the authoritative list + in-flight PRs.
 > **Filed during the work:** #161 (Stop button reset), #172 (decide model attribution on assistant turns). Some inherited rationales below are now stale because the issue shipped or was closed won't-implement — trust the PLAN's progress log over this file where they disagree.
 > **Post-triage cluster (2026-06-04):** a tightly-interdependent prompt-caching / context-pinning family — **#191** (pin artifacts), **#187** (voice provider cache), **#188** (streaming), **#189** (OpenAI cache), **#190** (text-mode placeholder), **#192** (`backend-cache`) — filed outside this triage. See **Section 6b of `ISSUE-TRIAGE-PLAN.md`** for the dependency order + cost / latency / consistency categorization. Linchpin: **#191 first** (standalone consistency win + hard pre-condition for #187/#192).
 

--- a/frontend/src/components/ArtifactsNav.js
+++ b/frontend/src/components/ArtifactsNav.js
@@ -15,6 +15,8 @@ import { BUILTIN_KIND_ORDER, isBuiltinKind } from '../utils/artifactKinds';
 let _artifactsCache = [];
 
 const bubbleStyle = (active) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
   padding: '6px 14px',
   background: active ? 'var(--bg-card)' : 'none',
   border: '1px solid',
@@ -24,8 +26,16 @@ const bubbleStyle = (active) => ({
   fontFamily: 'var(--sans)',
   fontSize: '0.8rem',
   fontWeight: 300,
+  textDecoration: 'none',
   cursor: 'pointer',
 });
+
+// Let cmd/ctrl/shift/alt-click (and native middle-click on the <a>) fall
+// through to the browser so bubbles open in a new tab/window; intercept only
+// plain left-clicks for in-app SPA navigation (which also respects the host
+// page's unsaved-edits guard via `go`).
+const isModifiedClick = (e) =>
+  e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1;
 
 export default function ArtifactsNav({ activeKind, onNavigate, creating, children }) {
   const location = useLocation();
@@ -67,10 +77,21 @@ export default function ArtifactsNav({ activeKind, onNavigate, creating, childre
     .slice()
     .sort((a, b) => (a.title || a.kind).localeCompare(b.title || b.kind));
 
+  const onBubbleClick = (e, to) => {
+    if (isModifiedClick(e)) return; // browser handles new-tab/window
+    e.preventDefault();
+    go(to);
+  };
+
   const navBubble = (label, to) => (
-    <button key={to} onClick={() => go(to)} style={bubbleStyle(path === to)}>
+    <a
+      key={to}
+      href={to}
+      onClick={(e) => onBubbleClick(e, to)}
+      style={bubbleStyle(path === to)}
+    >
       {label}
-    </button>
+    </a>
   );
 
   const artBubble = (a) => {
@@ -80,14 +101,15 @@ export default function ArtifactsNav({ activeKind, onNavigate, creating, childre
     const active = !creating
       && (path === to || (!!activeKind && a.kind === activeKind));
     return (
-      <button
+      <a
         key={a.kind}
-        onClick={() => go(to)}
+        href={to}
+        onClick={(e) => onBubbleClick(e, to)}
         title={a.description || undefined}
         style={bubbleStyle(active)}
       >
         {a.title || a.kind}
-      </button>
+      </a>
     );
   };
 
@@ -97,21 +119,24 @@ export default function ArtifactsNav({ activeKind, onNavigate, creating, childre
       {navBubble('Todo', '/todo')}
       {pinned.map(artBubble)}
       {custom.map(artBubble)}
-      <button
-        onClick={() => go('/artifacts?create=1')}
+      <a
+        href="/artifacts?create=1"
+        onClick={(e) => onBubbleClick(e, '/artifacts?create=1')}
         title="Create a new artifact"
         style={{
+          display: 'inline-flex', alignItems: 'center',
           padding: '6px 14px',
           background: creating ? 'var(--bg-card)' : 'none',
           border: '1px solid',
           borderColor: creating ? 'var(--accent)' : 'var(--border)',
           borderRadius: '16px',
           color: creating ? 'var(--text-primary)' : 'var(--text-muted)',
-          fontFamily: 'var(--sans)', fontSize: '0.8rem', cursor: 'pointer',
+          fontFamily: 'var(--sans)', fontSize: '0.8rem',
+          textDecoration: 'none', cursor: 'pointer',
         }}
       >
         +
-      </button>
+      </a>
       {children}
     </div>
   );

--- a/frontend/src/components/InlineArtifactSection.js
+++ b/frontend/src/components/InlineArtifactSection.js
@@ -9,6 +9,7 @@ import MarkdownBody from './MarkdownBody';
  *
  * Props:
  *   type: "profile" | "todo" | "recent" | "recent_raw" | "ai_preferences"
+ *         | "memory" | "scratchpad" | "intentions"
  *   artifact: { id, version_number, content, source_tokens, covers_start, covers_end } or null
  */
 
@@ -28,6 +29,9 @@ const InlineArtifactSection = ({ type, artifact }) => {
     recent: 'Recent Context Summary',
     ai_preferences: 'AI Preferences',
     recent_raw: 'Recent Context Raw',
+    memory: 'Memory',
+    scratchpad: 'Scratchpad',
+    intentions: 'Intentions',
   };
   const label = LABELS[type] || type;
 

--- a/frontend/src/components/IntentionsView.js
+++ b/frontend/src/components/IntentionsView.js
@@ -28,7 +28,9 @@ function StatusDot({ state }) {
     fontSize: '0.55rem', fontWeight: 700, color: 'var(--bg-deep)',
   };
   if (state === 'fulfilled') {
-    return <span style={{ ...base, background: 'var(--success)' }}>✓</span>;
+    // Achieved — the brightest, fully-resolved amber, marked done (the app's
+    // checked-item vocabulary). Reads as "active, brightened into completion".
+    return <span style={{ ...base, background: 'var(--accent)' }}>✓</span>;
   }
   if (state === 'released') {
     return <span style={{ ...base, border: '1.5px solid var(--border-hover)', opacity: 0.5 }} />;
@@ -36,7 +38,7 @@ function StatusDot({ state }) {
   if (state === 'inferred') {
     return <span style={{ ...base, border: '1.5px dashed var(--border-hover)' }} />;
   }
-  // active — a held, living intention
+  // active — a held, living intention (dim amber, no marker)
   return <span style={{ ...base, background: 'var(--accent-dim)' }} />;
 }
 
@@ -108,15 +110,15 @@ export default function IntentionsView({ content }) {
         <div key={i} style={{ marginBottom: '2.5rem' }}>
           {section.title && (
             <div style={{
-              fontFamily: 'var(--sans)', fontSize: '0.68rem', fontWeight: 500,
-              letterSpacing: '0.18em', textTransform: 'uppercase',
-              color: 'var(--accent)', opacity: 0.6, marginBottom: '0.9rem',
-              display: 'flex', alignItems: 'center', gap: '8px',
+              fontFamily: 'var(--sans)', fontSize: '0.86rem', fontWeight: 600,
+              letterSpacing: '0.16em', textTransform: 'uppercase',
+              color: 'var(--accent)', opacity: 0.82, marginBottom: '1.1rem',
+              display: 'flex', alignItems: 'center', gap: '10px',
             }}>
               <span>{section.title}</span>
               <span style={{
                 color: 'var(--text-muted)', fontWeight: 300,
-                fontSize: '0.65rem', letterSpacing: '0.05em', textTransform: 'none',
+                fontSize: '0.74rem', letterSpacing: '0.05em', textTransform: 'none',
               }}>
                 {section.entries.length}
               </span>

--- a/frontend/src/components/IntentionsView.js
+++ b/frontend/src/components/IntentionsView.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import MarkdownBody from './MarkdownBody';
+import { parseIntentions, statusState } from '../utils/intentions';
+
+/**
+ * IntentionsView — structured renderer for the intentions artifact.
+ *
+ * The artifact is a flat list (one "## <name>" entry per intention, grouped
+ * under "# Endorsed" / "# Inferred" sections), so default markdown rendering
+ * turns it into a wall of large display headings. This renders it in the same
+ * visual language as the Todo list: accent uppercase section headers with a
+ * count, and clean entry rows (status dot, name, body, dated notes) separated
+ * by subtle dividers.
+ *
+ * The markdown structure is unchanged — it stays clean for the AI to maintain
+ * and editable in the raw view. If the content doesn't parse into the expected
+ * shape (no "## " entries), we fall back to plain markdown so nothing is lost.
+ *
+ * parseIntentions / statusState live in utils/intentions (no react-markdown
+ * import) so the parser is unit-testable in isolation.
+ */
+
+function StatusDot({ state }) {
+  const base = {
+    width: '15px', height: '15px', borderRadius: '50%',
+    flexShrink: 0, marginTop: '4px', boxSizing: 'border-box',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    fontSize: '0.55rem', fontWeight: 700, color: 'var(--bg-deep)',
+  };
+  if (state === 'fulfilled') {
+    return <span style={{ ...base, background: 'var(--success)' }}>✓</span>;
+  }
+  if (state === 'released') {
+    return <span style={{ ...base, border: '1.5px solid var(--border-hover)', opacity: 0.5 }} />;
+  }
+  if (state === 'inferred') {
+    return <span style={{ ...base, border: '1.5px dashed var(--border-hover)' }} />;
+  }
+  // active — a held, living intention
+  return <span style={{ ...base, background: 'var(--accent-dim)' }} />;
+}
+
+function IntentionEntry({ entry }) {
+  const state = statusState(entry.status);
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'flex-start', gap: '12px',
+      padding: '14px 0', borderBottom: '1px solid var(--bg-surface)',
+    }}>
+      <StatusDot state={state} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontFamily: 'var(--serif)', fontSize: '1.06rem', fontWeight: 500,
+          lineHeight: 1.35, color: 'var(--text-primary)',
+          opacity: state === 'released' ? 0.6 : 1,
+        }}>
+          {entry.name}
+        </div>
+        {entry.status && (
+          <div style={{
+            fontFamily: 'var(--sans)', fontSize: '0.72rem', fontWeight: 300,
+            letterSpacing: '0.03em', color: 'var(--text-muted)',
+            marginTop: '3px',
+          }}>
+            {entry.status}
+          </div>
+        )}
+        {entry.body.length > 0 && (
+          <div style={{
+            fontFamily: 'var(--sans)', fontSize: '0.9rem', fontWeight: 300,
+            lineHeight: 1.6, color: 'var(--text-secondary)', marginTop: '7px',
+          }}>
+            {entry.body.join(' ')}
+          </div>
+        )}
+        {entry.notes.length > 0 && (
+          <ul style={{
+            listStyle: 'none', margin: '8px 0 0', padding: 0,
+            borderLeft: '1px solid var(--border)', paddingLeft: '12px',
+          }}>
+            {entry.notes.map((n, i) => (
+              <li key={i} style={{
+                fontFamily: 'var(--sans)', fontSize: '0.78rem', fontWeight: 300,
+                lineHeight: 1.55, color: 'var(--text-muted)', marginBottom: '3px',
+              }}>
+                {n}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function IntentionsView({ content }) {
+  const sections = parseIntentions(content);
+  const hasEntries = sections.some((s) => s.entries.length > 0);
+
+  // Format drift / unexpected content — don't lose anything, render raw.
+  if (!hasEntries) {
+    return <MarkdownBody>{content}</MarkdownBody>;
+  }
+
+  return (
+    <div>
+      {sections.map((section, i) => (
+        <div key={i} style={{ marginBottom: '2.5rem' }}>
+          {section.title && (
+            <div style={{
+              fontFamily: 'var(--sans)', fontSize: '0.68rem', fontWeight: 500,
+              letterSpacing: '0.18em', textTransform: 'uppercase',
+              color: 'var(--accent)', opacity: 0.6, marginBottom: '0.9rem',
+              display: 'flex', alignItems: 'center', gap: '8px',
+            }}>
+              <span>{section.title}</span>
+              <span style={{
+                color: 'var(--text-muted)', fontWeight: 300,
+                fontSize: '0.65rem', letterSpacing: '0.05em', textTransform: 'none',
+              }}>
+                {section.entries.length}
+              </span>
+            </div>
+          )}
+          {section.entries.map((entry, j) => (
+            <IntentionEntry key={j} entry={entry} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/IntentionsView.js
+++ b/frontend/src/components/IntentionsView.js
@@ -52,8 +52,8 @@ function IntentionEntry({ entry }) {
       <StatusDot state={state} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{
-          fontFamily: 'var(--serif)', fontSize: '1.06rem', fontWeight: 500,
-          lineHeight: 1.35, color: 'var(--text-primary)',
+          fontFamily: 'var(--serif)', fontSize: '1.16rem', fontWeight: 600,
+          lineHeight: 1.3, color: 'var(--text-primary)',
           opacity: state === 'released' ? 0.6 : 1,
         }}>
           {entry.name}

--- a/frontend/src/components/IntentionsView.js
+++ b/frontend/src/components/IntentionsView.js
@@ -54,6 +54,11 @@ function IntentionEntry({ entry }) {
         <div style={{
           fontFamily: 'var(--serif)', fontSize: '1.16rem', fontWeight: 600,
           lineHeight: 1.3, color: 'var(--text-primary)',
+          // Cormorant is a high-contrast display serif; at this small size the
+          // app's global grayscale font-smoothing thins its hairlines on the
+          // dark bg. A same-color hairline shadow fattens the strokes just
+          // enough to render crisply without changing the letterforms.
+          textShadow: '0 0 0.45px currentColor',
           opacity: state === 'released' ? 0.6 : 1,
         }}>
           {entry.name}

--- a/frontend/src/components/QuotedContent.js
+++ b/frontend/src/components/QuotedContent.js
@@ -3,11 +3,12 @@ import MarkdownBody from './MarkdownBody';
 import InlineQuoteBubble from './InlineQuoteBubble';
 import InlineArtifactSection from './InlineArtifactSection';
 
-// Pattern to match {user_profile}, {user_todo}, {user_recent}, {user_recent_raw}, {user_ai_preferences} placeholders
+// Pattern to match {user_profile}, {user_todo}, {user_recent}, {user_recent_raw},
+// {user_ai_preferences}, {user_memory}, {user_scratchpad}, {user_intentions} placeholders
 // NOTE: recent_raw must come before recent in the alternation to avoid partial matching
-const ARTIFACT_PATTERN = /\{user_(profile|todo|recent_raw|recent|ai_preferences)\}/g;
+const ARTIFACT_PATTERN = /\{user_(profile|todo|recent_raw|recent|ai_preferences|memory|scratchpad|intentions)\}/g;
 // Combined pattern for splitting (quotes + artifacts)
-const COMBINED_PATTERN = /(\{quote:\d+\}|\{user_(?:profile|todo|recent_raw|recent|ai_preferences)\})/g;
+const COMBINED_PATTERN = /(\{quote:\d+\}|\{user_(?:profile|todo|recent_raw|recent|ai_preferences|memory|scratchpad|intentions)\})/g;
 
 /**
  * QuotedContent - Renders content with inline quote previews.
@@ -53,7 +54,7 @@ const QuotedContent = ({ content, quotes, contextArtifacts, onQuoteClick, onChec
     }
 
     // Check if this part is an artifact placeholder
-    const artifactMatch = part.match(/^\{user_(profile|todo|recent_raw|recent|ai_preferences)\}$/);
+    const artifactMatch = part.match(/^\{user_(profile|todo|recent_raw|recent|ai_preferences|memory|scratchpad|intentions)\}$/);
     if (artifactMatch) {
       segments.push({ type: 'artifact', artifactType: artifactMatch[1] });
       continue;

--- a/frontend/src/pages/ArtifactsPage.js
+++ b/frontend/src/pages/ArtifactsPage.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import MarkdownBody from '../components/MarkdownBody';
+import IntentionsView from '../components/IntentionsView';
 import api from '../api';
 import ArtifactsNav from '../components/ArtifactsNav';
 import VersionHistoryDrawer from '../components/VersionHistoryDrawer';
@@ -17,42 +18,6 @@ const KIND_BLURBS = {
 
 const titleFromKind = (k) =>
   k.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-
-// The intentions artifact is a structured list (# Endorsed / # Inferred
-// sections, each "## <name>" an entry with a status line + dated notes).
-// MarkdownBody renders h1/h2 as large serif display headings, which turns the
-// list into a wall of giant headings. Scope smaller, list-friendly heading
-// sizes to this artifact only — sections become quiet uppercase dividers,
-// names become readable serif lines. !important is required because
-// MarkdownBody sets heading sizes as inline styles. The markdown structure is
-// unchanged (stays clean for the AI to maintain and readable in raw/edit view).
-const INTENTIONS_STYLE = `
-.loore-intentions h1 {
-  font-family: var(--sans) !important;
-  font-size: 0.78rem !important;
-  font-weight: 600 !important;
-  line-height: 1.4 !important;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-muted) !important;
-  margin: 2.2em 0 0.9em !important;
-  padding-bottom: 0.4em;
-  border-bottom: 1px solid var(--border);
-}
-.loore-intentions h1:first-child { margin-top: 0.2em !important; }
-.loore-intentions h2 {
-  font-family: var(--serif) !important;
-  font-size: 1.08rem !important;
-  font-weight: 600 !important;
-  line-height: 1.35 !important;
-  color: var(--text-primary) !important;
-  margin: 1.4em 0 0.15em !important;
-}
-.loore-intentions h2 + p { margin-top: 0.15em; }
-.loore-intentions p { margin: 0.3em 0; }
-.loore-intentions ul { margin: 0.35em 0 0.2em; padding-left: 1.2em; }
-.loore-intentions li { margin: 0.15em 0; font-size: 0.88rem; color: var(--text-muted); }
-`;
 
 export default function ArtifactsPage() {
   const { kind: kindParam } = useParams();
@@ -397,15 +362,13 @@ export default function ArtifactsPage() {
       {/* Rendered content */}
       {active && !editing && (
         active.content ? (
-          <div
-            className={`loore-profile${active.kind === 'intentions' ? ' loore-intentions' : ''}`}
-            style={{
-              fontFamily: 'var(--sans)', fontSize: '0.92rem', fontWeight: 300,
-              color: 'var(--text-secondary)', lineHeight: 1.7,
-            }}
-          >
-            {active.kind === 'intentions' && <style>{INTENTIONS_STYLE}</style>}
-            <MarkdownBody>{active.content}</MarkdownBody>
+          <div className="loore-profile" style={{
+            fontFamily: 'var(--sans)', fontSize: '0.92rem', fontWeight: 300,
+            color: 'var(--text-secondary)', lineHeight: 1.7,
+          }}>
+            {active.kind === 'intentions'
+              ? <IntentionsView content={active.content} />
+              : <MarkdownBody>{active.content}</MarkdownBody>}
           </div>
         ) : (
           <div style={{ textAlign: 'center', padding: '40px 0' }}>

--- a/frontend/src/pages/ArtifactsPage.js
+++ b/frontend/src/pages/ArtifactsPage.js
@@ -12,6 +12,7 @@ import { formatDate } from '../utils/date';
 const KIND_BLURBS = {
   memory: "Durable facts the AI remembers about you across sessions. It updates this on its own as you talk.",
   scratchpad: "The AI's working notes for ongoing threads — where it left off, open questions.",
+  intentions: "Your longer-running aspirations — noticed, clarified, and tracked together with the AI. Fulfilled or consciously released, both count.",
 };
 
 const titleFromKind = (k) =>

--- a/frontend/src/pages/ArtifactsPage.js
+++ b/frontend/src/pages/ArtifactsPage.js
@@ -18,6 +18,42 @@ const KIND_BLURBS = {
 const titleFromKind = (k) =>
   k.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 
+// The intentions artifact is a structured list (# Endorsed / # Inferred
+// sections, each "## <name>" an entry with a status line + dated notes).
+// MarkdownBody renders h1/h2 as large serif display headings, which turns the
+// list into a wall of giant headings. Scope smaller, list-friendly heading
+// sizes to this artifact only — sections become quiet uppercase dividers,
+// names become readable serif lines. !important is required because
+// MarkdownBody sets heading sizes as inline styles. The markdown structure is
+// unchanged (stays clean for the AI to maintain and readable in raw/edit view).
+const INTENTIONS_STYLE = `
+.loore-intentions h1 {
+  font-family: var(--sans) !important;
+  font-size: 0.78rem !important;
+  font-weight: 600 !important;
+  line-height: 1.4 !important;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted) !important;
+  margin: 2.2em 0 0.9em !important;
+  padding-bottom: 0.4em;
+  border-bottom: 1px solid var(--border);
+}
+.loore-intentions h1:first-child { margin-top: 0.2em !important; }
+.loore-intentions h2 {
+  font-family: var(--serif) !important;
+  font-size: 1.08rem !important;
+  font-weight: 600 !important;
+  line-height: 1.35 !important;
+  color: var(--text-primary) !important;
+  margin: 1.4em 0 0.15em !important;
+}
+.loore-intentions h2 + p { margin-top: 0.15em; }
+.loore-intentions p { margin: 0.3em 0; }
+.loore-intentions ul { margin: 0.35em 0 0.2em; padding-left: 1.2em; }
+.loore-intentions li { margin: 0.15em 0; font-size: 0.88rem; color: var(--text-muted); }
+`;
+
 export default function ArtifactsPage() {
   const { kind: kindParam } = useParams();
   const navigate = useNavigate();
@@ -361,10 +397,14 @@ export default function ArtifactsPage() {
       {/* Rendered content */}
       {active && !editing && (
         active.content ? (
-          <div className="loore-profile" style={{
-            fontFamily: 'var(--sans)', fontSize: '0.92rem', fontWeight: 300,
-            color: 'var(--text-secondary)', lineHeight: 1.7,
-          }}>
+          <div
+            className={`loore-profile${active.kind === 'intentions' ? ' loore-intentions' : ''}`}
+            style={{
+              fontFamily: 'var(--sans)', fontSize: '0.92rem', fontWeight: 300,
+              color: 'var(--text-secondary)', lineHeight: 1.7,
+            }}
+          >
+            {active.kind === 'intentions' && <style>{INTENTIONS_STYLE}</style>}
             <MarkdownBody>{active.content}</MarkdownBody>
           </div>
         ) : (

--- a/frontend/src/utils/intentions.js
+++ b/frontend/src/utils/intentions.js
@@ -1,0 +1,63 @@
+// Pure parsing helpers for the intentions artifact, kept free of any
+// component / react-markdown imports so they're unit-testable in isolation.
+
+// Parse the intentions markdown into [{ title, entries: [{ name, status,
+// body, notes }] }]. Tolerant of missing status/body, a leading section-less
+// run of entries, and arbitrary section titles.
+export function parseIntentions(md) {
+  const lines = (md || '').split('\n');
+  const sections = [];
+  let section = null;
+  let entry = null;
+
+  const flushEntry = () => {
+    if (entry && section) section.entries.push(entry);
+    entry = null;
+  };
+  const ensureSection = (title) => {
+    section = { title, entries: [] };
+    sections.push(section);
+  };
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    const h1 = raw.match(/^#\s+(.+)/);
+    const h2 = raw.match(/^##\s+(.+)/);
+    const note = raw.match(/^\s*[-*]\s+(.+)/);
+
+    if (h2) {
+      flushEntry();
+      if (!section) ensureSection('');
+      entry = { name: h2[1].trim(), status: '', body: [], notes: [] };
+      continue;
+    }
+    if (h1) {
+      flushEntry();
+      ensureSection(h1[1].trim());
+      continue;
+    }
+    if (!entry) continue;
+    if (note) {
+      entry.notes.push(note[1].trim());
+      continue;
+    }
+    if (!line) continue;
+    const italic = line.match(/^\*(.+)\*$/) || line.match(/^_(.+)_$/);
+    if (italic && !entry.status && entry.body.length === 0) {
+      entry.status = italic[1].trim();
+    } else {
+      entry.body.push(line);
+    }
+  }
+  flushEntry();
+  return sections;
+}
+
+// Derive a coarse state from the status line for the dot styling.
+export function statusState(status) {
+  const s = (status || '').toLowerCase();
+  if (s.includes('fulfilled')) return 'fulfilled';
+  if (s.includes('released')) return 'released';
+  if (s.includes('inferred') || s.includes('unconfirmed')) return 'inferred';
+  return 'active';
+}

--- a/frontend/src/utils/intentions.test.js
+++ b/frontend/src/utils/intentions.test.js
@@ -1,0 +1,45 @@
+import { parseIntentions } from './intentions';
+
+const SAMPLE = `# Endorsed
+## Help people become more intentional through Loore
+*held since early — active*
+The meta-intention.
+
+## Get Pája to see the cage
+*held since early — fulfilled 2026-06-25*
+Not to punish, but because without her acknowledgment the system can't move.
+- 2026-06-25: User confirmed this is fulfilled.
+
+# Inferred
+## Build a life that is coherent regardless of the marriage
+*noticed early — inferred, unconfirmed*
+Valeč, Loore, the spiritual path — none depend on Pája.`;
+
+test('splits into Endorsed/Inferred sections with entry counts', () => {
+  const sections = parseIntentions(SAMPLE);
+  expect(sections.map((s) => s.title)).toEqual(['Endorsed', 'Inferred']);
+  expect(sections[0].entries).toHaveLength(2);
+  expect(sections[1].entries).toHaveLength(1);
+});
+
+test('parses name, status, body and dated notes per entry', () => {
+  const [endorsed] = parseIntentions(SAMPLE);
+  const cage = endorsed.entries[1];
+  expect(cage.name).toBe('Get Pája to see the cage');
+  expect(cage.status).toBe('held since early — fulfilled 2026-06-25');
+  expect(cage.body.join(' ')).toContain("can't move");
+  expect(cage.notes).toEqual(['2026-06-25: User confirmed this is fulfilled.']);
+});
+
+test('an entry with only a status line has empty body and notes', () => {
+  const [endorsed] = parseIntentions(SAMPLE);
+  const meta = endorsed.entries[0];
+  expect(meta.status).toBe('held since early — active');
+  expect(meta.body).toEqual(['The meta-intention.']);
+  expect(meta.notes).toEqual([]);
+});
+
+test('content with no entries returns no parsed entries (falls back to markdown)', () => {
+  const sections = parseIntentions('just some freeform text, no headings');
+  expect(sections.some((s) => s.entries.length > 0)).toBe(false);
+});


### PR DESCRIPTION
## ⚠️ Stacked PR — merge AFTER #200/#201
Same-file stack (agentic.txt, llm_completion.py).

## Summary
First implementation of #150, built per the "machinery final, prompt is a v0 for maintainer tuning" division of labor.

- **`intentions` is a third default artifact kind** — versioned, encrypted, per-session pinned (#191), exported, editable at /artifacts, written by the LLM through the existing `update_artifact` tool. **Zero new plumbing** — the #158 substrate carries it.
- **Ambient via its own `{user_intentions}` placeholder** (not behind `read_artifact`): detection only works if the tracked list is always in context, mirroring memory/scratchpad.
- **v0 prompt section** (`agentic.txt` — *this is the part to tune*): tentative detection of surfacing aspirations (at most once per conversation, never mid-emotional-processing, never re-raising a declined theme), clarification in the user's own words before recording, per-intention structure with status line + dated notes, conversational tracking, and the issue's two equally-valid endings — **fulfilled** or **consciously released** (entries are kept, not deleted: released intentions are part of the lore).

Also rides on this branch: triage-doc reconciliation against live GitHub state (#138/#160 marked closed; authoritative snapshot added).

## Verification
4 new/updated tests (default-kind exposure, ambient resolution + index exclusion, tool write path); 455 green; frontend builds. Live staging conversation transcript in the PR comment below.

## Note on the issue's validation caveat
#150 suggested validating the clarification pattern cheaply before building. The build cost collapsed to ~a prompt section thanks to #158, which inverts the economics: the staging conversation below *is* the validation, and tuning happens in production prompt text rather than a throwaway prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)