### PR TITLE
fix(#124): resumed recordings no longer drop pre-resume audio

### DIFF
--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -10,7 +10,9 @@ import shutil
 from backend.utils.audio_storage import move_draft_audio_to_node_dir
 from backend.utils.encryption import encrypt_file
 from backend.utils.llm_nodes import pick_model_for_generation
-from backend.utils.webm_utils import persist_init_segment
+from backend.utils.webm_utils import (
+    chunk_is_init_bearing, persist_init_segment,
+)
 
 drafts_bp = Blueprint("drafts_bp", __name__)
 
@@ -646,6 +648,29 @@ def upload_streaming_chunk(session_id):
         # if persist_init_segment raised, we don't want a half-committed
         # mime that'd survive a future early-commit refactor.
         draft.streaming_mime_type = form_mime_family
+    elif chunk_is_init_bearing(chunk_path):
+        # A chunk N>0 that carries its own stream header came from a
+        # fresh MediaRecorder — the user resumed a recovered recording
+        # (#124). Persist its init under an index-suffixed name so
+        # transcription can split the batch into subsessions instead of
+        # binary-concatenating incompatible streams (which silently
+        # drops the pre-resume audio at remux).
+        #
+        # Unlike chunk 0 we do NOT reject the upload on extraction
+        # failure: the chunk's audio is real and already streamed once —
+        # rejecting would lose it outright, while keeping it preserves
+        # at worst today's behavior for this subsession.
+        try:
+            persist_init_segment(chunk_path, chunk_dir, index=chunk_index)
+            current_app.logger.info(
+                f"Session {session_id}: chunk {chunk_index} opens a new "
+                f"subsession (resumed recording); init persisted"
+            )
+        except (ValueError, OSError) as exc:
+            current_app.logger.error(
+                f"Failed to extract subsession init from chunk "
+                f"{chunk_index} of session {session_id}: {exc}"
+            )
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -624,9 +624,11 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
 
         chunk_dir = audio_storage_root / f"drafts/{draft.user_id}/{session_id}"
 
-        # Collect and decrypt chunk files
+        # Collect and decrypt chunk files (keyed by index — sub-batch
+        # partitioning below needs per-chunk paths, #124)
         temp_files = []
-        decrypted_paths = []
+        paths_by_idx = {}
+        merged_by_subbatch = []  # [(sub_indices, merged_path)] (#124)
 
         try:
             for idx in sorted(chunk_indices):
@@ -637,96 +639,147 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 if enc_path.exists():
                     temp_path = decrypt_file_to_temp(str(enc_path))
                     temp_files.append(temp_path)
-                    decrypted_paths.append(temp_path)
+                    paths_by_idx[idx] = temp_path
                 elif chunk_path.exists():
-                    decrypted_paths.append(str(chunk_path))
+                    paths_by_idx[idx] = str(chunk_path)
                 else:
                     logger.warning(
                         f"Chunk file not found for session {session_id}, "
                         f"index {idx}: {chunk_path}"
                     )
 
-            if not decrypted_paths:
+            if not paths_by_idx:
                 raise FileNotFoundError(
                     f"No chunk files found for session {session_id}, "
                     f"indices {chunk_indices}"
                 )
 
-            # If this batch doesn't include chunk 0, decrypt the cached
-            # init segment so concat_fragmented_media can prepend it —
-            # only chunk 0 carries the format-specific header (WebM:
-            # EBML/Segment/Tracks; fMP4: ftyp+moov), so later batches
-            # would otherwise be header-less fragment data that ffmpeg
-            # can't remux.
-            first_chunk = min(chunk_indices) if chunk_indices else 0
-            init_segment_path = None
-            if first_chunk > 0:
-                init_enc = chunk_dir / f"init{ext}.enc"
-                init_plain = chunk_dir / f"init{ext}"
-                if init_enc.exists():
-                    init_segment_path = decrypt_file_to_temp(str(init_enc))
-                    temp_files.append(init_segment_path)
-                elif init_plain.exists():
-                    init_segment_path = str(init_plain)
+            # Partition into subsessions (#124): a resumed recording's
+            # chunks come from a fresh MediaRecorder whose stream is not
+            # byte-concat-compatible with the chunks before it. The
+            # upload route persists `init.{N}{ext}` for every chunk N>0
+            # that opens a new stream; those N are split points. Each
+            # sub-batch is merged + transcribed independently and the
+            # transcripts are joined — instead of one merged file with a
+            # second init mid-stream, which made ffmpeg silently drop
+            # everything before it.
+            present = sorted(paths_by_idx)
+            boundaries = {
+                idx for idx in present
+                if idx > 0 and (
+                    (chunk_dir / f"init.{idx}{ext}").exists()
+                    or (chunk_dir / f"init.{idx}{ext}.enc").exists()
+                )
+            }
+            sub_batches = []
+            current = []
+            for idx in present:
+                if idx in boundaries and current:
+                    sub_batches.append(current)
+                    current = []
+                current.append(idx)
+            if current:
+                sub_batches.append(current)
+            if len(sub_batches) > 1:
+                logger.info(
+                    f"Session {session_id}: batch {min(present)}-"
+                    f"{max(present)} spans {len(sub_batches)} subsessions "
+                    f"(boundaries at {sorted(boundaries)})"
+                )
+
+            def _resolve_init(sub_indices):
+                """Init segment for a sub-batch, or None.
+
+                A sub-batch starting at a subsession boundary N uses its
+                own `init.{N}{ext}`; a sub-batch starting at chunk 0
+                needs none (chunk 0 self-carries the header); any other
+                start uses the legacy chunk-0 init (`init{ext}`).
+                """
+                start = sub_indices[0]
+                if start in boundaries:
+                    candidates = [
+                        chunk_dir / f"init.{start}{ext}.enc",
+                        chunk_dir / f"init.{start}{ext}",
+                    ]
+                elif start > 0:
+                    candidates = [
+                        chunk_dir / f"init{ext}.enc",
+                        chunk_dir / f"init{ext}",
+                    ]
                 else:
-                    logger.warning(
-                        f"No init segment found for session {session_id} "
-                        f"batch starting at chunk {first_chunk}; "
-                        "concat will likely fail"
-                    )
+                    return None
+                for cand in candidates:
+                    if not cand.exists():
+                        continue
+                    if cand.suffix == '.enc':
+                        path = decrypt_file_to_temp(str(cand))
+                        temp_files.append(path)
+                        return path
+                    return str(cand)
+                logger.warning(
+                    f"No init segment found for session {session_id} "
+                    f"sub-batch starting at chunk {start}; "
+                    "concat will likely fail"
+                )
+                return None
 
-            # Merge MediaRecorder fragments into a single valid file.
-            # Binary-append the fragments and remux — see
-            # concat_fragmented_media for the full rationale. Same code
-            # path handles both Matroska/WebM and fMP4.
-            merged_path = concat_fragmented_media(
-                decrypted_paths,
-                init_segment_path=init_segment_path,
-                output_suffix=ext,
-            )
-            merge_input = merged_path
+            # Merge + transcribe each subsession independently (#124).
+            # Binary-append the fragments and remux per sub-batch — see
+            # concat_fragmented_media for the rationale. Same code path
+            # handles both Matroska/WebM and fMP4.
+            api_key = get_openai_chat_key(flask_app.config)
+            if not api_key:
+                raise ValueError("OpenAI API key not configured")
+            client = OpenAI(api_key=api_key)
 
-            # Compress if needed (no-op for already-compressed WebM/MP4)
-            merge_input_path = pathlib.Path(merge_input)
-            processed_path = compress_audio_if_needed(merge_input_path, logger)
+            transcripts = []
+            batch_duration_sec = 0.0
+            for sub_indices in sub_batches:
+                merged_path = concat_fragmented_media(
+                    [paths_by_idx[i] for i in sub_indices],
+                    init_segment_path=_resolve_init(sub_indices),
+                    output_suffix=ext,
+                )
+                merged_by_subbatch.append((sub_indices, merged_path))
 
-            # Measure duration for cost tracking
-            batch_duration_sec = get_audio_duration(processed_path, logger)
+                # Compress if needed (no-op for compressed WebM/MP4)
+                merge_input_path = pathlib.Path(merged_path)
+                processed_path = compress_audio_if_needed(
+                    merge_input_path, logger)
 
-            try:
-                # Transcribe via gpt-4o-transcribe
-                api_key = get_openai_chat_key(flask_app.config)
-                if not api_key:
-                    raise ValueError(
-                        "OpenAI API key not configured"
-                    )
+                batch_duration_sec += get_audio_duration(
+                    processed_path, logger)
 
-                client = OpenAI(api_key=api_key)
-                with open(processed_path, "rb") as audio_file:
-                    # Pass an explicit (name, file) tuple so the API
-                    # infers the format from `ext` rather than from the
-                    # tempfile's auto-generated suffix.
-                    resp = client.audio.transcriptions.create(
-                        model="gpt-4o-transcribe",
-                        file=(f"audio{ext}", audio_file),
-                        response_format="text"
-                    )
-
-                    if hasattr(resp, "text"):
-                        transcript = resp.text
-                    elif isinstance(resp, dict):
-                        transcript = (
-                            resp.get("text") or resp.get("transcript") or ""
+                try:
+                    with open(processed_path, "rb") as audio_file:
+                        # Explicit (name, file) tuple so the API infers
+                        # the format from `ext` rather than the
+                        # tempfile's auto-generated suffix.
+                        resp = client.audio.transcriptions.create(
+                            model="gpt-4o-transcribe",
+                            file=(f"audio{ext}", audio_file),
+                            response_format="text"
                         )
-                    else:
-                        transcript = str(resp)
 
-            finally:
-                if processed_path != merge_input_path:
-                    try:
-                        os.unlink(processed_path)
-                    except Exception:
-                        pass
+                        if hasattr(resp, "text"):
+                            sub_text = resp.text
+                        elif isinstance(resp, dict):
+                            sub_text = (
+                                resp.get("text")
+                                or resp.get("transcript") or ""
+                            )
+                        else:
+                            sub_text = str(resp)
+                    if sub_text and sub_text.strip():
+                        transcripts.append(sub_text.strip())
+                finally:
+                    if processed_path != merge_input_path:
+                        try:
+                            os.unlink(processed_path)
+                        except Exception:
+                            pass
+
+            transcript = "\n\n".join(transcripts)
 
             # Store transcript in the first chunk of the batch;
             # mark all batch chunks as completed
@@ -760,23 +813,26 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 )
                 db.session.add(cost_log)
 
-            # Encrypt the merged audio and store as a batch file;
-            # delete individual chunk .enc files.
+            # Encrypt the merged audio and store as batch files — one
+            # per subsession (#124); delete individual chunk .enc files
+            # only for sub-batches whose merge succeeded.
             # IMPORTANT: do this BEFORE committing chunk status to DB,
             # because finalize_draft_streaming polls for completed chunks
             # and may move/delete the directory once all are done.
-            if merged_path and os.path.exists(merged_path):
+            from backend.utils.encryption import encrypt_file
+            for sub_indices, sub_merged in merged_by_subbatch:
+                if not (sub_merged and os.path.exists(sub_merged)):
+                    continue
                 batch_filename = (
-                    f"batch_{min(chunk_indices):04d}-"
-                    f"{max(chunk_indices):04d}{ext}"
+                    f"batch_{min(sub_indices):04d}-"
+                    f"{max(sub_indices):04d}{ext}"
                 )
                 batch_dest = chunk_dir / batch_filename
-                shutil.move(merged_path, str(batch_dest))
-                from backend.utils.encryption import encrypt_file
+                shutil.move(sub_merged, str(batch_dest))
                 encrypt_file(str(batch_dest))
 
-                # Delete individual encrypted chunk files in the batch
-                for idx in chunk_indices:
+                # Delete individual encrypted chunk files in the sub-batch
+                for idx in sub_indices:
                     for chunk_name in [
                         f"chunk_{idx:04d}{ext}.enc",
                         f"chunk_{idx:04d}{ext}",
@@ -874,12 +930,14 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                     os.unlink(tf)
                 except Exception:
                     pass
-            # Clean up merged file if still around
-            if merged_path and os.path.exists(merged_path):
-                try:
-                    os.unlink(merged_path)
-                except Exception:
-                    pass
+            # Clean up any merged files still around (one per
+            # subsession, #124; moved away on success)
+            for _, sub_merged in merged_by_subbatch:
+                if sub_merged and os.path.exists(sub_merged):
+                    try:
+                        os.unlink(sub_merged)
+                    except Exception:
+                        pass
 
 
 class DraftFinalizationTask(Task):

--- a/backend/tests/test_resume_subsessions.py
+++ b/backend/tests/test_resume_subsessions.py
@@ -1,0 +1,220 @@
+"""Tests for resumed-recording subsession handling (#124).
+
+A recording resumed after a refresh comes from a fresh MediaRecorder
+whose stream is not byte-concat-compatible with earlier chunks. These
+tests cover the pieces that make the fix: init-bearing detection,
+suffixed init persistence, and sub-batch partitioning/init resolution
+inside transcribe_chunk_batch (exercised with synthetic WebM/MP4-shaped
+fixtures and a mocked transcription API — no ffmpeg, no OpenAI).
+"""
+import os
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+import pytest  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.utils.webm_utils import (  # noqa: E402
+    WEBM_MAGIC, chunk_is_init_bearing, init_segment_name,
+)
+
+# fMP4 chunk head: [4-byte size]["ftyp"]...; WebM: EBML magic first.
+MP4_INIT_HEAD = b"\x00\x00\x00\x20ftypisom-rest-of-box"
+WEBM_INIT_HEAD = WEBM_MAGIC + b"\x9fB\x86\x81\x01-rest"
+FRAGMENT_HEAD = b"\x00\x00\x01\x10moofdata-no-init-here"
+
+
+def _write(tmp_path, name, data):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return p
+
+
+# ── Detection ────────────────────────────────────────────────────────────
+
+def test_detects_mp4_and_webm_init_chunks(tmp_path):
+    assert chunk_is_init_bearing(_write(tmp_path, "a.mp4", MP4_INIT_HEAD))
+    assert chunk_is_init_bearing(_write(tmp_path, "a.webm", WEBM_INIT_HEAD))
+
+
+def test_fragment_chunks_not_init_bearing(tmp_path):
+    assert not chunk_is_init_bearing(
+        _write(tmp_path, "b.mp4", FRAGMENT_HEAD))
+    assert not chunk_is_init_bearing(_write(tmp_path, "tiny.webm", b"abc"))
+    assert not chunk_is_init_bearing(tmp_path / "missing.webm")
+
+
+def test_init_segment_name_suffixing():
+    assert init_segment_name(".webm") == "init.webm"
+    assert init_segment_name(".mp4", 7) == "init.7.mp4"
+
+
+# ── Batch partitioning inside transcribe_chunk_batch ─────────────────────
+
+def _run_batch(tmp_path, monkeypatch, chunk_indices, boundary_indices,
+               ext=".webm"):
+    """Run transcribe_chunk_batch against synthetic fixtures.
+
+    Returns (concat_calls, stored_text) where concat_calls captures
+    (paths, init_segment_path) per sub-batch merge.
+    """
+    from flask import Flask
+    from backend.extensions import db as _db
+    from backend.models import User, Draft, NodeTranscriptChunk
+
+    _GLUE = ("backend.celery_app", "backend.tasks.streaming_transcription")
+    saved = {k: sys.modules.get(k) for k in _GLUE}
+    fake_celery_app = MagicMock()
+
+    # @celery.task(...) must return the real function, not a MagicMock,
+    # so the test can invoke the task body directly.
+    def _passthrough_task(*args, **kwargs):
+        def deco(f):
+            return f
+        return deco
+    fake_celery_app.celery.task = _passthrough_task
+
+    sys.modules["backend.celery_app"] = fake_celery_app
+    sys.modules.pop("backend.tasks.streaming_transcription", None)
+    import backend.tasks.streaming_transcription as st
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    fake_celery_app.flask_app = app
+    st.flask_app = app
+
+    session_id = "sess-124"
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.flush()
+        draft = Draft(user_id=user.id, session_id=session_id,
+                      streaming_status='recording',
+                      streaming_mime_type=(
+                          "audio/mp4" if ext == ".mp4" else "audio/webm"))
+        draft.set_content("")
+        _db.session.add(draft)
+        for idx in chunk_indices:
+            chunk = NodeTranscriptChunk(
+                session_id=session_id, chunk_index=idx, status='stored')
+            _db.session.add(chunk)
+        _db.session.commit()
+
+        # Fixture files: plaintext chunks + suffixed inits at boundaries
+        chunk_dir = tmp_path / f"drafts/{user.id}/{session_id}"
+        chunk_dir.mkdir(parents=True)
+        for idx in chunk_indices:
+            head = (MP4_INIT_HEAD if ext == ".mp4" else WEBM_INIT_HEAD) \
+                if (idx == 0 or idx in boundary_indices) else FRAGMENT_HEAD
+            (chunk_dir / f"chunk_{idx:04d}{ext}").write_bytes(
+                head + b"payload%d" % idx)
+        (chunk_dir / f"init{ext}").write_bytes(b"INIT0")
+        for b in boundary_indices:
+            (chunk_dir / f"init.{b}{ext}").write_bytes(b"INIT%d" % b)
+
+        monkeypatch.setenv("AUDIO_STORAGE_PATH", str(tmp_path))
+
+        concat_calls = []
+
+        def fake_concat(paths, init_segment_path=None, output_suffix=None):
+            concat_calls.append((list(paths), init_segment_path))
+            out = tmp_path / f"merged_{len(concat_calls)}{output_suffix}"
+            out.write_bytes(b"merged")
+            return str(out)
+
+        monkeypatch.setattr(st, "concat_fragmented_media", fake_concat)
+        monkeypatch.setattr(st, "compress_audio_if_needed",
+                            lambda p, log: p)
+        monkeypatch.setattr(st, "get_audio_duration", lambda p, log: 15.0)
+        monkeypatch.setattr(st, "get_openai_chat_key", lambda cfg: "key")
+
+        class FakeTranscriptions:
+            def __init__(self):
+                self.n = 0
+
+            def create(self, **kwargs):
+                self.n += 1
+                return type("R", (), {"text": f"part{self.n}"})()
+
+        fake_openai = MagicMock()
+        fake_openai.return_value.audio.transcriptions = FakeTranscriptions()
+        monkeypatch.setattr(st, "OpenAI", fake_openai)
+
+        # Call the task body directly (bind=True → self first)
+        st.transcribe_chunk_batch(MagicMock(), session_id,
+                                  list(chunk_indices))
+
+        stored = NodeTranscriptChunk.query.filter_by(
+            session_id=session_id,
+            chunk_index=min(chunk_indices)).first()
+        stored_text = stored.get_text() if stored else None
+        _db.session.rollback()
+        _db.drop_all()
+
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+    return concat_calls, stored_text
+
+
+def test_resumed_batch_splits_at_boundary(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2, 3], boundary_indices=[2])
+    # Two independent merges: [0,1] with no init (chunk 0 self-carries),
+    # [2,3] with the suffixed subsession init.
+    assert len(concat_calls) == 2
+    (paths1, init1), (paths2, init2) = concat_calls
+    assert len(paths1) == 2 and init1 is None
+    assert len(paths2) == 2 and init2 is not None
+    assert "init.2" in init2
+    # Both subsessions' transcripts present, in order
+    assert stored == "part1\n\npart2"
+
+
+def test_unresumed_batch_single_merge(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2], boundary_indices=[])
+    assert len(concat_calls) == 1
+    assert concat_calls[0][1] is None  # starts at 0 → no init prefix
+    assert stored == "part1"
+
+
+def test_later_batch_without_boundary_uses_legacy_init(tmp_path,
+                                                       monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[20, 21], boundary_indices=[])
+    assert len(concat_calls) == 1
+    assert concat_calls[0][1] is not None
+    assert concat_calls[0][1].endswith("init.webm")
+
+
+def test_mp4_resumed_batch_splits(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2, 3], boundary_indices=[2], ext=".mp4")
+    assert len(concat_calls) == 2
+    assert "init.2" in concat_calls[1][1]

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -113,12 +113,45 @@ def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
     return value, length, is_unknown
 
 
+WEBM_MAGIC = b'\x1aE\xdf\xa3'  # EBML header
+
+
+def chunk_is_init_bearing(chunk_path: pathlib.Path) -> bool:
+    """True if the chunk starts its own media stream (#124).
+
+    A chunk N>0 that begins with an fMP4 `ftyp` box or a WebM EBML
+    header came from a fresh MediaRecorder instance — i.e. the user
+    resumed a recovered recording. Such chunks open a new "subsession"
+    that must be transcribed separately from the chunks before it.
+    """
+    try:
+        with open(chunk_path, 'rb') as f:
+            head = f.read(8)
+    except OSError:
+        return False
+    if len(head) < 8:
+        return False
+    return head[4:8] == b'ftyp' or head[:4] == WEBM_MAGIC
+
+
+def init_segment_name(ext: str, index: int = None) -> str:
+    """Filename for a persisted init segment.
+
+    Chunk 0's init keeps the legacy name `init{ext}`; a resumed
+    subsession starting at chunk N persists as `init.{N}{ext}` (#124).
+    """
+    return f"init{ext}" if index is None else f"init.{index}{ext}"
+
+
 def persist_init_segment(
     chunk_path: pathlib.Path, chunk_dir: pathlib.Path,
+    index: int = None,
 ) -> None:
-    """Extract the init segment from a chunk-0 file on disk and persist it
-    at `chunk_dir/init{ext}.enc` (or `init{ext}` if encryption is disabled),
-    where `ext` matches the chunk's file extension (`.webm` or `.mp4`).
+    """Extract the init segment from an init-bearing chunk on disk and
+    persist it at `chunk_dir/init{ext}.enc` (chunk 0) or
+    `chunk_dir/init.{index}{ext}.enc` (a resumed subsession's first chunk,
+    #124) — without `.enc` when encryption is disabled. `ext` matches the
+    chunk's file extension (`.webm` or `.mp4`).
 
     Dispatches on the chunk's suffix: WebM goes through the EBML walker,
     MP4 through the ISOBMFF box walker. Both raise ValueError on malformed
@@ -141,7 +174,7 @@ def persist_init_segment(
     else:
         raise ValueError(f"Unsupported chunk extension: {ext}")
 
-    init_path = chunk_dir / ("init" + ext)
+    init_path = chunk_dir / init_segment_name(ext, index)
     with open(init_path, 'wb') as f:
         f.write(init_bytes)
     try:


### PR DESCRIPTION
## Rebased standalone onto `main` (2026-07-01)
Previously stacked on #203; the #124 fix is logically independent of onboarding, so the branch was rebased to carry **only** the #124 commit on top of current `main`. Diff is now the true 4-file scope. `streaming_transcription.py` auto-merged cleanly with the already-merged #198 caching work.

## Summary
Closes #124 — the silent data-loss bug where a recovered recording's pre-resume audio vanished at finalize. Implements the issue's own design verbatim (it was function-level precise):

1. **Upload** (`drafts.py`): chunks N>0 starting with an fMP4 `ftyp` box or WebM EBML magic are subsession boundaries; their init persists as `init.{N}{ext}` (chunk 0 keeps the legacy `init{ext}`).
2. **Transcription** (`transcribe_chunk_batch`): batches partition into sub-batches at boundaries; each merges + transcribes independently with its own init prefix; transcripts join in chunk order; one encrypted batch audio file per subsession.
3. `audio_storage`'s init filter already matched `init.*` — no change needed (as the issue predicted).

## Technical choices made
- **Unresumed recordings take the byte-identical single-sub-batch path** — zero behavior change for the common case.
- **Subsession init extraction failure logs but does NOT reject the upload** (unlike chunk 0's 400): the audio already streamed once and rejection would lose it outright; keeping it degrades at worst to today's behavior for that one subsession. This asymmetry is deliberate — flag if you disagree.
- Per-subsession batch files mean a resumed session stores `batch_0000-0001.webm.enc` + `batch_0002-0003.webm.enc` instead of one file; the existing `batch_*` glob handling downstream is unaffected.

## Verification
- 7 fixture-based tests: detection (fMP4/WebM/fragments), suffixed naming, batch partitioning + init resolution + transcript joining for both formats, legacy-init path for later batches, single-merge regression guard.
- **Full backend suite green on the rebased branch: 661 passed.**
- **Not verified live**: the real repro needs ~40s of mic audio + a mid-recording refresh — the Chrome extension can't feed deterministic mic input (long-standing constraint from the triage plan). The issue's repro steps on staging would be the definitive check when you have 2 minutes with a real microphone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
