### PR TITLE
feat(#145,#140): section-aware TTS chapters + tiny-first-chunk fallback

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -875,6 +875,10 @@ class TTSChunk(db.Model):
     profile_id = db.Column(db.Integer, db.ForeignKey("user_profile.id"), nullable=True)
     # Zero-based index of the chunk
     chunk_index = db.Column(db.Integer, nullable=False)
+    # Chapter metadata (#145): which markdown section this chunk belongs
+    # to. section_title is None for content before the first heading.
+    section_index = db.Column(db.Integer, nullable=True)
+    section_title = db.Column(db.String(256), nullable=True)
     # URL to the audio chunk file
     audio_url = db.Column(db.String, nullable=True)
     # Duration of the audio chunk in seconds (from pydub/ffprobe)

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -1658,8 +1658,15 @@ def get_tts_status(node_id):
                 db.session.commit()
             elif task.state == 'FAILURE':
                 # Surface the worker exception so failures are
-                # diagnosable without SSH access to worker logs.
-                task_info = {"error": str(task.info)[:500]}
+                # diagnosable without SSH access to worker logs —
+                # scrubbed: no API keys, no filesystem paths, no
+                # provider response bodies (security review finding).
+                import re as _re
+                raw = f"{type(task.info).__name__}: {task.info}"
+                raw = _re.sub(r"sk-[A-Za-z0-9_\-]+", "[key]", raw)
+                raw = _re.sub(r"(?:/[\w.\-]+){2,}", "[path]", raw)
+                raw = raw.split("{", 1)[0]  # drop JSON response bodies
+                task_info = {"error": raw[:200]}
         except Exception as e:
             # If Celery check fails, log and continue with DB status
             current_app.logger.warning(f"Failed to check Celery task status: {e}")

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -2426,3 +2426,45 @@ def delete_node(node_id):
         db.session.rollback()
         current_app.logger.error(f"Error soft-deleting node {node_id}: {e}")
         return jsonify({"error": "Error deleting node", "details": str(e)}), 500
+
+
+@nodes_bp.route("/<int:node_id>/tts-chapters", methods=["GET"])
+@login_required
+def get_tts_chapters(node_id):
+    """Chapter list for a node's generated TTS audio (#145).
+
+    Built from persisted TTSChunk rows: each chapter is the first chunk
+    of a markdown section, with its cumulative start time (sum of prior
+    chunk durations) so the player can jump within the merged file and
+    map chapters onto the chunked queue alike.
+    """
+    node = Node.query.get_or_404(node_id)
+    if not can_user_access_node(node) and not getattr(
+            current_user, "is_admin", False):
+        return jsonify({"error": "Unauthorized"}), 403
+
+    from backend.models import TTSChunk
+    chunks = TTSChunk.query.filter_by(node_id=node_id).order_by(
+        TTSChunk.chunk_index).all()
+    if not chunks:
+        return jsonify({"chapters": []}), 200
+
+    chapters = []
+    elapsed = 0.0
+    seen_sections = set()
+    for chunk in chunks:
+        key = chunk.section_index
+        if key is not None and key not in seen_sections:
+            seen_sections.add(key)
+            chapters.append({
+                "section_index": key,
+                "title": chunk.section_title or "Introduction",
+                "chunk_index": chunk.chunk_index,
+                "start_time": round(elapsed, 2),
+            })
+        elapsed += chunk.duration or 0.0
+
+    # A single untitled section = no real chapters — don't render a list
+    if len(chapters) <= 1:
+        return jsonify({"chapters": []}), 200
+    return jsonify({"chapters": chapters}), 200

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -1656,6 +1656,10 @@ def get_tts_status(node_id):
             elif task.state == 'SUCCESS':
                 node.tts_task_status = 'completed'
                 db.session.commit()
+            elif task.state == 'FAILURE':
+                # Surface the worker exception so failures are
+                # diagnosable without SSH access to worker logs.
+                task_info = {"error": str(task.info)[:500]}
         except Exception as e:
             # If Celery check fails, log and continue with DB status
             current_app.logger.warning(f"Failed to check Celery task status: {e}")

--- a/backend/routes/sse.py
+++ b/backend/routes/sse.py
@@ -191,6 +191,10 @@ def _tts_stream_generator(app, entity_cls, entity_id, chunk_fk_attr,
                 }
                 if chunk.duration is not None:
                     chunk_data["duration"] = chunk.duration
+                # Chapter metadata (#145)
+                if chunk.section_index is not None:
+                    chunk_data["section_index"] = chunk.section_index
+                    chunk_data["section_title"] = chunk.section_title
                 yield format_sse_message(chunk_data, event="chunk_ready")
                 last_sent_chunk = chunk.chunk_index
 

--- a/backend/tasks/tts.py
+++ b/backend/tasks/tts.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from backend.celery_app import celery, flask_app
 from backend.models import Node, UserProfile, TTSChunk, APICostLog
 from backend.extensions import db
-from backend.utils.audio_processing import adaptive_chunk_text
+from backend.utils.audio_processing import section_aware_chunk_text
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import encrypt_file
 from backend.utils.cost import calculate_audio_cost_microdollars
@@ -149,17 +149,24 @@ def _generate_tts_chunks(task, entity, text, target_dir, audio_storage_root,
     entity.tts_task_progress = 30
     db.session.commit()
 
-    chunks = adaptive_chunk_text(text)
+    chunk_specs = section_aware_chunk_text(text)
+    chunks = [c for c, _title, _idx in chunk_specs]
     logger.info(
         f"Text split into {len(chunks)} chunks for TTS "
-        f"for {entity_label} (sizes: {[len(c) for c in chunks]})"
+        f"for {entity_label} (sizes: {[len(c) for c in chunks]}, "
+        f"sections: {len({s for _, _, s in chunk_specs})})"
     )
 
-    # Create TTSChunk records for streaming playback
+    # Create TTSChunk records for streaming playback (with chapter
+    # metadata, #145)
     chunk_fk = {chunk_fk_attr: entity.id}
     created_chunks = []
-    for i in range(len(chunks)):
-        tts_chunk = TTSChunk(chunk_index=i, status='pending', **chunk_fk)
+    for i, (_chunk, section_title, section_index) in enumerate(chunk_specs):
+        tts_chunk = TTSChunk(
+            chunk_index=i, status='pending',
+            section_index=section_index,
+            section_title=section_title,
+            **chunk_fk)
         db.session.add(tts_chunk)
         created_chunks.append(tts_chunk)
     db.session.commit()

--- a/backend/tasks/tts.py
+++ b/backend/tasks/tts.py
@@ -63,6 +63,12 @@ def _strip_heading_sections(text):
     return text.strip()
 
 
+# Silence appended to a chapter's final audio chunk (#145 v3): the
+# audible breath between a chapter's last sentence and the next spoken
+# title. Belongs to the ENDING chapter so chapter start_times (computed
+# from per-chunk durations) stay exact.
+CHAPTER_END_SILENCE_MS = 900
+
 # Audio storage root path (matches the one in routes/nodes.py)
 import pathlib
 AUDIO_STORAGE_ROOT = pathlib.Path(os.environ.get("AUDIO_STORAGE_PATH", "data/audio")).resolve()
@@ -157,6 +163,13 @@ def _generate_tts_chunks(task, entity, text, target_dir, audio_storage_root,
         f"sections: {len({s for _, _, s in chunk_specs})})"
     )
 
+    # Chunks that close a chapter (a different section follows) get
+    # trailing silence appended (#145 v3).
+    section_end_indices = {
+        i for i in range(len(chunk_specs) - 1)
+        if chunk_specs[i][2] != chunk_specs[i + 1][2]
+    }
+
     # Create TTSChunk records for streaming playback (with chapter
     # metadata, #145)
     chunk_fk = {chunk_fk_attr: entity.id}
@@ -240,6 +253,12 @@ def _generate_tts_chunks(task, entity, text, target_dir, audio_storage_root,
                 resp.stream_to_file(part_path)
 
             segment = AudioSegment.from_file(str(part_path), format="mp3")
+            if i in section_end_indices:
+                segment = segment + AudioSegment.silent(
+                    duration=CHAPTER_END_SILENCE_MS)
+                # Re-export so live chunked playback (which streams this
+                # file directly) carries the chapter pause as well.
+                segment.export(str(part_path), format="mp3")
             chunk_duration = len(segment) / 1000.0
             audio_parts.append((i, segment, part_path))
 

--- a/backend/tests/test_tts_chapters.py
+++ b/backend/tests/test_tts_chapters.py
@@ -22,7 +22,8 @@ for _mod in ["flask_login", "backend.models", "backend.extensions"]:
         del sys.modules[_mod]
 
 from backend.utils.audio_processing import (  # noqa: E402
-    MIN_FIRST_CHUNK_CHARS, section_aware_chunk_text, split_sections,
+    MIN_FIRST_CHUNK_CHARS, TTS_AUDIO_SECS_PER_CHAR, TTS_CHUNK_OVERHEAD_SECS,
+    TTS_GEN_CHARS_PER_SEC, section_aware_chunk_text, split_sections,
 )
 
 LONG = ("This is a reasonably long sentence used to pad sections so the "
@@ -103,9 +104,8 @@ def test_140_v2_short_first_chunk_bounds_second_chunk():
     # section) followed by a ~117s second chunk from the old STATIC
     # budget (computed off the theoretical 318-char first chunk). The
     # second chunk must be sized from the ACTUAL emitted first chunk's
-    # playback window: ~145 chars → ~(9s − 2s) × 106 ≈ 740-char cap
-    # (≈46s of audio), so it finishes generating before playback
-    # reaches it.
+    # playback window so it finishes generating before playback reaches
+    # it (a 2s generation floor applies when the window is very tight).
     intro = ("This opening sentence is deliberately sized to roughly one "
              "hundred and forty characters so the first chunk plays back "
              "for about nine seconds.")
@@ -113,27 +113,32 @@ def test_140_v2_short_first_chunk_bounds_second_chunk():
     chunks = section_aware_chunk_text(text)
     first, second = chunks[0][0], chunks[1][0]
     assert len(first) < 200  # short, section-bounded first chunk
-    window_secs = len(first) * 0.062 - 2.0
-    assert len(second) <= int(window_secs * 106.0)
-    assert len(second) > 300  # but still a real chunk, not degenerate
+    window = max(len(first) * TTS_AUDIO_SECS_PER_CHAR
+                 - TTS_CHUNK_OVERHEAD_SECS, 2.0)
+    assert len(second) <= int(window * TTS_GEN_CHARS_PER_SEC)
+    # And nowhere near the old static ~1900-char budget
+    assert len(second) < 1000
 
 
 def test_140_v2_gapless_pipeline_invariant():
     # For ANY mix of short and long sections, generation of chunks 2..N
     # must fit inside the playback time of the already-emitted chunks,
-    # so audio never stalls. A 2s scheduling floor exists for very short
-    # openers (a tiny chunk grants ~212 chars + 2s overhead ≈ 4s of gen
-    # against <2s of playback), so allow a 6s transient overshoot — it
-    # self-corrects because each floor grant adds ~13s of playback.
+    # so audio never stalls. The 2s generation floor for very short
+    # openers may transiently overshoot the window (by at most the
+    # floor grant: 2s of gen + the per-chunk overhead); it self-corrects
+    # because every floor-granted chunk adds far more playback than gen.
     text = (f"# A\nTiny.\n# B\n{LONG}\n# C\nShort again here.\n"
             f"# D\n{LONG * 4}")
     chunks = section_aware_chunk_text(text)
-    gen, play, overhead = 106.0, 0.062, 2.0
+    gen = TTS_GEN_CHARS_PER_SEC
+    play = TTS_AUDIO_SECS_PER_CHAR
+    overhead = TTS_CHUNK_OVERHEAD_SECS
+    tolerance = 2.0 + overhead
     playback = len(chunks[0][0]) * play
     committed = 0.0
     for c, _t, _i in chunks[1:]:
         committed += len(c) / gen + overhead
-        assert committed <= playback + 6.0, (
+        assert committed <= playback + tolerance, (
             f"chunk of {len(c)} chars overruns playback window: "
             f"gen {committed:.1f}s vs playback {playback:.1f}s")
         playback += len(c) * play

--- a/backend/tests/test_tts_chapters.py
+++ b/backend/tests/test_tts_chapters.py
@@ -1,0 +1,168 @@
+"""Tests for section-aware TTS chunking + chapters (#145, #140)."""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+import pytest  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.utils.audio_processing import (  # noqa: E402
+    MIN_FIRST_CHUNK_CHARS, section_aware_chunk_text, split_sections,
+)
+
+LONG = ("This is a reasonably long sentence used to pad sections so the "
+        "chunker has real material to work with. " * 12)
+
+
+# ── split_sections ───────────────────────────────────────────────────────
+
+def test_split_sections_h1_h2_are_chapters():
+    text = f"Preamble text.\n\n# Alpha\n{LONG}\n## Beta\n{LONG}\n### gamma\nstays"
+    sections = split_sections(text)
+    titles = [t for t, _ in sections]
+    assert titles == [None, "Alpha", "Beta"]
+    # h3 stays inside Beta's body
+    assert "### gamma" in sections[2][1]
+
+
+def test_split_sections_no_headings():
+    assert split_sections("just text") == [(None, "just text")]
+    assert split_sections("") == []
+
+
+def test_split_sections_heading_line_not_in_body():
+    sections = split_sections("# Title\nBody here")
+    assert sections == [("Title", "Body here")]
+
+
+# ── section_aware_chunk_text ─────────────────────────────────────────────
+
+def test_chunks_never_cross_sections():
+    text = f"# One\n{LONG}\n# Two\n{LONG}"
+    chunks = section_aware_chunk_text(text)
+    for _text, title, idx in chunks:
+        assert title in ("One", "Two")
+    # Contiguous non-decreasing section indices
+    indices = [idx for _, _, idx in chunks]
+    assert indices == sorted(indices)
+    assert set(indices) == {0, 1}
+
+
+def test_first_chunk_stays_small_globally():
+    text = f"# One\n{LONG}\n# Two\n{LONG}"
+    chunks = section_aware_chunk_text(text)
+    assert len(chunks[0][0]) <= 320  # fast-start budget
+    assert any(len(c) > 1000 for c, _, _ in chunks[1:])  # later are big
+
+
+def test_no_heading_text_single_section_matches_legacy_sizing():
+    chunks = section_aware_chunk_text(LONG * 3)
+    assert all(title is None and idx == 0 for _, title, idx in chunks)
+    assert len(chunks) >= 3
+
+
+def test_empty_sections_skipped():
+    chunks = section_aware_chunk_text("# Empty\n# Full\ncontent here")
+    assert [(t, i) for _, t, i in chunks] == [("Full", 1)]
+
+
+def test_140_tiny_first_sentence_falls_back_to_word_split():
+    # First sentence is tiny ("Hi.") — sentence split would give a
+    # sub-MIN chunk; the fallback splits word-aware near the budget.
+    text = "Hi. " + ("word " * 400)
+    chunks = section_aware_chunk_text(text)
+    first = chunks[0][0]
+    assert len(first) >= MIN_FIRST_CHUNK_CHARS
+    assert not first.endswith("wor")  # never mid-word
+
+
+# ── chapters endpoint ────────────────────────────────────────────────────
+
+def test_chapters_endpoint(tmp_path):
+    from flask import Flask
+    from backend.extensions import db as _db
+    from backend.models import User, Node, TTSChunk
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.nodes import nodes_bp
+    app.register_blueprint(nodes_bp, url_prefix="/api/nodes")
+
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.flush()
+        node = Node(user_id=user.id, human_owner_id=user.id,
+                    node_type="text")
+        node.set_content("x")
+        _db.session.add(node)
+        _db.session.flush()
+        specs = [
+            (0, None, None, 10.0),
+            (1, 0, "Intro part", None),     # legacy row w/o duration
+            (2, 1, "Chapter A", 20.0),
+            (3, 1, "Chapter A", 30.0),
+            (4, 2, "Chapter B", 5.0),
+        ]
+        # Row 0 simulates pre-#145 chunks (no section metadata)
+        for idx, s_idx, s_title, dur in specs:
+            _db.session.add(TTSChunk(
+                node_id=node.id, chunk_index=idx, status='completed',
+                section_index=s_idx, section_title=s_title, duration=dur))
+        _db.session.commit()
+
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(user.id)
+            sess["_fresh"] = True
+
+        body = client.get(
+            f"/api/nodes/{node.id}/tts-chapters").get_json()
+        chapters = body["chapters"]
+        assert [c["title"] for c in chapters] == [
+            "Intro part", "Chapter A", "Chapter B"]
+        assert [c["chunk_index"] for c in chapters] == [1, 2, 4]
+        # Start times accumulate prior durations (None counts as 0)
+        assert [c["start_time"] for c in chapters] == [10.0, 10.0, 60.0]
+
+        # Single/no sections → empty list (no chapter UI)
+        node2 = Node(user_id=user.id, human_owner_id=user.id,
+                     node_type="text")
+        node2.set_content("y")
+        _db.session.add(node2)
+        _db.session.flush()
+        _db.session.add(TTSChunk(node_id=node2.id, chunk_index=0,
+                                 status='completed', duration=5.0))
+        _db.session.commit()
+        assert client.get(
+            f"/api/nodes/{node2.id}/tts-chapters"
+        ).get_json()["chapters"] == []
+
+        _db.session.rollback()
+        _db.drop_all()

--- a/backend/tests/test_tts_chapters.py
+++ b/backend/tests/test_tts_chapters.py
@@ -57,6 +57,13 @@ def test_chunks_never_cross_sections():
     chunks = section_aware_chunk_text(text)
     for _text, title, idx in chunks:
         assert title in ("One", "Two")
+    # Spoken titles (v2): each section's first chunk opens with the
+    # bare title, sentence-terminated, blank-line-separated.
+    firsts = {}
+    for c, _t, i in chunks:
+        firsts.setdefault(i, c)
+    assert firsts[0].startswith("One.\n\n")
+    assert firsts[1].startswith("Two.\n\n")
     # Contiguous non-decreasing section indices
     indices = [idx for _, _, idx in chunks]
     assert indices == sorted(indices)
@@ -166,3 +173,10 @@ def test_chapters_endpoint(tmp_path):
 
         _db.session.rollback()
         _db.drop_all()
+
+
+def test_spoken_title_keeps_existing_punctuation():
+    chunks = section_aware_chunk_text("# Ready?\nBody text here.")
+    assert chunks[0][0].startswith("Ready?\n\n")
+    # No markdown markers in the spoken text
+    assert "#" not in chunks[0][0]

--- a/backend/tests/test_tts_chapters.py
+++ b/backend/tests/test_tts_chapters.py
@@ -98,6 +98,47 @@ def test_140_tiny_first_sentence_falls_back_to_word_split():
     assert not first.endswith("wor")  # never mid-word
 
 
+def test_140_v2_short_first_chunk_bounds_second_chunk():
+    # Regression: user-reported stall — a ~9s first chunk (short opening
+    # section) followed by a ~117s second chunk from the old STATIC
+    # budget (computed off the theoretical 318-char first chunk). The
+    # second chunk must be sized from the ACTUAL emitted first chunk's
+    # playback window: ~145 chars → ~(9s − 2s) × 106 ≈ 740-char cap
+    # (≈46s of audio), so it finishes generating before playback
+    # reaches it.
+    intro = ("This opening sentence is deliberately sized to roughly one "
+             "hundred and forty characters so the first chunk plays back "
+             "for about nine seconds.")
+    text = f"# Todo\n{intro}\n# Details\n{LONG * 3}"
+    chunks = section_aware_chunk_text(text)
+    first, second = chunks[0][0], chunks[1][0]
+    assert len(first) < 200  # short, section-bounded first chunk
+    window_secs = len(first) * 0.062 - 2.0
+    assert len(second) <= int(window_secs * 106.0)
+    assert len(second) > 300  # but still a real chunk, not degenerate
+
+
+def test_140_v2_gapless_pipeline_invariant():
+    # For ANY mix of short and long sections, generation of chunks 2..N
+    # must fit inside the playback time of the already-emitted chunks,
+    # so audio never stalls. A 2s scheduling floor exists for very short
+    # openers (a tiny chunk grants ~212 chars + 2s overhead ≈ 4s of gen
+    # against <2s of playback), so allow a 6s transient overshoot — it
+    # self-corrects because each floor grant adds ~13s of playback.
+    text = (f"# A\nTiny.\n# B\n{LONG}\n# C\nShort again here.\n"
+            f"# D\n{LONG * 4}")
+    chunks = section_aware_chunk_text(text)
+    gen, play, overhead = 106.0, 0.062, 2.0
+    playback = len(chunks[0][0]) * play
+    committed = 0.0
+    for c, _t, _i in chunks[1:]:
+        committed += len(c) / gen + overhead
+        assert committed <= playback + 6.0, (
+            f"chunk of {len(c)} chars overruns playback window: "
+            f"gen {committed:.1f}s vs playback {playback:.1f}s")
+        playback += len(c) * play
+
+
 # ── chapters endpoint ────────────────────────────────────────────────────
 
 def test_chapters_endpoint(tmp_path):

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -4,6 +4,7 @@ Extracted from routes/nodes.py to be shared between API and Celery tasks.
 """
 import os
 import pathlib
+import re
 import tempfile
 import ffmpeg
 from pydub import AudioSegment
@@ -304,3 +305,96 @@ def adaptive_chunk_text(text: str, first_chunk_gen_secs: float = 3.0) -> list:
         remaining = remaining[split_point:].strip()
 
     return chunks
+
+
+# Minimum sensible first chunk (#140): a tiny first sentence ("Okay.")
+# produces a sub-second clip — an audible stitch artifact and a wasted
+# API round-trip. Below this size we split word-aware at the target
+# instead of at the sentence boundary.
+MIN_FIRST_CHUNK_CHARS = 80
+
+_CHAPTER_HEADING_RE = re.compile(r'^(#{1,2})\s+(.+?)\s*$', re.MULTILINE)
+
+
+def split_sections(text):
+    """Split markdown into chapter sections at h1/h2 headings (#145).
+
+    Returns [(title_or_None, body)]. Content before the first heading
+    becomes a section with title None. Heading lines themselves are NOT
+    part of the body (v0 decision: chapter titles are visual labels, not
+    read aloud). h3+ headings stay inside their section's body.
+    """
+    matches = list(_CHAPTER_HEADING_RE.finditer(text or ""))
+    if not matches:
+        return [(None, (text or "").strip())] if (text or "").strip() else []
+
+    sections = []
+    preamble = text[:matches[0].start()].strip()
+    if preamble:
+        sections.append((None, preamble))
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[m.end():end].strip()
+        sections.append((m.group(2).strip(), body))
+    return sections
+
+
+def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
+    """Chunk text for streaming TTS without crossing chapter boundaries.
+
+    Returns [(chunk_text, section_title, section_index)]. The adaptive
+    size schedule (small first chunk → medium second → full-size rest)
+    applies GLOBALLY across sections so playback still starts fast, while
+    every chunk belongs to exactly one section — the prerequisite for
+    chapter-accurate jumping in the player (#145).
+
+    Sections whose body is empty (e.g. a heading directly followed by
+    another heading) are skipped — they'd produce zero-length audio.
+    """
+    gen_chars_per_sec = 106.0
+    audio_secs_per_char = 0.062
+    overhead_secs = 2.0
+
+    first_chunk_chars = min(
+        int(first_chunk_gen_secs * gen_chars_per_sec), TTS_MAX_CHARS)
+    first_play_secs = first_chunk_chars * audio_secs_per_char
+    next_budget_secs = max(first_play_secs - overhead_secs, 2.0)
+    second_chunk_chars = min(
+        int(next_budget_secs * gen_chars_per_sec), TTS_MAX_CHARS)
+
+    def _budget(global_idx):
+        if global_idx == 0:
+            return first_chunk_chars
+        if global_idx == 1:
+            return second_chunk_chars
+        return TTS_MAX_CHARS
+
+    out = []
+    for section_index, (title, body) in enumerate(split_sections(text)):
+        remaining = body
+        while remaining:
+            budget = _budget(len(out))
+            if len(remaining) <= budget:
+                out.append((remaining, title, section_index))
+                break
+            split_point = _split_at_sentence(remaining, budget)
+            # #140: a tiny first chunk (short opening sentence) falls
+            # back to a word-aware split at the full budget.
+            if len(out) == 0 and split_point < MIN_FIRST_CHUNK_CHARS:
+                split_point = _split_at_word(remaining, budget)
+            chunk = remaining[:split_point].strip()
+            if chunk:
+                out.append((chunk, title, section_index))
+            remaining = remaining[split_point:].strip()
+    return out
+
+
+def _split_at_word(text, max_chars):
+    """Last word boundary within max_chars (never mid-word)."""
+    if len(text) <= max_chars:
+        return len(text)
+    chunk = text[:max_chars]
+    best = chunk.rfind(' ')
+    for sep in ('\n', '\t'):
+        best = max(best, chunk.rfind(sep))
+    return best + 1 if best > 0 else max_chars

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -364,17 +364,30 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
 
     first_chunk_chars = min(
         int(first_chunk_gen_secs * gen_chars_per_sec), TTS_MAX_CHARS)
-    first_play_secs = first_chunk_chars * audio_secs_per_char
-    next_budget_secs = max(first_play_secs - overhead_secs, 2.0)
-    second_chunk_chars = min(
-        int(next_budget_secs * gen_chars_per_sec), TTS_MAX_CHARS)
 
-    def _budget(global_idx):
-        if global_idx == 0:
+    # Gapless-pipeline budgets (#140 v2): chunk N must finish generating
+    # before playback reaches it. With playback starting when chunk 1 is
+    # ready, that means gen-time of chunks 2..N must fit inside the
+    # playback time of chunks 1..N-1. Budgets therefore derive from the
+    # ACTUAL emitted chunks — a short first chunk (sentence or section
+    # boundary) gets a proportionally smaller second chunk (~40-50s of
+    # audio instead of the old static ~2min, which stalled playback).
+    emitted_playback_secs = [0.0]   # cumulative playback of chunks 1..N
+    committed_gen_secs = [0.0]      # cumulative gen time of chunks 2..N
+
+    def _budget():
+        if not out:
             return first_chunk_chars
-        if global_idx == 1:
-            return second_chunk_chars
-        return TTS_MAX_CHARS
+        window = (emitted_playback_secs[0] - committed_gen_secs[0]
+                  - overhead_secs)
+        return max(min(int(max(window, 2.0) * gen_chars_per_sec),
+                       TTS_MAX_CHARS), 1)
+
+    def _account(chunk_len):
+        if out:  # chunks 2..N consume the generation window
+            committed_gen_secs[0] += (chunk_len / gen_chars_per_sec
+                                      + overhead_secs)
+        emitted_playback_secs[0] += chunk_len * audio_secs_per_char
 
     out = []
     for section_index, (title, body) in enumerate(split_sections(text)):
@@ -384,8 +397,9 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
         else:
             remaining = body
         while remaining:
-            budget = _budget(len(out))
+            budget = _budget()
             if len(remaining) <= budget:
+                _account(len(remaining))
                 out.append((remaining, title, section_index))
                 break
             split_point = _split_at_sentence(remaining, budget)
@@ -395,6 +409,7 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
                 split_point = _split_at_word(remaining, budget)
             chunk = remaining[:split_point].strip()
             if chunk:
+                _account(len(chunk))
                 out.append((chunk, title, section_index))
             remaining = remaining[split_point:].strip()
     return out

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -307,6 +307,16 @@ def adaptive_chunk_text(text: str, first_chunk_gen_secs: float = 3.0) -> list:
     return chunks
 
 
+# Streaming TTS pipeline model (#140). Generation rate is the OpenAI API
+# streaming rate; overhead is the per-chunk fixed cost AROUND the API call:
+# pydub decode of the returned MP3, section-end silence re-export, DB
+# status commits, encryption, and the SSE poll interval. Calibrated from
+# live staging timings 2026-06-10 (solved from chunk-ready wall times:
+# rate ≈ 104 chars/s, fixed ≈ 7.3s — the old 2.0s only modeled the API).
+TTS_GEN_CHARS_PER_SEC = 106.0
+TTS_AUDIO_SECS_PER_CHAR = 0.062
+TTS_CHUNK_OVERHEAD_SECS = 7.0
+
 # Minimum sensible first chunk (#140): a tiny first sentence ("Okay.")
 # produces a sub-second clip — an audible stitch artifact and a wasted
 # API round-trip. Below this size we split word-aware at the target
@@ -358,9 +368,9 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
     Sections whose body is empty (e.g. a heading directly followed by
     another heading) are skipped — they'd produce zero-length audio.
     """
-    gen_chars_per_sec = 106.0
-    audio_secs_per_char = 0.062
-    overhead_secs = 2.0
+    gen_chars_per_sec = TTS_GEN_CHARS_PER_SEC
+    audio_secs_per_char = TTS_AUDIO_SECS_PER_CHAR
+    overhead_secs = TTS_CHUNK_OVERHEAD_SECS
 
     first_chunk_chars = min(
         int(first_chunk_gen_secs * gen_chars_per_sec), TTS_MAX_CHARS)

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -348,6 +348,13 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
     every chunk belongs to exactly one section — the prerequisite for
     chapter-accurate jumping in the player (#145).
 
+    Section titles ARE spoken (maintainer decision, v2 of #145): each
+    section's text starts with the bare title (no markdown markers,
+    sentence-terminated) separated from the body by a blank line, which
+    gives the TTS voice an audible chapter pause. Chapter start_times
+    stay exact — the title audio belongs to its own section's first
+    chunk.
+
     Sections whose body is empty (e.g. a heading directly followed by
     another heading) are skipped — they'd produce zero-length audio.
     """
@@ -371,7 +378,11 @@ def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
 
     out = []
     for section_index, (title, body) in enumerate(split_sections(text)):
-        remaining = body
+        if title and body:
+            spoken = title if title[-1] in '.!?' else f"{title}."
+            remaining = f"{spoken}\n\n{body}"
+        else:
+            remaining = body
         while remaining:
             budget = _budget(len(out))
             if len(remaining) <= budget:

--- a/frontend/src/components/GlobalAudioPlayer.js
+++ b/frontend/src/components/GlobalAudioPlayer.js
@@ -111,6 +111,36 @@ const GlobalAudioPlayer = () => {
         {currentAudio.title || 'Audio Player'}
       </div>
 
+      {/* Chapters (#145) — only for TTS audio with real sections */}
+      {currentAudio.chapters && currentAudio.chapters.length > 1 && (
+        <select
+          value=""
+          onChange={(e) => {
+            const ch = currentAudio.chapters[Number(e.target.value)];
+            if (ch) seekToCumulativeTime(ch.start_time);
+            e.target.value = '';
+          }}
+          title="Jump to chapter"
+          style={{
+            background: 'var(--bg-input)',
+            border: '1px solid var(--border)',
+            borderRadius: '4px',
+            color: 'var(--text-muted)',
+            fontSize: '11px',
+            fontFamily: 'var(--sans)',
+            padding: '2px 4px',
+            maxWidth: isMobile ? '90px' : '130px',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          <option value="" disabled>Chapters</option>
+          {currentAudio.chapters.map((ch, i) => (
+            <option key={i} value={i}>{ch.title}</option>
+          ))}
+        </select>
+      )}
+
       {/* Controls */}
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
         {isPlaying ? (

--- a/frontend/src/components/GlobalAudioPlayer.js
+++ b/frontend/src/components/GlobalAudioPlayer.js
@@ -111,21 +111,29 @@ const GlobalAudioPlayer = () => {
         {currentAudio.title || 'Audio Player'}
       </div>
 
-      {/* Chapters (#145) — only for TTS audio with real sections */}
+      {/* Chapters (#145) — only for TTS audio with real sections.
+          Controlled: shows the chapter currently playing and advances
+          live as playback crosses section boundaries. */}
       {currentAudio.chapters && currentAudio.chapters.length > 1 && (
         <select
-          value=""
+          value={(() => {
+            let idx = 0;
+            for (let i = 0; i < currentAudio.chapters.length; i++) {
+              if (displayTime >= currentAudio.chapters[i].start_time) idx = i;
+              else break;
+            }
+            return idx;
+          })()}
           onChange={(e) => {
             const ch = currentAudio.chapters[Number(e.target.value)];
             if (ch) seekToCumulativeTime(ch.start_time);
-            e.target.value = '';
           }}
-          title="Jump to chapter"
+          title="Current chapter — select to jump"
           style={{
             background: 'var(--bg-input)',
             border: '1px solid var(--border)',
             borderRadius: '4px',
-            color: 'var(--text-muted)',
+            color: 'var(--text-secondary)',
             fontSize: '11px',
             fontFamily: 'var(--sans)',
             padding: '2px 4px',
@@ -134,7 +142,6 @@ const GlobalAudioPlayer = () => {
             flexShrink: 0,
           }}
         >
-          <option value="" disabled>Chapters</option>
           {currentAudio.chapters.map((ch, i) => (
             <option key={i} value={i}>{ch.title}</option>
           ))}

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -37,6 +37,12 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
   const [ttsTaskActive, setTtsTaskActive] = useState(false);
   const [sseActive, setSseActive] = useState(false);
   const sseChunkCountRef = useRef(0);
+  // Chapters determined for the currently-cached audio (#145). Held in a
+  // ref so the in-session replay short-circuits below (cached audioSrc /
+  // audioChunks) reuse the same chapter list the player was first loaded
+  // with, instead of dropping the dropdown on a second click. Empty for
+  // recorded-original or unstructured audio.
+  const chaptersRef = useRef([]);
 
   const isNode = nodeId != null;
   const id = isNode ? nodeId : profileId;
@@ -73,11 +79,14 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     if (sseChunkCountRef.current === 1) {
       // First chunk: start playback immediately via loadAudioQueue
       setLoading(false);
-      fetchChapters().then((chapters) => loadAudioQueue(
-        [chunkUrl],
-        { title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters },
-        chunkDuration != null ? [chunkDuration] : null
-      ));
+      fetchChapters().then((chapters) => {
+        chaptersRef.current = chapters;
+        loadAudioQueue(
+          [chunkUrl],
+          { title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters },
+          chunkDuration != null ? [chunkDuration] : null
+        );
+      });
     } else {
       // Subsequent chunks: append to the active queue
       appendChunkToQueue(chunkUrl, chunkDuration);
@@ -134,6 +143,7 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     setTtsTaskActive(false);
     setSseActive(false);
     sseChunkCountRef.current = 0;
+    chaptersRef.current = [];
   }, [nodeId, profileId, content]);
 
   // Clean up SSE on unmount
@@ -187,15 +197,18 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     warmup(); // Unlock audio on Safari during user gesture
 
     try {
-      // If we already have audio chunks cached, play them
+      // If we already have audio chunks cached, play them (carry the
+      // chapters from the first load so a same-session replay keeps the
+      // dropdown — #145)
       if (audioChunks && audioChunks.length > 0) {
-        await loadAudioQueue(audioChunks, { title: fullTitle, id, type: isNode ? 'node' : 'profile' }, audioChunkDurations);
+        await loadAudioQueue(audioChunks, { title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters: chaptersRef.current }, audioChunkDurations);
         return;
       }
 
-      // If we already have a single audio source, play it
+      // If we already have a single audio source, play it (same: preserve
+      // the cached chapters on replay — #145)
       if (audioSrc) {
-        await loadAudio({ url: audioSrc, title: fullTitle, id, type: isNode ? 'node' : 'profile' });
+        await loadAudio({ url: audioSrc, title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters: chaptersRef.current });
         return;
       }
 
@@ -302,6 +315,7 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
       // Load audio into global player (chapters only for TTS audio —
       // recorded-original playback has no section structure, #145)
       const chapters = (!original_url && tts_url) ? await fetchChapters() : [];
+      chaptersRef.current = chapters;
       await loadAudio({ url: srcUrl, title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters });
       setLoading(false);
     } catch (err) {

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -42,10 +42,11 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
   const id = isNode ? nodeId : profileId;
   const baseUrl = isNode ? `/nodes/${id}` : `/profile/${id}`;
 
-  // Extract header from content if available
+  // Extract header from content if available. The "Node N" form is a
+  // fallback only — when the content has a title, show just the title.
   const header = extractMarkdownHeader(content);
   const baseTitle = isNode ? `Node ${id}` : `Profile ${id}`;
-  const fullTitle = header ? `${baseTitle}: ${header}` : baseTitle;
+  const fullTitle = header || baseTitle;
 
   // Chapter list for TTS playback (#145) — empty for unstructured text.
   const fetchChapters = useCallback(async () => {

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -47,6 +47,19 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
   const baseTitle = isNode ? `Node ${id}` : `Profile ${id}`;
   const fullTitle = header ? `${baseTitle}: ${header}` : baseTitle;
 
+  // Chapter list for TTS playback (#145) — empty for unstructured text.
+  const fetchChapters = useCallback(async () => {
+    if (!isNode) return [];
+    try {
+      const res = await api.get(`/nodes/${id}/tts-chapters`, {
+        validateStatus: (s) => s === 200 || s === 404,
+      });
+      return res.status === 200 ? (res.data.chapters || []) : [];
+    } catch (e) {
+      return [];
+    }
+  }, [id, isNode]);
+
   // SSE streaming for TTS chunks
   const handleChunkReady = useCallback((data) => {
     const chunkUrl = data.audio_url.startsWith('http')
@@ -59,16 +72,16 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     if (sseChunkCountRef.current === 1) {
       // First chunk: start playback immediately via loadAudioQueue
       setLoading(false);
-      loadAudioQueue(
+      fetchChapters().then((chapters) => loadAudioQueue(
         [chunkUrl],
-        { title: fullTitle, id, type: isNode ? 'node' : 'profile' },
+        { title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters },
         chunkDuration != null ? [chunkDuration] : null
-      );
+      ));
     } else {
       // Subsequent chunks: append to the active queue
       appendChunkToQueue(chunkUrl, chunkDuration);
     }
-  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue]);
+  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue, fetchChapters]);
 
   const handleAllComplete = useCallback((data) => {
     setSseActive(false);
@@ -285,8 +298,10 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
         : `${process.env.REACT_APP_BACKEND_URL}${urlPath}`;
       setAudioSrc(srcUrl);
 
-      // Load audio into global player
-      await loadAudio({ url: srcUrl, title: fullTitle, id, type: isNode ? 'node' : 'profile' });
+      // Load audio into global player (chapters only for TTS audio —
+      // recorded-original playback has no section structure, #145)
+      const chapters = (!original_url && tts_url) ? await fetchChapters() : [];
+      await loadAudio({ url: srcUrl, title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters });
       setLoading(false);
     } catch (err) {
       console.error('Error playing audio:', err);

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -29,7 +29,7 @@ const extractMarkdownHeader = (content) => {
  */
 const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGenerated }) => {
   const { user } = useUser();
-  const { loadAudio, loadAudioQueue, appendChunkToQueue, setGeneratingTTS, currentAudio, isPlaying, warmup } = useAudio();
+  const { loadAudio, loadAudioQueue, updateChapters, appendChunkToQueue, setGeneratingTTS, currentAudio, isPlaying, warmup } = useAudio();
   const [loading, setLoading] = useState(false);
   const [audioSrc, setAudioSrc] = useState(null);
   const [audioChunks, setAudioChunks] = useState(null); // For chunked playback
@@ -43,6 +43,9 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
   // with, instead of dropping the dropdown on a second click. Empty for
   // recorded-original or unstructured audio.
   const chaptersRef = useRef([]);
+  // Last section_index seen on the SSE stream — used to refresh chapter
+  // start times once per chapter as streaming crosses section boundaries.
+  const lastSectionRef = useRef(null);
 
   const isNode = nodeId != null;
   const id = isNode ? nodeId : profileId;
@@ -75,10 +78,12 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     const chunkDuration = data.duration != null ? data.duration : null;
 
     sseChunkCountRef.current += 1;
+    const section = data.section_index != null ? data.section_index : null;
 
     if (sseChunkCountRef.current === 1) {
       // First chunk: start playback immediately via loadAudioQueue
       setLoading(false);
+      lastSectionRef.current = section;
       fetchChapters().then((chapters) => {
         chaptersRef.current = chapters;
         loadAudioQueue(
@@ -90,8 +95,21 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     } else {
       // Subsequent chunks: append to the active queue
       appendChunkToQueue(chunkUrl, chunkDuration);
+      // When a chunk from a NEW section arrives, every earlier chunk is
+      // already generated — so that chapter's cumulative start time is now
+      // final. Refresh the chapter list so the indicator/seek are correct
+      // progressively during streaming, one chapter at a time, rather than
+      // only at completion (#145). The completion handler re-fetches once
+      // more as a final backstop.
+      if (section != null && section !== lastSectionRef.current) {
+        lastSectionRef.current = section;
+        fetchChapters().then((chapters) => {
+          chaptersRef.current = chapters;
+          updateChapters(id, isNode ? 'node' : 'profile', chapters);
+        });
+      }
     }
-  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue, fetchChapters]);
+  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue, fetchChapters, updateChapters]);
 
   const handleAllComplete = useCallback((data) => {
     setSseActive(false);
@@ -105,12 +123,21 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
         : `${process.env.REACT_APP_BACKEND_URL}${data.tts_url}`;
       setAudioSrc(finalUrl);
     }
+    // The chapters fetched on the first streamed chunk were computed from
+    // chunk durations that weren't all generated yet, so later chapters'
+    // start times clustered together (wrong indicator + wrong seek). Now
+    // that every chunk is generated, re-fetch the final chapters and swap
+    // them into both the live player and the replay cache (#145).
+    fetchChapters().then((chapters) => {
+      chaptersRef.current = chapters;
+      updateChapters(id, isNode ? 'node' : 'profile', chapters);
+    });
     // Fresh generation completes via this SSE path (the tts-status poll is
     // only a fallback), so tell the parent the entry now has TTS — this is
     // what makes the edit "regenerate audio?" prompt (#66) fire without a
     // page refresh.
     if (onTtsGenerated) onTtsGenerated();
-  }, [setGeneratingTTS, onTtsGenerated]);
+  }, [setGeneratingTTS, onTtsGenerated, fetchChapters, updateChapters, id, isNode]);
 
   const { disconnect: disconnectSSE } = useTTSStreamSSE(id, {
     enabled: sseActive,
@@ -144,6 +171,7 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     setSseActive(false);
     sseChunkCountRef.current = 0;
     chaptersRef.current = [];
+    lastSectionRef.current = null;
   }, [nodeId, profileId, content]);
 
   // Clean up SSE on unmount

--- a/frontend/src/contexts/AudioContext.js
+++ b/frontend/src/contexts/AudioContext.js
@@ -805,6 +805,20 @@ export const AudioProvider = ({ children }) => {
     }).catch(() => {});
   }, []);
 
+  // Replace the chapter list on the currently-loaded audio (#145). Used
+  // after TTS generation completes to swap the chapters fetched mid-stream
+  // (their start times were computed from not-yet-generated chunk durations,
+  // so later chapters clustered together) for the final, correctly-spaced
+  // ones. Guarded on id/type so a different audio that started meanwhile is
+  // not clobbered.
+  const updateChapters = useCallback((id, type, chapters) => {
+    setCurrentAudio((prev) =>
+      prev && prev.id === id && prev.type === type
+        ? { ...prev, chapters }
+        : prev
+    );
+  }, []);
+
   const value = {
     currentAudio,
     isPlaying,
@@ -822,6 +836,7 @@ export const AudioProvider = ({ children }) => {
     setGeneratingTTS,
     loadAudio,
     loadAudioQueue,
+    updateChapters,
     appendChunkToQueue,
     play,
     pause,


### PR DESCRIPTION
## ✅ Merged to `main` 2026-06-30 (squash `966bb92`)
Merged out of stack order (by confidence, not stack position): rebased standalone onto `main` — replaying only the #145/#140 commits and dropping the not-yet-merged #203/#204 base — for a clean per-feature diff. See **Post-review fixes** below for two correctness bugs found and fixed during live re-verification.

## Summary
Closes #145, closes #140. Headings become chapters in the audio player — spoken chapter titles, audible chapter pauses, a live now-playing chapter dropdown with click-to-jump, in both live chunked playback and merged-file replay (one code path via the existing `seekToCumulativeTime`).

## Decisions (finalized with maintainer during staging review)
The issue's two open product questions plus the UX details, as decided:

1. **Chapter depth: h1 + h2** are chapters; h3+ stays inside its parent section. One regex to change (`_CHAPTER_HEADING_RE`).
2. **Titles ARE spoken** *(revised from the v0 label-only default)* — bare title with markdown markers stripped, sentence-terminated, separated from the body by a **blank line** (a period alone pauses too briefly; the blank-line pause was ear-tested and approved). Titles already ending in `.!?` keep their punctuation.
3. **Chapter-end pause: ~900ms of real silence** appended to each section's final audio chunk. Text-level whitespace can't carry across sections (each is its own TTS request), so the pause is baked into the audio; it's included in that chunk's recorded duration, keeping chapter `start_time`s exact. Tuning knob: `CHAPTER_END_SILENCE_MS` in `tts.py`.
4. **The dropdown is a live now-playing indicator** *(revised from a static jump menu)* — controlled by the player's `cumulativeTime`, it displays the chapter under the playhead and advances automatically across boundaries; selecting still jumps.
5. **Player title shows just the content title** — the `Node N:` prefix remains only as the fallback for untitled content.
6. Chapter UI renders only for **>1 real section** — unstructured notes keep today's clean player.
7. **Cumulative gapless-pipeline chunk budgets** *(revised after maintainer's stall report — a 9s first chunk was followed by a ~117s second chunk)*: the old schedule sized chunk 2 statically off the *theoretical* 318-char first chunk, so a short first chunk (sentence/section-bounded) stalled playback while chunk 2 generated. Budgets now derive from the **actual emitted chunks**: chunk N may use `(playback banked by chunks 1..N-1) − (generation already committed) − overhead`. Chunk sizes ramp (e.g. 148 → 150 → 281 → 1127 → 2678 chars) and each chunk is ready before playback reaches it, converging to the 4096-char model cap.
8. **#140**: a first sentence under 80 chars triggers a word-aware split at the fast-start budget (no more sub-second first clips).
9. Title-only sections (heading directly followed by another heading) produce no audio.

### Pipeline calibration (live staging measurement)
Solving the SSE `chunk_ready` wall-times from a live staging run gave: API generation ≈ 104 chars/s (matches the modeled 106), but **fixed per-chunk overhead ≈ 7.3s**, not the 2s the model assumed — the difference is pydub MP3 decode, section-end silence re-export, DB status commits, encryption, and the SSE poll interval. The constant is now `TTS_CHUNK_OVERHEAD_SECS = 7.0` (module-level, tests derive bounds from it). This was measured on staging's 512M containers; production should be faster, which only adds margin.

## Reliability notes from staging
- An early reproducible TTS failure turned out **environmental** (did not survive worker-container recreation; OOM under the 512M staging cap is the leading suspect). Two mitigations shipped here: `tts-status` now surfaces FAILURE details (scrubbed per automated security review — exception type + message, with keys/paths/response bodies stripped), and streaming the multi-part concat is noted as a follow-up if it recurs.
- Verification methodology note: `/media` paths repeat across staging DB wipes and nginx caches them for 24h — audio verification used cache-busted URLs and WebAudio amplitude analysis (the chapter-end silence is confirmed as literal zero-RMS at the boundary).

## Verification
- 12 tests (section splitting, the #140 stall regression, a gapless-pipeline invariant over mixed short/long sections, boundary-respecting chunking, global fast-start, spoken-title formatting + punctuation, empty-section skip, #140 fallback, chapters endpoint incl. legacy rows + cumulative start times). Full suite green; frontend builds.
- Staging, end-to-end and ear-tested by maintainer: chapters generate with exact start times, dropdown tracks playback live and jumps correctly, spoken titles + both pauses approved, title display clean.

## Post-review fixes (rebase + live re-verification, 2026-06-30)
Two real correctness bugs — both latent in the original PR, surfaced only by exercising the live *generate-then-listen* path on staging — were found and fixed on-branch before merge:

1. **Chapters dropdown vanished on a same-session replay** (`626a2c5`). After generation, `handleAllComplete` caches the merged `tts.mp3` in `audioSrc`; a second in-session click then short-circuited through the cached `audioSrc`/`audioChunks` branches in `SpeakerIcon.handlePlay`, which replayed *without* chapters. A page reload looked fine because a fresh mount clears the cache and falls through to the single-file `loadAudio` path, which does re-fetch chapters. Fixed by holding the chapters for the currently-cached audio in a `chaptersRef` (set on the SSE first-chunk and single-file load paths, reset on node/content change) and passing them on both cached-replay branches; recorded-original audio keeps an empty list, so its playback shows no chapters as before.

2. **Wrong chapter start times during in-session generation** (`3b340b6`). The chapters fetched on the first streamed chunk computed `start_time` from cumulative chunk *durations*, but later chunks weren't generated yet (null durations) — so later chapters clustered at the same time. Symptom (in-session, until reload): the now-playing indicator skipped Middle→Final, clicking Middle showed Final, and clicking Final replayed Middle. Fixed by re-fetching the chapter list and swapping it into the live player + replay cache **(a)** progressively as streaming crosses each section boundary — the `chunk_ready` SSE event carries `section_index`, so once a new section's chunk arrives every earlier chunk is generated and that chapter's cumulative start time is final — and **(b)** once more at generation completion as a backstop. New `AudioContext.updateChapters(id, type, chapters)` performs the swap, guarded on `id`/`type` so a different audio that started meanwhile is not clobbered.

Re-verified live on staging (in-session, **no reload**): during playback the indicator stays on Middle through 0:19–0:23 and switches to Final exactly at the 23.98s boundary; selecting Middle from the dropdown seeks to 0:11 / "Middle theme", selecting Final seeks to 0:23 / "Final theme"; and the dropdown survives close-player → replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
