### PR TITLE
fix(#88,#127): mic-interruption auto-pause + resume re-acquire; lifecycle flush; sendBeacon; 59-min chime

### DIFF
--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -5,6 +5,46 @@ import { isSpendBlocked, notifySpendBlocked } from '../utils/spendCap';
 import { useToast } from '../contexts/ToastContext';
 
 /**
+ * Play a rising two-note "wrap up soon" chime via the Web Audio API.
+ * Rising + repeated so it reads as an attention cue, not a failure (cf.
+ * the descending playErrorSound in useStreamingTranscription — same idiom).
+ * The sound matters more than the toast here: long recordings often run
+ * with the screen off / phone pocketed via headphones, where a visual
+ * toast is never seen. Best-effort — silently ignored if audio is
+ * unavailable or blocked.
+ */
+function playWarningSound() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    // Recording implies a prior user gesture, but the context can still be
+    // suspended when the tab is backgrounded (screen off) — resume it.
+    if (ctx.state === 'suspended') ctx.resume();
+    const playTone = (freq, startTime, duration) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.type = 'triangle';
+      gain.gain.setValueAtTime(0.2, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    // Two rising G5 -> C6 chimes, repeated for salience in a pocket.
+    playTone(784, now, 0.18);
+    playTone(1047, now + 0.20, 0.24);
+    playTone(784, now + 0.52, 0.18);
+    playTone(1047, now + 0.72, 0.30);
+    setTimeout(() => ctx.close(), 1200);
+  } catch (e) {
+    // Audio not available - silently ignore
+    console.warn('[StreamingMicButton] Could not play warning sound:', e);
+  }
+}
+
+/**
  * StreamingMicButton - A microphone button that supports real-time streaming transcription.
  *
  * When recording, audio chunks are sent to the server every 5 minutes (configurable)
@@ -50,16 +90,19 @@ export default function StreamingMicButton({
     onError,
   });
 
-  // #127: warn before the ~60-minute mark so a long recording can be
-  // wrapped up deliberately instead of silently degrading.
+  // #127: warn just before the ~60-minute cliff so a long recording can be
+  // wrapped up deliberately instead of silently dropping content. Fires once
+  // per recording, with a sound as well as a toast — these sessions often run
+  // with the screen off, so a visual-only warning would go unnoticed.
   const { addToast } = useToast();
   const longRecordingWarnedRef = useRef(false);
   useEffect(() => {
     if (duration < 1) longRecordingWarnedRef.current = false;
-    if (duration >= 55 * 60 && !longRecordingWarnedRef.current) {
+    if (duration >= 59 * 60 && !longRecordingWarnedRef.current) {
       longRecordingWarnedRef.current = true;
+      playWarningSound();
       addToast(
-        'You\u2019ve been recording for 55 minutes — consider stopping '
+        'You\u2019ve been recording for 59 minutes — consider stopping '
         + 'soon and continuing in a new recording.', 10000);
     }
   }, [duration, addToast]);

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -1,7 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStreamingTranscription } from '../hooks/useStreamingTranscription';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
 import { isSpendBlocked, notifySpendBlocked } from '../utils/spendCap';
+import { useToast } from '../contexts/ToastContext';
 
 /**
  * StreamingMicButton - A microphone button that supports real-time streaming transcription.
@@ -48,6 +49,20 @@ export default function StreamingMicButton({
     onComplete,
     onError,
   });
+
+  // #127: warn before the ~60-minute mark so a long recording can be
+  // wrapped up deliberately instead of silently degrading.
+  const { addToast } = useToast();
+  const longRecordingWarnedRef = useRef(false);
+  useEffect(() => {
+    if (duration < 1) longRecordingWarnedRef.current = false;
+    if (duration >= 55 * 60 && !longRecordingWarnedRef.current) {
+      longRecordingWarnedRef.current = true;
+      addToast(
+        'You\u2019ve been recording for 55 minutes — consider stopping '
+        + 'soon and continuing in a new recording.', 10000);
+    }
+  }, [duration, addToast]);
 
   const isOnline = useOnlineStatus();
   const isIdleOffline = !isOnline && sessionState === 'idle';

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -42,6 +42,7 @@ export function useStreamingMediaRecorder({
   const durationIntervalRef = useRef(null);
   const stopResolveRef = useRef(null); // Resolve fn for the stop promise
   const dataAvailableFiredRef = useRef(false); // Track if ondataavailable ran during stop
+  const lifecycleCleanupRef = useRef(null); // #88 visibility/pagehide listeners
   const pausedAtRef = useRef(null); // Timestamp when paused
   const totalPausedMsRef = useRef(0); // Accumulated paused duration
   const mimeTypeRef = useRef(null); // Active recorder's mimeType (so non-state callbacks like getPartialBlob can read it)
@@ -60,6 +61,10 @@ export function useStreamingMediaRecorder({
 
   const resetRecording = useCallback(() => {
     // Clean up previous recording
+    if (lifecycleCleanupRef.current) {
+      lifecycleCleanupRef.current();
+      lifecycleCleanupRef.current = null;
+    }
     if (mediaUrl) {
       URL.revokeObjectURL(mediaUrl);
     }
@@ -253,6 +258,10 @@ export function useStreamingMediaRecorder({
       };
 
       mediaRecorder.onstop = () => {
+        if (lifecycleCleanupRef.current) {
+          lifecycleCleanupRef.current();
+          lifecycleCleanupRef.current = null;
+        }
         console.log(`[StreamingRecorder] onstop fired: totalChunks=${chunksRef.current.length}, chunkIndex=${chunkIndexRef.current}`);
         // Combine all chunks into final blob
         const blob = new Blob(chunksRef.current, { type: mediaRecorder.mimeType });
@@ -296,6 +305,28 @@ export function useStreamingMediaRecorder({
       const durationOffsetMs = durationOffset * 1000;
 
       // Start recording with timeslice for chunked output
+      // #88: flush the in-flight timeslice when the page is about to be
+      // hidden or unloaded (phone call, lock screen, tab switch, kill).
+      // requestData() emits the buffered audio through the normal
+      // ondataavailable → upload path while the page can still run JS;
+      // the upload layer adds a sendBeacon fallback for dying pages.
+      const lifecycleFlush = () => {
+        if (recorderRef.current
+            && recorderRef.current.state === 'recording') {
+          console.log('[StreamingRecorder] Lifecycle flush (visibility/pagehide)');
+          try { recorderRef.current.requestData(); } catch (e) { /* no-op */ }
+        }
+      };
+      const onVisibility = () => {
+        if (document.visibilityState === 'hidden') lifecycleFlush();
+      };
+      window.addEventListener('pagehide', lifecycleFlush);
+      document.addEventListener('visibilitychange', onVisibility);
+      lifecycleCleanupRef.current = () => {
+        window.removeEventListener('pagehide', lifecycleFlush);
+        document.removeEventListener('visibilitychange', onVisibility);
+      };
+
       // The timeslice parameter makes ondataavailable fire at the specified interval
       mediaRecorder.start(chunkIntervalMs);
       setStatus('recording');

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -43,6 +43,10 @@ export function useStreamingMediaRecorder({
   const stopResolveRef = useRef(null); // Resolve fn for the stop promise
   const dataAvailableFiredRef = useRef(false); // Track if ondataavailable ran during stop
   const lifecycleCleanupRef = useRef(null); // #88 visibility/pagehide listeners
+  const trackCleanupRef = useRef(null); // #88 mic-track mute/ended listeners
+  const interruptedRef = useRef(false); // #88 mic taken by the OS (phone call / lock screen)
+  const userStopRef = useRef(false); // A user-initiated stop is in flight
+  const durationOffsetMsRef = useRef(0); // ms of audio recorded before this session (resume)
   const pausedAtRef = useRef(null); // Timestamp when paused
   const totalPausedMsRef = useRef(0); // Accumulated paused duration
   const mimeTypeRef = useRef(null); // Active recorder's mimeType (so non-state callbacks like getPartialBlob can read it)
@@ -65,6 +69,10 @@ export function useStreamingMediaRecorder({
       lifecycleCleanupRef.current();
       lifecycleCleanupRef.current = null;
     }
+    if (trackCleanupRef.current) {
+      trackCleanupRef.current();
+      trackCleanupRef.current = null;
+    }
     if (mediaUrl) {
       URL.revokeObjectURL(mediaUrl);
     }
@@ -86,6 +94,9 @@ export function useStreamingMediaRecorder({
     pausedAtRef.current = null;
     totalPausedMsRef.current = 0;
     mimeTypeRef.current = null;
+    interruptedRef.current = false;
+    userStopRef.current = false;
+    durationOffsetMsRef.current = 0;
     setMediaBlob(null);
     setMediaUrl('');
     setDuration(0);
@@ -93,6 +104,159 @@ export function useStreamingMediaRecorder({
     setError(null);
     setStatus('idle');
   }, [mediaUrl]);
+
+  // Wire ondataavailable/onstop/onerror on a recorder instance. Shared by the
+  // initial start and the interruption re-acquire path (#88) so both
+  // recorders behave identically. Every handler guards on
+  // recorderRef.current so a stale recorder (replaced by reset or
+  // re-acquire) can't emit chunks into the wrong session or clobber UI
+  // state after teardown.
+  const wireRecorder = useCallback((mediaRecorder, stream) => {
+    // MediaRecorder with a timeslice emits format-specific fragments
+    // of one continuous stream — only chunk 0 has the init prefix
+    // (Matroska EBML/Segment/Tracks for WebM, ftyp+moov for fMP4);
+    // chunks 1+ are header-less fragment bodies whose timestamps are
+    // absolute to the original recording. Per the respective byte-stream
+    // formats, those fragments concatenated in order as raw bytes form
+    // exactly one valid file. So we upload each blob verbatim and let
+    // the backend do the binary concat + a single remux pass to rewrite
+    // duration metadata.
+    mediaRecorder.ondataavailable = (e) => {
+      if (recorderRef.current !== mediaRecorder) {
+        // Stale recorder — drop the data, but never strand a pending stop.
+        if (stopResolveRef.current) {
+          stopResolveRef.current();
+          stopResolveRef.current = null;
+        }
+        return;
+      }
+      const recorderState = recorderRef.current?.state || 'unknown';
+      console.log(`[StreamingRecorder] ondataavailable fired: size=${e.data?.size || 0}, recorderState=${recorderState}, timeSinceStart=${Date.now() - startTimeRef.current}ms`);
+
+      dataAvailableFiredRef.current = true;
+
+      if (e.data && e.data.size > 0) {
+        chunksRef.current.push(e.data);
+
+        if (onChunkReady) {
+          const chunkIndex = chunkIndexRef.current;
+          chunkIndexRef.current += 1;
+          setChunkCount(prev => prev + 1);
+
+          console.log(`[StreamingRecorder] Chunk ${chunkIndex} ready: size=${e.data.size}, totalChunks=${chunksRef.current.length}`);
+          onChunkReady(e.data, chunkIndex);
+        }
+      } else {
+        console.warn(`[StreamingRecorder] ondataavailable with empty data: size=${e.data?.size}, recorderState=${recorderState}`);
+      }
+
+      if (stopResolveRef.current) {
+        stopResolveRef.current();
+        stopResolveRef.current = null;
+      }
+    };
+
+    mediaRecorder.onstop = () => {
+      if (recorderRef.current !== mediaRecorder) return;
+
+      // #88: the recorder can stop on its own when the OS takes the mic
+      // for good (track 'ended' — phone call / lock screen, esp. iOS).
+      // That is an interruption, not a user stop (user stops set
+      // userStopRef first): hold the session paused so the user can
+      // resume with a re-acquired mic instead of finalizing half-dead.
+      const track = stream.getAudioTracks()[0];
+      const trackDied = interruptedRef.current
+        || (track && track.readyState === 'ended');
+      if (trackDied && !userStopRef.current) {
+        console.log('[StreamingRecorder] onstop from mic interruption — holding paused for resume');
+        interruptedRef.current = true;
+        stream.getTracks().forEach(t => t.stop());
+        if (!pausedAtRef.current) pausedAtRef.current = Date.now();
+        setStatus('paused');
+        return;
+      }
+
+      if (lifecycleCleanupRef.current) {
+        lifecycleCleanupRef.current();
+        lifecycleCleanupRef.current = null;
+      }
+      if (trackCleanupRef.current) {
+        trackCleanupRef.current();
+        trackCleanupRef.current = null;
+      }
+      console.log(`[StreamingRecorder] onstop fired: totalChunks=${chunksRef.current.length}, chunkIndex=${chunkIndexRef.current}`);
+      // Combine all chunks into final blob
+      const blob = new Blob(chunksRef.current, { type: mediaRecorder.mimeType });
+      const url = URL.createObjectURL(blob);
+      setMediaBlob(blob);
+      setMediaUrl(url);
+
+      const ms = Date.now() - startTimeRef.current - totalPausedMsRef.current + durationOffsetMsRef.current;
+      setDuration(ms / 1000);
+      setStatus('recorded');
+      userStopRef.current = false;
+
+      // Stop duration tracking
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+        durationIntervalRef.current = null;
+      }
+
+      // Stop all tracks
+      stream.getTracks().forEach(track => track.stop());
+
+      // Fallback: if ondataavailable didn't fire (no data to emit),
+      // resolve the stop promise here so stopStreaming doesn't hang.
+      // When ondataavailable DID fire, it resolves the promise itself
+      // after its async work completes — so we skip this.
+      if (stopResolveRef.current && !dataAvailableFiredRef.current) {
+        console.log('[StreamingRecorder] onstop resolving stop promise (no ondataavailable)');
+        stopResolveRef.current();
+        stopResolveRef.current = null;
+      }
+    };
+
+    mediaRecorder.onerror = (e) => {
+      console.error('MediaRecorder error:', e);
+      setError(e.error?.message || 'Recording error');
+      setStatus('idle');
+    };
+  }, [onChunkReady]);
+
+  // #88: watch the mic track for OS-level interruption (phone call, lock
+  // screen). 'mute' = capture suspended (may or may not come back);
+  // 'ended' = gone for good. Either way the recorder would keep
+  // "recording" silence with the timer climbing, so flush what's buffered
+  // and auto-pause. Deliberately NO auto-resume on 'unmute' — the user
+  // resumes explicitly (lock-screen play button), and resumeRecording
+  // re-acquires the mic if the track died.
+  const watchTrack = useCallback((mediaRecorder, stream) => {
+    const track = stream.getAudioTracks()[0];
+    if (!track) return;
+    const onInterruption = (e) => {
+      if (recorderRef.current !== mediaRecorder) return;
+      if (mediaRecorder.state === 'recording') {
+        console.log(`[StreamingRecorder] Mic track ${e.type} (phone call / lock screen) — auto-pausing`);
+        interruptedRef.current = true;
+        // Flush buffered audio through the normal upload path first —
+        // same mechanism as a user pause.
+        try { mediaRecorder.requestData(); } catch (err) { /* no-op */ }
+        try { mediaRecorder.pause(); } catch (err) { /* no-op */ }
+        if (!pausedAtRef.current) pausedAtRef.current = Date.now();
+        setStatus('paused');
+      } else if (e.type === 'ended') {
+        // Already paused (or auto-stopped): just mark the track dead so
+        // resume knows to re-acquire rather than resume into silence.
+        interruptedRef.current = true;
+      }
+    };
+    track.addEventListener('mute', onInterruption);
+    track.addEventListener('ended', onInterruption);
+    trackCleanupRef.current = () => {
+      track.removeEventListener('mute', onInterruption);
+      track.removeEventListener('ended', onInterruption);
+    };
+  }, []);
 
   // startingChunkIndex: offset for chunk numbering when resuming an interrupted session
   // durationOffset: seconds of audio already recorded before this session
@@ -221,88 +385,15 @@ export function useStreamingMediaRecorder({
       chunksRef.current = [];
       chunkIndexRef.current = startingChunkIndex;
 
-      // MediaRecorder with a timeslice emits format-specific fragments
-      // of one continuous stream — only chunk 0 has the init prefix
-      // (Matroska EBML/Segment/Tracks for WebM, ftyp+moov for fMP4);
-      // chunks 1+ are header-less fragment bodies whose timestamps are
-      // absolute to the original recording. Per the respective byte-stream
-      // formats, those fragments concatenated in order as raw bytes form
-      // exactly one valid file. So we upload each blob verbatim and let
-      // the backend do the binary concat + a single remux pass to rewrite
-      // duration metadata.
-      mediaRecorder.ondataavailable = (e) => {
-        const recorderState = recorderRef.current?.state || 'unknown';
-        console.log(`[StreamingRecorder] ondataavailable fired: size=${e.data?.size || 0}, recorderState=${recorderState}, timeSinceStart=${Date.now() - startTimeRef.current}ms`);
-
-        dataAvailableFiredRef.current = true;
-
-        if (e.data && e.data.size > 0) {
-          chunksRef.current.push(e.data);
-
-          if (onChunkReady) {
-            const chunkIndex = chunkIndexRef.current;
-            chunkIndexRef.current += 1;
-            setChunkCount(prev => prev + 1);
-
-            console.log(`[StreamingRecorder] Chunk ${chunkIndex} ready: size=${e.data.size}, totalChunks=${chunksRef.current.length}`);
-            onChunkReady(e.data, chunkIndex);
-          }
-        } else {
-          console.warn(`[StreamingRecorder] ondataavailable with empty data: size=${e.data?.size}, recorderState=${recorderState}`);
-        }
-
-        if (stopResolveRef.current) {
-          stopResolveRef.current();
-          stopResolveRef.current = null;
-        }
-      };
-
-      mediaRecorder.onstop = () => {
-        if (lifecycleCleanupRef.current) {
-          lifecycleCleanupRef.current();
-          lifecycleCleanupRef.current = null;
-        }
-        console.log(`[StreamingRecorder] onstop fired: totalChunks=${chunksRef.current.length}, chunkIndex=${chunkIndexRef.current}`);
-        // Combine all chunks into final blob
-        const blob = new Blob(chunksRef.current, { type: mediaRecorder.mimeType });
-        const url = URL.createObjectURL(blob);
-        setMediaBlob(blob);
-        setMediaUrl(url);
-
-        const ms = Date.now() - startTimeRef.current - totalPausedMsRef.current + durationOffsetMs;
-        setDuration(ms / 1000);
-        setStatus('recorded');
-
-        // Stop duration tracking
-        if (durationIntervalRef.current) {
-          clearInterval(durationIntervalRef.current);
-          durationIntervalRef.current = null;
-        }
-
-        // Stop all tracks
-        stream.getTracks().forEach(track => track.stop());
-
-        // Fallback: if ondataavailable didn't fire (no data to emit),
-        // resolve the stop promise here so stopStreaming doesn't hang.
-        // When ondataavailable DID fire, it resolves the promise itself
-        // after its async work completes — so we skip this.
-        if (stopResolveRef.current && !dataAvailableFiredRef.current) {
-          console.log('[StreamingRecorder] onstop resolving stop promise (no ondataavailable)');
-          stopResolveRef.current();
-          stopResolveRef.current = null;
-        }
-      };
-
-      mediaRecorder.onerror = (e) => {
-        console.error('MediaRecorder error:', e);
-        setError(e.error?.message || 'Recording error');
-        setStatus('idle');
-      };
+      wireRecorder(mediaRecorder, stream);
+      watchTrack(mediaRecorder, stream);
 
       startTimeRef.current = Date.now();
       totalPausedMsRef.current = 0;
       pausedAtRef.current = null;
-      const durationOffsetMs = durationOffset * 1000;
+      interruptedRef.current = false;
+      userStopRef.current = false;
+      durationOffsetMsRef.current = durationOffset * 1000;
 
       // Start recording with timeslice for chunked output
       // #88: flush the in-flight timeslice when the page is about to be
@@ -335,7 +426,7 @@ export function useStreamingMediaRecorder({
       // Start duration tracking (subtracts paused time from elapsed)
       durationIntervalRef.current = setInterval(() => {
         if (startTimeRef.current && !pausedAtRef.current) {
-          const elapsed = Date.now() - startTimeRef.current - totalPausedMsRef.current + durationOffsetMs;
+          const elapsed = Date.now() - startTimeRef.current - totalPausedMsRef.current + durationOffsetMsRef.current;
           setDuration(elapsed / 1000);
         }
       }, 1000);
@@ -355,7 +446,7 @@ export function useStreamingMediaRecorder({
       }
       throw err;
     }
-  }, [resetRecording, chunkIntervalMs, onChunkReady]);
+  }, [resetRecording, chunkIntervalMs, wireRecorder, watchTrack]);
 
   const pauseRecording = useCallback(() => {
     if (recorderRef.current && recorderRef.current.state === 'recording') {
@@ -369,17 +460,81 @@ export function useStreamingMediaRecorder({
     }
   }, []);
 
-  const resumeRecording = useCallback(() => {
-    if (recorderRef.current && recorderRef.current.state === 'paused') {
-      // Accumulate the time spent paused
+  const resumeRecording = useCallback(async () => {
+    const rec = recorderRef.current;
+    if (!rec) return;
+
+    const track = streamRef.current ? streamRef.current.getAudioTracks()[0] : null;
+    const trackAlive = !!(track && track.readyState === 'live' && !track.muted);
+
+    if (rec.state === 'paused' && trackAlive) {
+      // Healthy mic: a plain user pause, or the OS gave the track back
+      // after an interruption (Android often unmutes once the call ends).
       if (pausedAtRef.current) {
         totalPausedMsRef.current += Date.now() - pausedAtRef.current;
         pausedAtRef.current = null;
       }
-      recorderRef.current.resume();
+      interruptedRef.current = false;
+      rec.resume();
       setStatus('recording');
+      return;
     }
-  }, []);
+
+    // Only an interruption leaves us here: paused on a muted/dead track,
+    // or the recorder auto-stopped when the track ended. Anything else
+    // (e.g. resume while actively recording) is a no-op.
+    if (rec.state !== 'paused' && !interruptedRef.current) return;
+
+    // #88: re-acquire the mic with a fresh getUserMedia + MediaRecorder —
+    // after a phone call the old track never delivers audio again. The new
+    // recorder's first chunk carries its own init segment; the server
+    // detects init-bearing chunks at N>0 and splits transcription into
+    // subsessions (#124), so chunk numbering simply continues. (chunksRef
+    // then spans two container streams — the local preview blob may only
+    // play up to the boundary; the server-side merge is canonical.)
+    console.log('[StreamingRecorder] Resuming after interruption — re-acquiring microphone');
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Detach + release the dead recorder/stream only once the new mic
+      // is granted, so a failed re-acquire leaves the paused state intact.
+      if (trackCleanupRef.current) {
+        trackCleanupRef.current();
+        trackCleanupRef.current = null;
+      }
+      const oldRecorder = rec;
+      const oldStream = streamRef.current;
+      oldRecorder.ondataavailable = null;
+      oldRecorder.onstop = null;
+      oldRecorder.onerror = null;
+      try {
+        if (oldRecorder.state !== 'inactive') oldRecorder.stop();
+      } catch (e) { /* already dead */ }
+      if (oldStream) oldStream.getTracks().forEach(t => t.stop());
+
+      streamRef.current = stream;
+      const mediaRecorder = new MediaRecorder(
+        stream,
+        mimeTypeRef.current ? { mimeType: mimeTypeRef.current } : undefined
+      );
+      recorderRef.current = mediaRecorder;
+      wireRecorder(mediaRecorder, stream);
+      watchTrack(mediaRecorder, stream);
+      mediaRecorder.start(chunkIntervalMs);
+
+      if (pausedAtRef.current) {
+        totalPausedMsRef.current += Date.now() - pausedAtRef.current;
+        pausedAtRef.current = null;
+      }
+      interruptedRef.current = false;
+      setError(null);
+      setStatus('recording');
+    } catch (err) {
+      // Stay paused — the user can retry resume, or stop and keep
+      // everything recorded up to the interruption (already uploaded).
+      console.error('[StreamingRecorder] Mic re-acquire failed:', err);
+      setError(err.message || 'Could not re-acquire microphone');
+    }
+  }, [wireRecorder, watchTrack, chunkIntervalMs]);
 
   const stopRecording = useCallback(() => {
     const state = recorderRef.current?.state;
@@ -396,6 +551,9 @@ export function useStreamingMediaRecorder({
       return new Promise((resolve) => {
         dataAvailableFiredRef.current = false;
         stopResolveRef.current = resolve;
+        // Mark this as a USER stop so onstop finalizes normally even when
+        // the mic track died mid-session (#88 interruption handling).
+        userStopRef.current = true;
         // stop() fires a final ondataavailable with all remaining data, then onstop.
         // Do NOT call requestData() before stop() — it creates a race condition
         // where the final chunk's ondataavailable may not fire reliably.

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -114,6 +114,28 @@ export function useStreamingTranscription(options = {}) {
     const family = blobType.split(';')[0].trim().toLowerCase();
     const ext = family === 'audio/mp4' ? '.mp4' : '.webm';
 
+    // #88: if the page is hidden (phone call / lock screen / closing),
+    // a normal XHR may be killed mid-flight. sendBeacon survives page
+    // death; fire it first and still run the normal upload — the server
+    // dedupes by chunk_index, so a double-delivery is harmless.
+    if (typeof document !== 'undefined'
+        && document.visibilityState === 'hidden'
+        && navigator.sendBeacon) {
+      try {
+        const beaconForm = new FormData();
+        beaconForm.append('chunk', blob, `chunk_${chunkIndex}${ext}`);
+        beaconForm.append('chunk_index', chunkIndex.toString());
+        beaconForm.append('mime_type', blobType);
+        const sent = navigator.sendBeacon(
+          `${process.env.REACT_APP_BACKEND_URL}/api/drafts/streaming/${sessionId}/audio-chunk`,
+          beaconForm
+        );
+        console.log(`[StreamingTranscription] sendBeacon fallback for chunk ${chunkIndex}: ${sent ? 'queued' : 'rejected'}`);
+      } catch (e) {
+        console.warn('[StreamingTranscription] sendBeacon failed', e);
+      }
+    }
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const formData = new FormData();


### PR DESCRIPTION
## Rebased standalone onto `main`

This was originally the tip of the 2026-06-10 overnight branch stack (branched off #208), so the body previously read "⚠️ merge AFTER #208." That was a **branch-stacking artifact, not a logical dependency** — this PR's only real change is 3 frontend files with zero overlap with #208's external-content work. Rebased with `git rebase --onto origin/main <#208-base>`, dropping #208 and the rest of the stack, so the branch is now `main` + this one commit and can merge on its own confidence.

Closes #88

## Summary
Voice-durability follow-up to #124 (#204), per the round plan. (#23 closed not-planned by maintainer.)

- **#88**: `visibilitychange(hidden)` / `pagehide` flush the in-flight MediaRecorder timeslice via `requestData()` (same mechanism the pause path already trusts), so up to 15s of audio stops evaporating when a call comes in or the phone locks. Uploads that start on a hidden page additionally fire a `sendBeacon` copy first — beacons survive page death; the existing server-side `chunk_index` dedupe makes the occasional double-delivery a no-op.
- **#88 mic-interruption handling** (added 2026-07-07 after Peter's live phone-call repro — transcript ended at the ring, post-call speech lost, timer kept climbing): the OS mutes/kills the mic track on a phone call, but MediaRecorder keeps "recording" silence. Now the mic track's `mute`/`ended` events **flush the buffered timeslice and auto-pause** (timer freezes, lock screen shows "Paused"). Deliberately **no auto-resume on unmute** — resume is explicit via the existing iOS lock-screen play button, and `resumeRecording` **re-acquires the mic** (fresh `getUserMedia` + `MediaRecorder`) when the track died. The re-acquired recorder's first chunk is init-bearing at index N>0, which the server already detects and splits into subsessions (#124) — chunk numbering simply continues. A recorder that stops on its own with a dead track is held paused for resume instead of finalizing half-dead; user stops finalize normally (`userStopRef`). Handler wiring extracted to `wireRecorder()`/`watchTrack()` with stale-guards on every handler (a replaced recorder can no longer emit chunks into the wrong session after reset/re-acquire — closes a latent race).
- **#127 warning slice**: one-shot warning at 59 minutes — toast **plus a rising two-note Web Audio chime** (these sessions often run screen-off / phone pocketed, so a visual-only toast is never seen). This is only the warning slice — the deeper 60-min hardening stays open in #127 (intentionally **not** closed by this PR).

## Verification
- Frontend build clean (no ESLint warnings, +309 B gzipped); flush listeners attach/detach with recorder lifecycle (no leaks across retakes).
- **Staging pass (2026-07-07, deployed bundle `main.1ae7361c.js`, live mic recording):** dispatched synthetic `visibilitychange(hidden)` and `pagehide` mid-recording. Confirmed in console: `Lifecycle flush (visibility/pagehide)` fired on every event, each flush emitted a **mid-timeslice** `ondataavailable` (chunks landed at 24.9s/28.1s between the 15s slices) and each flushed chunk uploaded successfully. The tab was natively hidden (backgrounded window), so every upload also exercised the sendBeacon path end-to-end.
- **Observed sendBeacon nuance:** beacons `queued` for chunks ≤64 KB but were `rejected` by Chrome for full-size ~240 KB chunks (per-origin beacon quota). This is fine for the design intent — the flush-at-hide chunk is a small partial slice — and rejection degrades gracefully to the normal upload, which completed every time. Worth knowing: the beacon safety net does not cover full 15s chunks.
- **Dedupe path exercised for real:** the synthetic `pagehide` also tripped the pre-existing draft-save/resume flow, which re-uploaded all prior chunks (identical sizes, same `chunk_index`) — all accepted, server dedupe makes the double-delivery a no-op exactly as designed.
- **Real phone-call/lock-screen repro remains yours** — it needs a physical phone (triage-documented limitation).
- The 59-min warning is timer-driven; verified by code path + the one-shot guard logic (waiting 59 real minutes isn't automatable). The chime mirrors the existing playErrorSound Web Audio idiom and resumes a suspended AudioContext (backgrounded tab) before playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

