### PR TITLE
fix(#183): full profile regen preserves user-written profiles (chronology-correct)

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -26,6 +26,17 @@ from flask_cors import CORS
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 def create_app():
+    # Error monitoring (roadmap Phase 0). No-op unless SENTRY_DSN is set.
+    sentry_dsn = os.environ.get("SENTRY_DSN")
+    if sentry_dsn:
+        import sentry_sdk
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+            send_default_pii=False,   # never attach user content/PII
+            traces_sample_rate=0.0,   # errors only, no perf tracing
+        )
+
     app = Flask(__name__)
     app.config.from_object(Config)
 
@@ -156,6 +167,15 @@ def create_app():
     # --------------------------------------------------------------------
     from backend.routes.sse import sse_bp
     app.register_blueprint(sse_bp, url_prefix="/api/sse")
+
+    # --------------------------------------------------------------------
+    # Health checks – liveness/readiness for monitoring (no auth).
+    # --------------------------------------------------------------------
+    from backend.routes.health import health_bp
+    app.register_blueprint(health_bp)
+    # Also under /api so the checks are reachable through the public
+    # nginx proxy (which only forwards /api, /auth, /media to Flask).
+    app.register_blueprint(health_bp, url_prefix="/api", name="health_api_bp")
 
     # Register CLI commands
     from backend.init_db import (

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -142,6 +142,9 @@ def create_app():
     from backend.routes.ai_preferences import ai_preferences_bp
     app.register_blueprint(ai_preferences_bp, url_prefix="/api/ai-preferences")
 
+    from backend.routes.artifacts import artifacts_bp
+    app.register_blueprint(artifacts_bp, url_prefix="/api/artifacts")
+
     from backend.routes.prompts import prompts_bp
     app.register_blueprint(prompts_bp, url_prefix="/api/prompts")
 

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -156,6 +156,9 @@ def create_app():
     from backend.routes.artifacts import artifacts_bp
     app.register_blueprint(artifacts_bp, url_prefix="/api/artifacts")
 
+    from backend.routes.external import external_bp
+    app.register_blueprint(external_bp, url_prefix="/api/external")
+
     from backend.routes.prompts import prompts_bp
     app.register_blueprint(prompts_bp, url_prefix="/api/prompts")
 

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -51,6 +51,11 @@ celery.conf.update(
             'task': 'backend.tasks.profile_batch.poll_profile_batches',
             'schedule': 60.0,  # ~1 min — batches typically finish in 1-5 min
         },
+        # No-op unless ANTHROPIC_SPEND_LIMIT_USD is set (issue #85).
+        'check-api-spend': {
+            'task': 'backend.tasks.spend_monitor.check_api_spend',
+            'schedule': 3600.0,  # hourly
+        },
     },
 )
 
@@ -73,3 +78,4 @@ from backend.tasks import voice_todo_merge  # noqa: F401
 from backend.tasks import recent_context  # noqa: F401
 from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
+from backend.tasks import spend_monitor  # noqa: F401

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -85,3 +85,4 @@ from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
 from backend.tasks import spend_monitor  # noqa: F401
 from backend.tasks import embeddings  # noqa: F401
+from backend.tasks import external_sync  # noqa: F401

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -41,6 +41,11 @@ celery.conf.update(
             'task': 'backend.tasks.node_cleanup.cleanup_deleted_nodes',
             'schedule': 86400.0,  # daily
         },
+        # Semantic-search embedding sweep (issue #155).
+        'sweep-embeddings': {
+            'task': 'backend.tasks.embeddings.sweep_embeddings',
+            'schedule': 300.0,  # every 5 min — new content searchable fast
+        },
         # Profile batch pipeline (issue #173). No-ops unless a user is
         # selected via PROFILE_USE_BATCH / PROFILE_BATCH_USER_IDS.
         'seed-profile-batches': {
@@ -73,3 +78,4 @@ from backend.tasks import voice_todo_merge  # noqa: F401
 from backend.tasks import recent_context  # noqa: F401
 from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
+from backend.tasks import embeddings  # noqa: F401

--- a/backend/config.py
+++ b/backend/config.py
@@ -194,6 +194,15 @@ class Config:
         "gpt-4o-transcribe": {"price_per_minute_usd": 0.006},
     }
 
+    # --- X (Twitter) API for bookmark sync (#155 / Download) ---
+    # Pay-per-use tier; OAuth2 PKCE app. Unset = feature env-gated off.
+    X_CLIENT_ID = os.environ.get("X_CLIENT_ID")
+    X_CLIENT_SECRET = os.environ.get("X_CLIENT_SECRET")
+    X_REDIRECT_URI = os.environ.get(
+        "X_REDIRECT_URI",
+        "https://loore.org/api/external/twitter/callback",
+    )
+
     # Magic link email authentication (SMTP)
     MAIL_SERVER = os.environ.get("MAIL_SERVER", "localhost")
     MAIL_PORT = int(os.environ.get("MAIL_PORT", "587"))

--- a/backend/config.py
+++ b/backend/config.py
@@ -74,6 +74,8 @@ class Config:
             "context_window": 1050000,
             "input_price_per_mtok": 5.00,
             "output_price_per_mtok": 30.00,
+            # OpenAI auto-cache discount (#189): GPT-5.5 caches at 75% off
+            "cached_input_multiplier": 0.25,
             "long_context_threshold": 272000,
             "long_context_input_multiplier": 2.0,
             "long_context_output_multiplier": 1.5,

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,6 +24,18 @@ class Config:
     # Default model (for backward compatibility and fallback)
     DEFAULT_LLM_MODEL = os.environ.get("LLM_NAME", "claude-opus-4.6")
 
+    # --- API spend monitoring (issue #85) ---
+    # Monthly Anthropic spend cap in USD. 0 (default) disables the check.
+    ANTHROPIC_SPEND_LIMIT_USD = float(
+        os.environ.get("ANTHROPIC_SPEND_LIMIT_USD", "0") or "0"
+    )
+    # Comma-separated fractions of the limit at which to alert.
+    SPEND_ALERT_THRESHOLDS = os.environ.get(
+        "SPEND_ALERT_THRESHOLDS", "0.5,0.8,0.95"
+    )
+    # Recipient for spend alerts (admin inbox also used for signup notices).
+    SPEND_ALERT_EMAIL = os.environ.get("SPEND_ALERT_EMAIL", "signup@loore.org")
+
     # --- Profile-generation batch processing (issue #173, Part A) ---
     # A user takes the Batch API path if the global switch is on OR their id
     # is in the canary allowlist. Both default off → batch ships dark.

--- a/backend/llm_providers.py
+++ b/backend/llm_providers.py
@@ -186,15 +186,18 @@ class LLMProvider:
             if m.get("content")
         ])
 
-        # Convert remaining messages to Anthropic format
+        # Convert remaining messages to Anthropic format. Content blocks
+        # are passed through as-is (#187): block boundaries and any
+        # cache_control markers placed upstream must survive — flattening
+        # to a string would erase the cache breakpoints.
         anthropic_messages = []
         for msg in messages:
             if msg["role"] in ["user", "assistant"]:
                 content = msg["content"]
-                # Convert content format if needed
                 if isinstance(content, list) and len(content) > 0:
-                    if isinstance(content[0], dict) and "text" in content[0]:
-                        content = content[0]["text"]
+                    if not (isinstance(content[0], dict)
+                            and "text" in content[0]):
+                        content = str(content)
                 anthropic_messages.append({
                     "role": msg["role"],
                     "content": content
@@ -208,7 +211,11 @@ class LLMProvider:
             max_tokens = DEFAULT_MAX_OUTPUT_TOKENS
 
         # Log the actual API call details
-        total_input_chars = sum(len(m.get("content", "")) for m in anthropic_messages)
+        total_input_chars = sum(
+            (len(m["content"]) if isinstance(m["content"], str)
+             else sum(len(b.get("text", "")) for b in m["content"]))
+            for m in anthropic_messages
+        )
         logger.info(f"Anthropic API call: model={model}, num_messages={len(anthropic_messages)}, total_input_chars={total_input_chars}, max_tokens={max_tokens}")
 
         kwargs = dict(
@@ -255,11 +262,21 @@ class LLMProvider:
         if truncated:
             logger.warning(f"Anthropic response truncated (max_tokens reached): model={model}, output_tokens={response.usage.output_tokens}")
 
+        cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+        cache_write = getattr(
+            response.usage, "cache_creation_input_tokens", 0) or 0
+        if cache_read or cache_write:
+            logger.info(
+                f"Anthropic prompt cache: read={cache_read} "
+                f"write={cache_write} uncached={response.usage.input_tokens}")
+
         return {
             "content": content,
             "total_tokens": total_tokens,
             "input_tokens": response.usage.input_tokens,
             "output_tokens": response.usage.output_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_write,
             "tool_calls": tool_calls,
             "truncated": truncated,
         }

--- a/backend/llm_providers.py
+++ b/backend/llm_providers.py
@@ -35,7 +35,8 @@ class LLMProvider:
 
     @staticmethod
     def get_completion(model_id: str, messages: list, api_keys: dict,
-                       max_tokens: int = None, tools: list = None) -> dict:
+                       max_tokens: int = None, tools: list = None,
+                       prompt_cache_key: str = None) -> dict:
         """
         Generate a completion using the specified model.
 
@@ -71,7 +72,7 @@ class LLMProvider:
         if provider == "openai":
             return LLMProvider._call_openai(
                 api_model, messages, api_keys["openai"], max_tokens,
-                tools=tools)
+                tools=tools, prompt_cache_key=prompt_cache_key)
         elif provider == "anthropic":
             return LLMProvider._call_anthropic(
                 api_model, messages, api_keys["anthropic"], max_tokens,
@@ -81,7 +82,8 @@ class LLMProvider:
 
     @staticmethod
     def _call_openai(model: str, messages: list, api_key: str,
-                     max_tokens: int = None, tools: list = None) -> dict:
+                     max_tokens: int = None, tools: list = None,
+                     prompt_cache_key: str = None) -> dict:
         """
         Call OpenAI API with the given model and messages.
 
@@ -102,6 +104,10 @@ class LLMProvider:
             temperature=1,
             max_completion_tokens=max_tokens or DEFAULT_MAX_OUTPUT_TOKENS,
         )
+        # #189: a stable per-conversation key improves OpenAI's automatic
+        # prefix-cache routing (best-effort; no behavior change otherwise).
+        if prompt_cache_key:
+            kwargs["prompt_cache_key"] = prompt_cache_key
 
         # Convert Anthropic-format tools to OpenAI format
         if tools:
@@ -148,11 +154,22 @@ class LLMProvider:
         if truncated:
             logger.warning(f"OpenAI response truncated (max_tokens reached): model={model}, output_tokens={response.usage.completion_tokens}")
 
+        # #189: OpenAI auto-caches >=1024-token prefixes; cached_tokens is
+        # the cached SUBSET of prompt_tokens (unlike Anthropic's disjoint
+        # counters) and is billed at a discount we must account for.
+        details = getattr(response.usage, "prompt_tokens_details", None)
+        cached_tokens = getattr(details, "cached_tokens", 0) or 0
+        if cached_tokens:
+            logger.info(
+                f"OpenAI prompt cache: cached={cached_tokens} of "
+                f"{response.usage.prompt_tokens} prompt tokens")
+
         return {
             "content": message.content or "",
             "total_tokens": response.usage.total_tokens,
             "input_tokens": response.usage.prompt_tokens,
             "output_tokens": response.usage.completion_tokens,
+            "cached_tokens": cached_tokens,
             "tool_calls": tool_calls,
             "truncated": truncated,
         }

--- a/backend/models.py
+++ b/backend/models.py
@@ -785,6 +785,10 @@ class TTSChunk(db.Model):
     profile_id = db.Column(db.Integer, db.ForeignKey("user_profile.id"), nullable=True)
     # Zero-based index of the chunk
     chunk_index = db.Column(db.Integer, nullable=False)
+    # Chapter metadata (#145): which markdown section this chunk belongs
+    # to. section_title is None for content before the first heading.
+    section_index = db.Column(db.Integer, nullable=True)
+    section_title = db.Column(db.String(256), nullable=True)
     # URL to the audio chunk file
     audio_url = db.Column(db.String, nullable=True)
     # Duration of the audio chunk in seconds (from pydub/ffprobe)

--- a/backend/models.py
+++ b/backend/models.py
@@ -593,6 +593,8 @@ class UserArtifact(db.Model):
     DEFAULT_KINDS = {
         "memory": "Memory",
         "scratchpad": "Scratchpad",
+        # Long-running aspirations the AI helps clarify and track (#150)
+        "intentions": "Intentions",
     }
 
     def set_content(self, plaintext):

--- a/backend/models.py
+++ b/backend/models.py
@@ -274,6 +274,21 @@ class Node(db.Model):
     def has_artifact(self, artifact_type):
         return self.get_artifact_row(artifact_type) is not None
 
+    def get_user_artifacts(self):
+        """Load pinned UserArtifact instances ({kind: artifact}).
+
+        Multiple "user_artifact" rows may exist per node (one per kind,
+        pinned at session start — #191).
+        """
+        result = {}
+        for a in self.context_artifacts:
+            if a.artifact_type != "user_artifact":
+                continue
+            row = UserArtifact.query.get(a.artifact_id)
+            if row is not None:
+                result[row.kind] = row
+        return result
+
     def get_artifact(self, artifact_type):
         """Load and return the actual model instance for *artifact_type*."""
         row = self.get_artifact_row(artifact_type)
@@ -542,6 +557,79 @@ class UserAIPreferences(db.Model):
     ai_usage = db.Column(db.String(16), nullable=False, default="chat")
 
     user = db.relationship("User", backref="ai_preferences")
+
+    def set_content(self, plaintext):
+        self.content = encrypt_content(plaintext)
+
+    def get_content(self):
+        return decrypt_content(self.content)
+
+
+class UserArtifact(db.Model):
+    """Generic named user artifact (issue #158): "memory", "scratchpad",
+    and user/LLM-created artifacts.
+
+    Append-only versioning like UserAIPreferences — each update inserts a
+    new row; the latest row per (user_id, kind) is current. Content is
+    encrypted at rest and included in data exports as a default Loore
+    artifact.
+    """
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    # Slug identifying the artifact across versions, e.g. "memory".
+    kind = db.Column(db.String(48), nullable=False, index=True)
+    title = db.Column(db.String(128), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    generated_by = db.Column(db.String(64), nullable=False)
+    tokens_used = db.Column(db.Integer, nullable=False, default=0)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    privacy_level = db.Column(db.String(16), nullable=False, default="private")
+    # Artifacts are LLM working memory — must be AI-readable to function.
+    ai_usage = db.Column(db.String(16), nullable=False, default="chat")
+
+    user = db.relationship("User", backref="artifacts")
+
+    # Default artifacts every user has (created lazily on first write).
+    DEFAULT_KINDS = {
+        "memory": "Memory",
+        "scratchpad": "Scratchpad",
+    }
+
+    def set_content(self, plaintext):
+        self.content = encrypt_content(plaintext)
+
+    def get_content(self):
+        return decrypt_content(self.content)
+
+    @classmethod
+    def latest_for(cls, user_id, kind):
+        return cls.query.filter_by(user_id=user_id, kind=kind).order_by(
+            cls.created_at.desc(), cls.id.desc()).first()
+
+    @classmethod
+    def latest_per_kind(cls, user_id):
+        """Latest version of every artifact kind the user has, as a dict."""
+        rows = cls.query.filter_by(user_id=user_id).order_by(
+            cls.created_at.asc(), cls.id.asc()).all()
+        latest = {}
+        for row in rows:
+            latest[row.kind] = row  # later rows overwrite earlier
+        return latest
+
+
+class UserFeedback(db.Model):
+    """User feedback captured via the LLM submit_feedback tool (#158),
+    for batch triage by the creators."""
+    __tablename__ = "user_feedback"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    category = db.Column(db.String(32), nullable=False, default="general")
+    source = db.Column(db.String(16), nullable=False, default="llm")
+    status = db.Column(db.String(16), nullable=False, default="new")
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    user = db.relationship("User", backref="feedback_items")
 
     def set_content(self, plaintext):
         self.content = encrypt_content(plaintext)

--- a/backend/models.py
+++ b/backend/models.py
@@ -12,6 +12,10 @@ class User(db.Model, UserMixin):
     description = db.Column(db.String(128), nullable=True, default="")
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     accepted_terms_at = db.Column(db.DateTime, nullable=True)
+    # First-login onboarding walkthrough completion (#147). NULL for
+    # pre-feature users too — at alpha scale they see the flow once
+    # (doubles as a what's-new tour) rather than being grandfathered.
+    onboarding_completed_at = db.Column(db.DateTime, nullable=True)
     accepted_terms_version = db.Column(db.String(16), nullable=True)
     # NEW: Approval status for our alpha (whitelisting) and optional email.
     approved = db.Column(db.Boolean, default=False, nullable=False)

--- a/backend/models.py
+++ b/backend/models.py
@@ -631,6 +631,27 @@ class APICostLog(db.Model):
     user = db.relationship("User", backref="api_cost_logs")
 
 
+class SpendAlert(db.Model):
+    """Dedupe record for API spend-limit alerts (issue #85).
+
+    One row per (provider, month, threshold) that has already been
+    alerted, so the hourly check never re-sends the same alert within
+    a calendar month.
+    """
+    __tablename__ = "spend_alert"
+    id = db.Column(db.Integer, primary_key=True)
+    provider = db.Column(db.String(32), nullable=False)
+    month = db.Column(db.String(7), nullable=False)  # "YYYY-MM" (UTC)
+    threshold = db.Column(db.Float, nullable=False)  # fraction of limit, e.g. 0.8
+    spend_usd = db.Column(db.Float, nullable=False)  # spend at alert time
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint("provider", "month", "threshold",
+                            name="uq_spend_alert_provider_month_threshold"),
+    )
+
+
 class TTSChunk(db.Model):
     """
     Stores individual TTS audio chunk URLs for streaming TTS playback.

--- a/backend/models.py
+++ b/backend/models.py
@@ -746,6 +746,99 @@ class SpendAlert(db.Model):
     )
 
 
+class ExternalItem(db.Model):
+    """External content imported into Loore (#155 component 2 / Download).
+
+    References the user consumes — Community Archive tweets, Twitter/X
+    bookmarks — kept SEPARATE from authored Nodes so profile generation,
+    exports, and the lore concept stay about the user's own words.
+    Content is encrypted at rest like all user data.
+    """
+    __tablename__ = "external_item"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    # 'community_archive' | 'twitter_bookmark'
+    source = db.Column(db.String(32), nullable=False)
+    # Stable per-source identifier (tweet id) for dedupe
+    external_id = db.Column(db.String(64), nullable=False)
+    author_handle = db.Column(db.String(64), nullable=True)
+    content = db.Column(db.Text, nullable=False)
+    url = db.Column(db.String(512), nullable=True)
+    posted_at = db.Column(db.DateTime, nullable=True)
+    fetched_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="external_items")
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "source", "external_id",
+                            name="uq_external_item_user_source_ext"),
+    )
+
+    def set_content(self, plaintext):
+        self.content = encrypt_content(plaintext)
+
+    def get_content(self):
+        return decrypt_content(self.content)
+
+
+class ExternalAccount(db.Model):
+    """A connected external account (OAuth), e.g. X for bookmark sync.
+
+    Tokens are encrypted at rest. One row per (user, provider).
+    """
+    __tablename__ = "external_account"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    provider = db.Column(db.String(32), nullable=False)  # 'twitter'
+    external_user_id = db.Column(db.String(64), nullable=True)
+    handle = db.Column(db.String(64), nullable=True)
+    access_token = db.Column(db.Text, nullable=True)
+    refresh_token = db.Column(db.Text, nullable=True)
+    token_expires_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    last_synced_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship("User", backref="external_accounts")
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "provider",
+                            name="uq_external_account_user_provider"),
+    )
+
+    def set_tokens(self, access_token, refresh_token=None):
+        self.access_token = encrypt_content(access_token or "")
+        if refresh_token is not None:
+            self.refresh_token = encrypt_content(refresh_token)
+
+    def get_access_token(self):
+        return decrypt_content(self.access_token) if self.access_token else None
+
+    def get_refresh_token(self):
+        return decrypt_content(self.refresh_token) if self.refresh_token else None
+
+
+class ExternalItemEmbedding(db.Model):
+    """Embedding for an ExternalItem (mirrors NodeEmbedding, #155)."""
+    __tablename__ = "external_item_embedding"
+    id = db.Column(db.Integer, primary_key=True)
+    item_id = db.Column(
+        db.Integer,
+        db.ForeignKey("external_item.id", ondelete="CASCADE"),
+        nullable=False, unique=True, index=True,
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    model = db.Column(db.String(64), nullable=False)
+    content_hash = db.Column(db.String(64), nullable=False)
+    vector = db.Column(db.LargeBinary, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    item = db.relationship("ExternalItem", backref=db.backref(
+        "embedding", uselist=False, cascade="all, delete-orphan"))
+
+
 class NodeEmbedding(db.Model):
     """Vector embedding of a node's content for semantic search (#155).
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -631,6 +631,33 @@ class APICostLog(db.Model):
     user = db.relationship("User", backref="api_cost_logs")
 
 
+class NodeEmbedding(db.Model):
+    """Vector embedding of a node's content for semantic search (#155).
+
+    One row per node (latest content only — re-embedded when content_hash
+    changes). Vectors are packed float32 (struct) — no pgvector dependency;
+    similarity is brute-force cosine in Python, fine at alpha scale.
+    Only nodes with ai_usage in AI_ALLOWED are embedded (embedding sends
+    content to OpenAI, so 'none' nodes are never submitted).
+    """
+    __tablename__ = "node_embedding"
+    id = db.Column(db.Integer, primary_key=True)
+    node_id = db.Column(
+        db.Integer,
+        db.ForeignKey("node.id", ondelete="CASCADE"),
+        nullable=False, unique=True, index=True,
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    model = db.Column(db.String(64), nullable=False)
+    content_hash = db.Column(db.String(64), nullable=False)
+    vector = db.Column(db.LargeBinary, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    node = db.relationship("Node", backref=db.backref(
+        "embedding", uselist=False, cascade="all, delete-orphan"))
+
+
 class TTSChunk(db.Model):
     """
     Stores individual TTS audio chunk URLs for streaming TTS playback.

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -43,11 +43,18 @@ A proposal goes through these statuses:
 - **failed** — something went wrong. You'll see `[todo-proposal:6428: failed — {error}.]`. Let the user know.
 
 ## Tools
-You have three tools available. Always provide a response alongside any tool call. Tool calls are silent side effects. When using a tool, briefly acknowledge what you're doing.
+You have six tools available. Always provide a response alongside any tool call. Tool calls are silent side effects. When using a tool, briefly acknowledge what you're doing.
 
 - **apply_todo_changes** — Apply previously proposed todo changes. Only call when the user explicitly confirms (e.g. "apply those changes", "yes update my todo").
 - **apply_github_issue** — Create the previously proposed GitHub issue. Call this only when the user explicitly confirms (e.g. "yes create it", "go ahead", "file that issue").
 - **update_ai_preferences** — Update how the user wants you to interact with them. Call proactively when they express preferences about tone, style, boundaries, topics to avoid, etc.
+- **update_artifact** — Create or update a persistent artifact. Two built-in artifacts are always in your context below: `memory` (durable facts about the user that future sessions should know — write here proactively whenever you learn something worth keeping: a recurring theme, a decision, a fact about their life or work) and `scratchpad` (your own working notes for ongoing threads — current state, open questions, where you left off). Pass the FULL updated text, not a diff. You can also create new artifact kinds when the user asks for a persistent document (e.g. a reading list).
+- **read_artifact** — Pull the full content of an artifact from the index below into context. The content arrives at the start of the NEXT turn, so tell the user you're pulling it up. Never call it for `memory` or `scratchpad` — those are already below.
+- **submit_feedback** — Pass the user's feedback about Loore itself to its creators. Offer it when they express praise, frustration, or product ideas that don't fit a GitHub issue.
+
+## Memory discipline
+
+At the start of a session, check `memory` for context relevant to what the user brings up. During the conversation, when you learn something durable — update `memory` with the full revised text, pruning anything outdated. Keep memory dense and factual; keep transient session state in `scratchpad` instead. Don't announce routine memory updates beyond a brief acknowledgment.
 
 <user_profile>
 {user_profile}
@@ -71,3 +78,18 @@ The last ~10,000 tokens of raw entries (uncompressed). This window may overlap w
 The user's notes on how they want you to interact.
 {user_ai_preferences}
 </user_ai_preferences>
+
+<user_memory>
+Durable facts and observations you chose to remember about this user across sessions. Maintain via update_artifact("memory", ...).
+{user_memory}
+</user_memory>
+
+<user_scratchpad>
+Your working notes for ongoing threads. Maintain via update_artifact("scratchpad", ...).
+{user_scratchpad}
+</user_scratchpad>
+
+<user_artifacts_index>
+Other persistent artifacts. Pull one into context with read_artifact.
+{user_artifacts_index}
+</user_artifacts_index>

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -9,6 +9,8 @@ The session may be in one of two modes, and the user can switch between them mid
 
 The current mode is indicated at the start of the conversation, and you'll be notified if the user switches modes.
 
+Messages in this conversation are prefixed with bracketed timestamps like `[2026-06-10 08:30 UTC]` — system metadata for your temporal awareness. Never include such timestamps in your own replies; in Voice Mode they would be read aloud.
+
 Your role here is not to perform therapy or coaching — it's to be a thoughtful, honest conversational partner who has access to this person's profile, recent context, todo list, and AI interaction preferences. The user's profile, if included below, is an AI-generated summary of their full archive and represents the system's current understanding of them. Notice connections to recurring themes, growth edges, or patterns they tend to circle around. Trust it as useful but imperfect. If the profile is empty or unavailable, simply work with what the user has shared — their words alone are enough. If the profile seems skewed or incomplete, trust what the user is sharing now over the profile.
 
 Respond naturally — the user chose Loore because they want genuine engagement with what they're saying, not warmth performed on command. Start with a short reflection of what the user said and then take it from there based on what the user requests or what you feel is right. Say what you actually see — including the uncomfortable thing, if there is one. Don't prematurely fall into problem solving, unless explicitly asked for.

--- a/backend/prompts/agentic.txt
+++ b/backend/prompts/agentic.txt
@@ -58,6 +58,27 @@ You have six tools available. Always provide a response alongside any tool call.
 
 At the start of a session, check `memory` for context relevant to what the user brings up. During the conversation, when you learn something durable — update `memory` with the full revised text, pruning anything outdated. Keep memory dense and factual; keep transient session state in `scratchpad` instead. Don't announce routine memory updates beyond a brief acknowledgment.
 
+## Intentions
+
+Intentions are the user's longer-running aspirations — directional, sometimes half-formed, distinct from concrete todos. Your role is to help the user notice, verbalize, and stay conscious of them. The tracked list is in `<user_intentions>` below.
+
+**Detecting.** When something in the user's writing sounds like an intention surfacing — a recurring wish, a "someday" theme, a value they keep circling, friction they keep mentioning — gently name it and ask whether it's something they want to hold as an intention. Be tentative: you're offering a mirror, not assigning homework. Don't do this when the user is mid-emotional-processing or when it would derail their thread; once per conversation at most, and never twice about the same theme after they decline.
+
+**Clarifying.** Before recording a new intention, help the user articulate it in their own words — what it actually is, why it matters, what it would look like to live it. A short exchange is enough; don't interrogate.
+
+**Recording.** When the user confirms, update the `intentions` artifact via update_artifact (full text, not a diff). Keep this structure per intention:
+
+```
+## <short name>
+*held since <date> — active*
+<the intention in the user's own words, 1-3 sentences>
+- <date>: <brief note on how it surfaced or evolved>
+```
+
+**Tracking.** When a conversation touches a held intention, connect it explicitly and append a dated note. If the user has clearly been living one, reflect that back. When an intention has gone quiet for a long stretch and the moment is right, check in on it — without guilt-tripping.
+
+**Closing.** There are two equally good endings: the intention is *fulfilled* (or absorbed into who they are), or the user *consciously releases* it. Mark the status line accordingly (`fulfilled <date>` / `consciously released <date>`) and keep the entry — released intentions are part of the lore, not failures to be deleted.
+
 <user_profile>
 {user_profile}
 </user_profile>
@@ -90,6 +111,11 @@ Durable facts and observations you chose to remember about this user across sess
 Your working notes for ongoing threads. Maintain via update_artifact("scratchpad", ...).
 {user_scratchpad}
 </user_scratchpad>
+
+<user_intentions>
+The user's tracked intentions (see the Intentions section). Maintain via update_artifact("intentions", ...).
+{user_intentions}
+</user_intentions>
 
 <user_artifacts_index>
 Other persistent artifacts. Pull one into context with read_artifact.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ redis==5.0.1
 ffmpeg-python==0.2.0
 google-cloud-kms>=2.0.0
 cryptography>=41.0.0
+sentry-sdk[flask]>=2.0.0

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -176,3 +176,46 @@ def activate_and_welcome(user_id):
         "approved": True,
         "email_sent": True,
     }), 200
+
+
+@admin_bp.route("/feedback", methods=["GET"])
+@login_required
+@admin_required
+def list_feedback():
+    """List user feedback submitted via the LLM tool (issue #158)."""
+    from backend.models import UserFeedback
+
+    status = request.args.get("status")
+    query = UserFeedback.query
+    if status:
+        query = query.filter_by(status=status)
+    items = query.order_by(UserFeedback.created_at.desc()).limit(500).all()
+
+    return jsonify({"feedback": [
+        {
+            "id": f.id,
+            "user_id": f.user_id,
+            "username": f.user.username if f.user else None,
+            "content": f.get_content(),
+            "category": f.category,
+            "source": f.source,
+            "status": f.status,
+            "created_at": iso_utc(f.created_at),
+        }
+        for f in items
+    ]}), 200
+
+
+@admin_bp.route("/feedback/<int:feedback_id>", methods=["PUT"])
+@login_required
+@admin_required
+def update_feedback_status(feedback_id):
+    from backend.models import UserFeedback
+
+    feedback = UserFeedback.query.get_or_404(feedback_id)
+    status = (request.get_json() or {}).get("status")
+    if status not in ("new", "reviewed", "done"):
+        return jsonify({"error": "Invalid status"}), 400
+    feedback.status = status
+    db.session.commit()
+    return jsonify({"id": feedback.id, "status": feedback.status}), 200

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -176,3 +176,46 @@ def activate_and_welcome(user_id):
         "approved": True,
         "email_sent": True,
     }), 200
+
+
+@admin_bp.route("/spend", methods=["GET"])
+@login_required
+@admin_required
+def spend_status():
+    """Month-to-date API spend + limit status (issue #85)."""
+    from backend.models import SpendAlert
+    from backend.utils.spend import (
+        get_month_spend_microdollars, parse_thresholds,
+    )
+
+    config = current_app.config
+    now = datetime.utcnow()
+    month = now.strftime("%Y-%m")
+
+    total = get_month_spend_microdollars(config, now=now)
+    anthropic = get_month_spend_microdollars(config, provider="anthropic", now=now)
+    openai = get_month_spend_microdollars(config, provider="openai", now=now)
+
+    limit_usd = config.get("ANTHROPIC_SPEND_LIMIT_USD") or 0
+    alerts = SpendAlert.query.filter_by(month=month).order_by(
+        SpendAlert.threshold).all()
+
+    return jsonify({
+        "month": month,
+        "total_usd": total / 1_000_000,
+        "anthropic_usd": anthropic / 1_000_000,
+        "openai_usd": openai / 1_000_000,
+        "limit_usd": limit_usd,
+        "limit_fraction_used": (
+            (anthropic / 1_000_000) / limit_usd if limit_usd > 0 else None
+        ),
+        "thresholds": parse_thresholds(config.get("SPEND_ALERT_THRESHOLDS")),
+        "alerts_fired": [
+            {
+                "threshold": a.threshold,
+                "spend_usd": a.spend_usd,
+                "at": iso_utc(a.created_at),
+            }
+            for a in alerts
+        ],
+    }), 200

--- a/backend/routes/artifacts.py
+++ b/backend/routes/artifacts.py
@@ -1,0 +1,140 @@
+"""User artifact routes (issue #158).
+
+Artifacts are generic named, versioned documents (memory, scratchpad,
+custom kinds). Same append-only versioning contract as AI preferences:
+PUT inserts a new row; the latest row per (user, kind) is current.
+"""
+import re
+
+from flask import Blueprint, jsonify, request
+from flask_login import login_required, current_user
+
+from backend.extensions import db
+from backend.models import UserArtifact
+from backend.utils.timefmt import iso_utc
+
+artifacts_bp = Blueprint("artifacts", __name__)
+
+_KIND_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,47}$')
+
+
+def _serialize(artifact, version_number=None, include_content=True):
+    data = {
+        "id": artifact.id,
+        "kind": artifact.kind,
+        "title": artifact.title,
+        "generated_by": artifact.generated_by,
+        "created_at": iso_utc(artifact.created_at),
+        "privacy_level": artifact.privacy_level,
+        "ai_usage": artifact.ai_usage,
+    }
+    if include_content:
+        data["content"] = artifact.get_content()
+    if version_number is not None:
+        data["version_number"] = version_number
+    return data
+
+
+@artifacts_bp.route("/", methods=["GET"])
+@login_required
+def list_artifacts():
+    """Latest version of each artifact kind, defaults included even when
+    they don't exist yet (so the UI can always render memory/scratchpad)."""
+    latest = UserArtifact.latest_per_kind(current_user.id)
+    items = []
+    for kind, title in UserArtifact.DEFAULT_KINDS.items():
+        if kind in latest:
+            continue
+        items.append({
+            "id": None, "kind": kind, "title": title, "content": "",
+            "generated_by": None, "created_at": None,
+            "privacy_level": "private", "ai_usage": "chat",
+        })
+    for kind in sorted(latest):
+        items.append(_serialize(latest[kind]))
+    return jsonify({"artifacts": items}), 200
+
+
+@artifacts_bp.route("/<kind>", methods=["GET"])
+@login_required
+def get_artifact(kind):
+    artifact = UserArtifact.latest_for(current_user.id, kind)
+    if artifact is None:
+        if kind in UserArtifact.DEFAULT_KINDS:
+            return jsonify({"artifact": {
+                "id": None, "kind": kind,
+                "title": UserArtifact.DEFAULT_KINDS[kind],
+                "content": "", "generated_by": None, "created_at": None,
+                "privacy_level": "private", "ai_usage": "chat",
+            }}), 200
+        return jsonify({"error": "Artifact not found"}), 404
+
+    version_count = UserArtifact.query.filter_by(
+        user_id=current_user.id, kind=kind).count()
+    return jsonify(
+        {"artifact": _serialize(artifact, version_number=version_count)}
+    ), 200
+
+
+@artifacts_bp.route("/<kind>", methods=["PUT"])
+@login_required
+def update_artifact(kind):
+    """Create a new version of an artifact (creates the kind if new)."""
+    if not _KIND_RE.match(kind):
+        return jsonify({"error": (
+            "Invalid kind: use a short lowercase slug "
+            "(letters, digits, dashes)."
+        )}), 400
+
+    data = request.get_json() or {}
+    content = data.get("content")
+    if content is None:
+        return jsonify({"error": "Content is required"}), 400
+
+    previous = UserArtifact.latest_for(current_user.id, kind)
+    title = (data.get("title") or "").strip()
+    if not title:
+        title = (previous.title if previous
+                 else UserArtifact.DEFAULT_KINDS.get(
+                     kind, kind.replace("-", " ").title()))
+
+    artifact = UserArtifact(
+        user_id=current_user.id,
+        kind=kind,
+        title=title[:128],
+        generated_by=data.get("generated_by", "user"),
+        tokens_used=0,
+    )
+    artifact.set_content(content)
+    db.session.add(artifact)
+    db.session.commit()
+
+    version_count = UserArtifact.query.filter_by(
+        user_id=current_user.id, kind=kind).count()
+    return jsonify(
+        {"artifact": _serialize(artifact, version_number=version_count)}
+    ), 200
+
+
+@artifacts_bp.route("/<kind>/versions", methods=["GET"])
+@login_required
+def get_artifact_versions(kind):
+    rows = UserArtifact.query.filter_by(
+        user_id=current_user.id, kind=kind
+    ).order_by(UserArtifact.created_at.desc(), UserArtifact.id.desc()).all()
+
+    total = len(rows)
+    versions = [
+        _serialize(row, version_number=total - i, include_content=False)
+        for i, row in enumerate(rows)
+    ]
+    return jsonify({"versions": versions}), 200
+
+
+@artifacts_bp.route("/versions/<int:version_id>", methods=["GET"])
+@login_required
+def get_artifact_version(version_id):
+    artifact = UserArtifact.query.get_or_404(version_id)
+    if artifact.user_id != current_user.id:
+        return jsonify({"error": "Unauthorized"}), 403
+    return jsonify({"artifact": _serialize(artifact)}), 200

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -3,6 +3,8 @@ import re
 from flask import Blueprint, jsonify, request
 from flask_login import login_required, current_user
 from backend.models import Node, User, UserProfile
+from datetime import datetime
+
 from backend.extensions import db
 from backend.utils.timefmt import iso_utc, is_valid_timezone
 from backend.utils.privacy import (
@@ -111,6 +113,7 @@ def get_dashboard():
             "description": current_user.description,
             "accepted_terms_at": iso_utc(current_user.accepted_terms_at),
             "terms_up_to_date": _terms_up_to_date(current_user),
+            "onboarding_completed": current_user.onboarding_completed_at is not None,
             "approved": current_user.approved,
             "email": current_user.email,
             "is_admin": current_user.is_admin,
@@ -245,6 +248,7 @@ def update_user():
                 "approved": current_user.approved,
                 "accepted_terms_at": iso_utc(current_user.accepted_terms_at),
                 "terms_up_to_date": _terms_up_to_date(current_user),
+            "onboarding_completed": current_user.onboarding_completed_at is not None,
                 "is_admin": current_user.is_admin,
                 "plan": current_user.plan,
                 "voice_mode_enabled": voice_mode_enabled,
@@ -280,3 +284,16 @@ def update_timezone():
         return jsonify({"error": "Failed to update timezone.",
                         "details": str(e)}), 500
     return jsonify({"timezone": current_user.timezone}), 200
+
+
+@dashboard_bp.route("/onboarding/complete", methods=["POST"])
+@login_required
+def complete_onboarding():
+    """Mark the first-login onboarding walkthrough as completed (#147).
+
+    Idempotent — both finishing and skipping the flow land here.
+    """
+    if current_user.onboarding_completed_at is None:
+        current_user.onboarding_completed_at = datetime.utcnow()
+        db.session.commit()
+    return jsonify({"onboarding_completed": True}), 200

--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -10,7 +10,9 @@ import shutil
 from backend.utils.audio_storage import move_draft_audio_to_node_dir
 from backend.utils.encryption import encrypt_file
 from backend.utils.llm_nodes import pick_model_for_generation
-from backend.utils.webm_utils import persist_init_segment
+from backend.utils.webm_utils import (
+    chunk_is_init_bearing, persist_init_segment,
+)
 
 drafts_bp = Blueprint("drafts_bp", __name__)
 
@@ -615,6 +617,29 @@ def upload_streaming_chunk(session_id):
         # if persist_init_segment raised, we don't want a half-committed
         # mime that'd survive a future early-commit refactor.
         draft.streaming_mime_type = form_mime_family
+    elif chunk_is_init_bearing(chunk_path):
+        # A chunk N>0 that carries its own stream header came from a
+        # fresh MediaRecorder — the user resumed a recovered recording
+        # (#124). Persist its init under an index-suffixed name so
+        # transcription can split the batch into subsessions instead of
+        # binary-concatenating incompatible streams (which silently
+        # drops the pre-resume audio at remux).
+        #
+        # Unlike chunk 0 we do NOT reject the upload on extraction
+        # failure: the chunk's audio is real and already streamed once —
+        # rejecting would lose it outright, while keeping it preserves
+        # at worst today's behavior for this subsession.
+        try:
+            persist_init_segment(chunk_path, chunk_dir, index=chunk_index)
+            current_app.logger.info(
+                f"Session {session_id}: chunk {chunk_index} opens a new "
+                f"subsession (resumed recording); init persisted"
+            )
+        except (ValueError, OSError) as exc:
+            current_app.logger.error(
+                f"Failed to extract subsession init from chunk "
+                f"{chunk_index} of session {session_id}: {exc}"
+            )
 
     # Encrypt the audio chunk at rest
     encrypted_path = encrypt_file(str(chunk_path))

--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -2,7 +2,7 @@ from flask import Blueprint, jsonify, Response, request, current_app
 from flask_login import login_required, current_user
 from backend.models import (
     Node, NodeVersion, UserProfile, UserPrompt, UserTodo,
-    UserAIPreferences,
+    UserAIPreferences, UserArtifact,
 )
 from backend.extensions import db
 from backend.utils.tokens import approximate_token_count, get_model_context_window
@@ -278,6 +278,17 @@ def format_node_tree(
                 UserAIPreferences.created_at <= ai_prefs.created_at,
             ).count()
             result += f"[AI Preferences v{ai_prefs_ver} (ref #{ai_prefs.id})]\n"
+
+        for kind, artifact in sorted(node.get_user_artifacts().items()):
+            artifact_ver = UserArtifact.query.filter(
+                UserArtifact.user_id == artifact.user_id,
+                UserArtifact.kind == kind,
+                UserArtifact.created_at <= artifact.created_at,
+            ).count()
+            result += (
+                f"[Artifact '{kind}' v{artifact_ver} "
+                f"(ref #{artifact.id})]\n"
+            )
 
         result += "\n"
 

--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -609,10 +609,14 @@ def _preselect_node_ids(user_id, budget, filter_ai_usage=False,
     node IDs ordered by created_at (direction controlled by
     chronological_order).  No nodes are loaded or decrypted.
     """
-    # Recursive CTE: all node IDs in the user's thread trees
+    # Recursive CTE: all node IDs in the user's thread trees. Seeded
+    # from EVERY node the user authored — not just their top-level
+    # threads — so replies they wrote inside other users' threads (and
+    # the sub-threads under them) are included too (#110). Overlapping
+    # subtrees are harmless: membership is checked with IN. Visibility/
+    # privacy is enforced below by _export_visible_filter.
     base = db.session.query(Node.id).filter(
         Node.user_id == user_id,
-        Node.parent_id.is_(None),
     ).cte(name="thread_nodes", recursive=True)
 
     thread_child = db.aliased(Node, flat=True)

--- a/backend/routes/external.py
+++ b/backend/routes/external.py
@@ -1,0 +1,257 @@
+"""External content routes (#155 component 2 / Download substrate).
+
+- Community Archive fetch (public API, any user, no credentials)
+- X bookmarks: OAuth2 PKCE connect + sync (env-gated by X_CLIENT_ID
+  until pay-per-use credits are configured) and a JSON import fallback
+- Listing imported references
+"""
+import base64
+import hashlib
+import json
+import secrets
+from datetime import datetime, timedelta
+
+import requests
+from flask import (
+    Blueprint, current_app, jsonify, redirect, request, session,
+)
+from flask_login import current_user, login_required
+
+from backend.extensions import db
+from backend.models import ExternalAccount, ExternalItem
+from backend.utils.timefmt import iso_utc
+
+external_bp = Blueprint("external_bp", __name__)
+
+X_AUTHORIZE_URL = "https://twitter.com/i/oauth2/authorize"
+X_TOKEN_URL = "https://api.twitter.com/2/oauth2/token"
+X_SCOPES = "tweet.read users.read bookmark.read offline.access"
+
+
+def _serialize_item(item):
+    content = item.get_content() or ""
+    return {
+        "id": item.id,
+        "source": item.source,
+        "author_handle": item.author_handle,
+        "preview": content[:280] + ("…" if len(content) > 280 else ""),
+        "url": item.url,
+        "posted_at": iso_utc(item.posted_at) if item.posted_at else None,
+        "fetched_at": iso_utc(item.fetched_at),
+    }
+
+
+@external_bp.route("/items", methods=["GET"])
+@login_required
+def list_items():
+    source = request.args.get("source")
+    page = request.args.get("page", 1, type=int)
+    per_page = min(request.args.get("per_page", 50, type=int), 200)
+
+    query = ExternalItem.query.filter_by(user_id=current_user.id)
+    if source:
+        query = query.filter_by(source=source)
+    total = query.count()
+    items = query.order_by(
+        ExternalItem.posted_at.desc().nullslast(),
+        ExternalItem.id.desc(),
+    ).offset((page - 1) * per_page).limit(per_page).all()
+
+    counts = dict(
+        db.session.query(ExternalItem.source, db.func.count())
+        .filter_by(user_id=current_user.id)
+        .group_by(ExternalItem.source).all()
+    )
+    return jsonify({
+        "items": [_serialize_item(i) for i in items],
+        "total": total,
+        "counts": counts,
+    }), 200
+
+
+@external_bp.route("/community-archive/fetch", methods=["POST"])
+@login_required
+def fetch_community_archive_route():
+    data = request.get_json() or {}
+    username = (data.get("username") or "").strip().lstrip("@")
+    if not username:
+        return jsonify({"error": "username is required"}), 400
+
+    from backend.tasks.external_sync import fetch_community_archive
+    task = fetch_community_archive.delay(
+        current_user.id, username,
+        max_items=min(int(data.get("max_items", 2000)), 10000))
+    return jsonify({"task_id": task.id, "status": "pending"}), 202
+
+
+@external_bp.route("/bookmarks/import", methods=["POST"])
+@login_required
+def import_bookmarks_json():
+    """JSON import fallback for X bookmarks (no API credits needed).
+
+    Accepts a flexible array of objects; recognizes common shapes from
+    bookmark-export browser scripts: {id|tweet_id|url, text|full_text,
+    author|username|screen_name, created_at}.
+    """
+    payload = request.get_json(silent=True)
+    if payload is None and "file" in request.files:
+        try:
+            payload = json.load(request.files["file"].stream)
+        except (ValueError, UnicodeDecodeError):
+            return jsonify({"error": "File is not valid JSON"}), 400
+    if isinstance(payload, dict):
+        payload = payload.get("bookmarks") or payload.get("data")
+    if not isinstance(payload, list):
+        return jsonify({"error": (
+            "Provide a JSON array of bookmarks (or {bookmarks: [...]}).")
+        }), 400
+
+    from backend.tasks.external_sync import _upsert_items
+
+    def _normalize(entry):
+        if not isinstance(entry, dict):
+            return None
+        text = entry.get("text") or entry.get("full_text")
+        tweet_id = entry.get("id") or entry.get("tweet_id")
+        url = entry.get("url")
+        if not tweet_id and url and "/status/" in str(url):
+            tweet_id = str(url).rstrip("/").split("/status/")[-1].split("?")[0]
+        if not tweet_id or not text:
+            return None
+        handle = (entry.get("author") or entry.get("username")
+                  or entry.get("screen_name"))
+        posted_at = None
+        if entry.get("created_at"):
+            try:
+                posted_at = datetime.fromisoformat(
+                    str(entry["created_at"]).replace("Z", "+00:00")
+                ).replace(tzinfo=None)
+            except (ValueError, TypeError):
+                pass
+        return {
+            "external_id": str(tweet_id),
+            "author_handle": handle,
+            "content": str(text),
+            "url": url or f"https://twitter.com/i/status/{tweet_id}",
+            "posted_at": posted_at,
+        }
+
+    items = [n for n in (_normalize(e) for e in payload) if n]
+    created, skipped = _upsert_items(
+        current_user.id, "twitter_bookmark", items)
+    return jsonify({
+        "created": created, "skipped": skipped,
+        "unrecognized": len(payload) - len(items),
+    }), 200
+
+
+# ── X OAuth2 PKCE connect (env-gated) ────────────────────────────────────
+
+def _x_configured():
+    return bool(current_app.config.get("X_CLIENT_ID"))
+
+
+@external_bp.route("/twitter/status", methods=["GET"])
+@login_required
+def twitter_status():
+    account = ExternalAccount.query.filter_by(
+        user_id=current_user.id, provider="twitter").first()
+    return jsonify({
+        "configured": _x_configured(),
+        "connected": bool(account and account.get_access_token()),
+        "handle": account.handle if account else None,
+        "last_synced_at": (iso_utc(account.last_synced_at)
+                           if account and account.last_synced_at else None),
+    }), 200
+
+
+@external_bp.route("/twitter/connect", methods=["GET"])
+@login_required
+def twitter_connect():
+    if not _x_configured():
+        return jsonify({"error": (
+            "X API is not configured (set X_CLIENT_ID / X_REDIRECT_URI)."
+        )}), 503
+
+    verifier = secrets.token_urlsafe(64)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    state = secrets.token_urlsafe(24)
+    session["x_oauth"] = {"verifier": verifier, "state": state}
+
+    from urllib.parse import urlencode
+    params = urlencode({
+        "response_type": "code",
+        "client_id": current_app.config["X_CLIENT_ID"],
+        "redirect_uri": current_app.config["X_REDIRECT_URI"],
+        "scope": X_SCOPES,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    })
+    return redirect(f"{X_AUTHORIZE_URL}?{params}")
+
+
+@external_bp.route("/twitter/callback", methods=["GET"])
+@login_required
+def twitter_callback():
+    stash = session.pop("x_oauth", None)
+    if (not stash or request.args.get("state") != stash["state"]
+            or not request.args.get("code")):
+        return redirect("/import?x_connect=failed")
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": request.args["code"],
+        "redirect_uri": current_app.config["X_REDIRECT_URI"],
+        "client_id": current_app.config["X_CLIENT_ID"],
+        "code_verifier": stash["verifier"],
+    }
+    auth = None
+    if current_app.config.get("X_CLIENT_SECRET"):
+        auth = (current_app.config["X_CLIENT_ID"],
+                current_app.config["X_CLIENT_SECRET"])
+    try:
+        token_resp = requests.post(
+            X_TOKEN_URL, data=data, auth=auth, timeout=30)
+        token_resp.raise_for_status()
+        tokens = token_resp.json()
+
+        me = requests.get(
+            "https://api.twitter.com/2/users/me",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+            timeout=30,
+        )
+        me.raise_for_status()
+        me_data = me.json().get("data", {})
+    except requests.RequestException:
+        current_app.logger.exception("X OAuth callback failed")
+        return redirect("/import?x_connect=failed")
+
+    account = ExternalAccount.query.filter_by(
+        user_id=current_user.id, provider="twitter").first()
+    if account is None:
+        account = ExternalAccount(
+            user_id=current_user.id, provider="twitter")
+        db.session.add(account)
+    account.set_tokens(tokens["access_token"], tokens.get("refresh_token"))
+    if tokens.get("expires_in"):
+        account.token_expires_at = (
+            datetime.utcnow() + timedelta(seconds=int(tokens["expires_in"])))
+    account.external_user_id = me_data.get("id")
+    account.handle = me_data.get("username")
+    db.session.commit()
+    return redirect("/import?x_connect=ok")
+
+
+@external_bp.route("/twitter/sync", methods=["POST"])
+@login_required
+def twitter_sync():
+    account = ExternalAccount.query.filter_by(
+        user_id=current_user.id, provider="twitter").first()
+    if account is None or not account.get_access_token():
+        return jsonify({"error": "X account not connected"}), 400
+    from backend.tasks.external_sync import sync_twitter_bookmarks
+    task = sync_twitter_bookmarks.delay(current_user.id)
+    return jsonify({"task_id": task.id, "status": "pending"}), 202

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,0 +1,58 @@
+"""Liveness and readiness endpoints (roadmap Phase 0).
+
+/health — liveness: the process is up and serving requests. Always 200.
+/ready  — readiness: critical dependencies reachable. 200 when DB and
+          Redis both respond, 503 otherwise (load balancers / monitors
+          should route away on 503).
+
+Unauthenticated by design — they expose only component up/down booleans.
+"""
+import logging
+
+from flask import Blueprint, current_app, jsonify
+from sqlalchemy import text
+
+from backend.extensions import db
+
+logger = logging.getLogger(__name__)
+
+health_bp = Blueprint("health_bp", __name__)
+
+
+def _check_db():
+    try:
+        db.session.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        logger.exception("Readiness check: database unreachable")
+        return False
+
+
+def _check_redis():
+    try:
+        import redis
+        url = current_app.config.get(
+            "CELERY_BROKER_URL", "redis://localhost:6379/0")
+        client = redis.Redis.from_url(
+            url, socket_connect_timeout=2, socket_timeout=2)
+        return bool(client.ping())
+    except Exception:
+        logger.exception("Readiness check: redis unreachable")
+        return False
+
+
+@health_bp.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok"}), 200
+
+
+@health_bp.route("/ready", methods=["GET"])
+def ready():
+    db_ok = _check_db()
+    redis_ok = _check_redis()
+    ready_ok = db_ok and redis_ok
+    return jsonify({
+        "status": "ready" if ready_ok else "not_ready",
+        "database": db_ok,
+        "redis": redis_ok,
+    }), (200 if ready_ok else 503)

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -2382,3 +2382,45 @@ def delete_node(node_id):
         db.session.rollback()
         current_app.logger.error(f"Error soft-deleting node {node_id}: {e}")
         return jsonify({"error": "Error deleting node", "details": str(e)}), 500
+
+
+@nodes_bp.route("/<int:node_id>/tts-chapters", methods=["GET"])
+@login_required
+def get_tts_chapters(node_id):
+    """Chapter list for a node's generated TTS audio (#145).
+
+    Built from persisted TTSChunk rows: each chapter is the first chunk
+    of a markdown section, with its cumulative start time (sum of prior
+    chunk durations) so the player can jump within the merged file and
+    map chapters onto the chunked queue alike.
+    """
+    node = Node.query.get_or_404(node_id)
+    if not can_user_access_node(node) and not getattr(
+            current_user, "is_admin", False):
+        return jsonify({"error": "Unauthorized"}), 403
+
+    from backend.models import TTSChunk
+    chunks = TTSChunk.query.filter_by(node_id=node_id).order_by(
+        TTSChunk.chunk_index).all()
+    if not chunks:
+        return jsonify({"chapters": []}), 200
+
+    chapters = []
+    elapsed = 0.0
+    seen_sections = set()
+    for chunk in chunks:
+        key = chunk.section_index
+        if key is not None and key not in seen_sections:
+            seen_sections.add(key)
+            chapters.append({
+                "section_index": key,
+                "title": chunk.section_title or "Introduction",
+                "chunk_index": chunk.chunk_index,
+                "start_time": round(elapsed, 2),
+            })
+        elapsed += chunk.duration or 0.0
+
+    # A single untitled section = no real chapters — don't render a list
+    if len(chapters) <= 1:
+        return jsonify({"chapters": []}), 200
+    return jsonify({"chapters": chapters}), 200

--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -172,3 +172,81 @@ def search():
         "has_more": (start + per_page) < total,
         "search_type": "keyword",
     })
+
+
+@search_bp.route("/search/semantic", methods=["GET"])
+@login_required
+def semantic_search():
+    """Semantic search over the user's own archive (#155).
+
+    Embeds the query and ranks the user's NodeEmbedding rows by cosine
+    similarity (brute-force scan — fine at alpha scale). Only AI-readable
+    nodes are embedded, so ai_usage='none' content never appears here
+    (keyword search still covers it).
+    """
+    from flask import current_app
+    from backend.models import NodeEmbedding
+    from backend.utils.api_keys import get_openai_chat_key
+    from backend.utils.embeddings import embed_texts, top_k_similar
+
+    q = request.args.get("q", "").strip()
+    limit = min(request.args.get("limit", 20, type=int), 50)
+    min_score = request.args.get("min_score", 0.2, type=float)
+
+    if not q:
+        return jsonify({"error": "Provide a query (q)."}), 400
+
+    api_key = get_openai_chat_key(current_app.config)
+    if not api_key:
+        return jsonify({"error": "Semantic search is not configured."}), 503
+
+    try:
+        query_vector = embed_texts(
+            [q], api_key, user_id=current_user.id,
+            request_type="embedding_query",
+        )[0]
+        db.session.commit()  # persist the query cost log
+    except Exception:
+        db.session.rollback()
+        return jsonify({"error": "Embedding the query failed."}), 502
+
+    rows = db.session.query(
+        NodeEmbedding.node_id, NodeEmbedding.vector
+    ).filter(NodeEmbedding.user_id == current_user.id).all()
+
+    ranked = top_k_similar(query_vector, rows, k=limit, min_score=min_score)
+    nodes_by_id = {
+        n.id: n for n in Node.query.filter(
+            Node.id.in_([node_id for node_id, _ in ranked]),
+            Node.deleted_at.is_(None),
+        ).all()
+    } if ranked else {}
+
+    results = []
+    for node_id, score in ranked:
+        node = nodes_by_id.get(node_id)
+        if node is None:
+            continue
+        # Defense in depth: embeddings are already scoped by user_id,
+        # but re-check ownership on the node itself.
+        if (node.user_id != current_user.id
+                and node.human_owner_id != current_user.id):
+            continue
+        content = node.get_content() or ""
+        results.append({
+            "id": node.id,
+            "preview": content[:200] + ("..." if len(content) > 200 else ""),
+            "snippet": None,
+            "node_type": node.node_type,
+            "created_at": iso_utc(node.created_at),
+            "username": node.user.username if node.user else "Unknown",
+            "child_count": len(node.children),
+            "parent_id": node.parent_id,
+            "score": round(score, 4),
+        })
+
+    return jsonify({
+        "results": results,
+        "total": len(results),
+        "mode": "semantic",
+    }), 200

--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -215,6 +215,41 @@ def semantic_search():
     ).filter(NodeEmbedding.user_id == current_user.id).all()
 
     ranked = top_k_similar(query_vector, rows, k=limit, min_score=min_score)
+
+    # External references (#155 component 2) — included unless opted out
+    include_external = request.args.get(
+        "include_external", "1") not in ("0", "false")
+    external_results = []
+    if include_external:
+        from backend.models import ExternalItem, ExternalItemEmbedding
+        ext_rows = db.session.query(
+            ExternalItemEmbedding.item_id, ExternalItemEmbedding.vector
+        ).filter(ExternalItemEmbedding.user_id == current_user.id).all()
+        ext_ranked = top_k_similar(
+            query_vector, ext_rows, k=limit, min_score=min_score)
+        items_by_id = {
+            i.id: i for i in ExternalItem.query.filter(
+                ExternalItem.id.in_([iid for iid, _ in ext_ranked]),
+                ExternalItem.user_id == current_user.id,
+            ).all()
+        } if ext_ranked else {}
+        for item_id, score in ext_ranked:
+            item = items_by_id.get(item_id)
+            if item is None:
+                continue
+            content = item.get_content() or ""
+            external_results.append({
+                "id": item.id,
+                "kind": "external",
+                "source": item.source,
+                "author_handle": item.author_handle,
+                "external_url": item.url,
+                "preview": content[:200] + ("..." if len(content) > 200
+                                            else ""),
+                "snippet": None,
+                "created_at": iso_utc(item.posted_at or item.fetched_at),
+                "score": round(score, 4),
+            })
     nodes_by_id = {
         n.id: n for n in Node.query.filter(
             Node.id.in_([node_id for node_id, _ in ranked]),
@@ -245,8 +280,14 @@ def semantic_search():
             "score": round(score, 4),
         })
 
+    # Merge node + external results by score
+    merged = sorted(
+        results + external_results,
+        key=lambda r: r["score"], reverse=True,
+    )[:limit]
+
     return jsonify({
-        "results": results,
-        "total": len(results),
+        "results": merged,
+        "total": len(merged),
         "mode": "semantic",
     }), 200

--- a/backend/routes/sse.py
+++ b/backend/routes/sse.py
@@ -191,6 +191,10 @@ def _tts_stream_generator(app, entity_cls, entity_id, chunk_fk_attr,
                 }
                 if chunk.duration is not None:
                     chunk_data["duration"] = chunk.duration
+                # Chapter metadata (#145)
+                if chunk.section_index is not None:
+                    chunk_data["section_index"] = chunk.section_index
+                    chunk_data["section_title"] = chunk.section_title
                 yield format_sse_message(chunk_data, event="chunk_ready")
                 last_sent_chunk = chunk.chunk_index
 

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -14,7 +14,9 @@ from sqlalchemy import or_
 
 from backend.celery_app import celery, flask_app
 from backend.extensions import db
-from backend.models import Node, NodeEmbedding
+from backend.models import (
+    ExternalItem, ExternalItemEmbedding, Node, NodeEmbedding,
+)
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.embeddings import (
     EMBEDDING_MODEL, content_hash, embed_texts, pack_vector,
@@ -103,7 +105,44 @@ def sweep_embeddings(limit=SWEEP_BATCH_SIZE):
                 embedded += 1
             db.session.commit()
 
-        logger.info("Embedding sweep: %d embedded, %d stale removed",
-                    embedded, len(stale))
+        # External references (#155 component 2): embed imported items
+        # the same way. They're user-curated content (bookmarks, CA
+        # tweets) — embedding makes them semantically searchable.
+        ext_rows = (
+            db.session.query(ExternalItem, ExternalItemEmbedding)
+            .outerjoin(ExternalItemEmbedding,
+                       ExternalItemEmbedding.item_id == ExternalItem.id)
+            .filter(ExternalItemEmbedding.id.is_(None))
+            .order_by(ExternalItem.id.desc())
+            .limit(limit)
+            .all()
+        )
+        ext_candidates = []
+        for item, _ in ext_rows:
+            text = item.get_content()
+            if text and text.strip():
+                ext_candidates.append((item, text))
+        ext_embedded = 0
+        for start in range(0, len(ext_candidates), EMBED_API_BATCH):
+            batch = ext_candidates[start:start + EMBED_API_BATCH]
+            vectors = embed_texts(
+                [text for _, text in batch], api_key,
+                user_id=batch[0][0].user_id)
+            for (item, text), vector in zip(batch, vectors):
+                db.session.add(ExternalItemEmbedding(
+                    item_id=item.id,
+                    user_id=item.user_id,
+                    model=EMBEDDING_MODEL,
+                    content_hash=content_hash(text),
+                    vector=pack_vector(vector),
+                ))
+                ext_embedded += 1
+            db.session.commit()
+
+        logger.info(
+            "Embedding sweep: %d nodes embedded, %d external items "
+            "embedded, %d stale removed", embedded, ext_embedded,
+            len(stale))
         return {"status": "ok", "embedded": embedded,
+                "external_embedded": ext_embedded,
                 "removed": len(stale)}

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -1,0 +1,109 @@
+"""Background embedding generation for semantic search (#155).
+
+A periodic sweep keeps NodeEmbedding rows in sync with node content. The
+sweep design (rather than per-write dispatch) covers every content path —
+text nodes, voice transcripts, LLM responses, imports — without touching
+each of them. New/edited nodes become searchable within one sweep period.
+
+Only nodes with ai_usage in AI_ALLOWED are embedded: embedding submits
+content to OpenAI, so 'none' nodes are never sent (their keyword search
+still works). Deleted nodes' embeddings are removed.
+"""
+from celery.utils.log import get_task_logger
+from sqlalchemy import or_
+
+from backend.celery_app import celery, flask_app
+from backend.extensions import db
+from backend.models import Node, NodeEmbedding
+from backend.utils.api_keys import get_openai_chat_key
+from backend.utils.embeddings import (
+    EMBEDDING_MODEL, content_hash, embed_texts, pack_vector,
+)
+from backend.utils.privacy import AI_ALLOWED
+
+logger = get_task_logger(__name__)
+
+SWEEP_BATCH_SIZE = 100
+EMBED_API_BATCH = 32
+
+
+def _candidate_nodes(limit):
+    """Nodes needing (re-)embedding: AI-readable, alive, with content,
+    and either missing an embedding row or carrying a stale hash."""
+    rows = (
+        db.session.query(Node, NodeEmbedding)
+        .outerjoin(NodeEmbedding, NodeEmbedding.node_id == Node.id)
+        .filter(
+            Node.deleted_at.is_(None),
+            Node.content.isnot(None),
+            Node.ai_usage.in_(AI_ALLOWED),
+        )
+        .order_by(Node.id.desc())
+        .all()
+    )
+    out = []
+    for node, emb in rows:
+        text = node.get_content()
+        if not text or not text.strip():
+            continue
+        digest = content_hash(text)
+        if emb is not None and emb.content_hash == digest \
+                and emb.model == EMBEDDING_MODEL:
+            continue
+        out.append((node, emb, text, digest))
+        if len(out) >= limit:
+            break
+    return out
+
+
+@celery.task(name='backend.tasks.embeddings.sweep_embeddings')
+def sweep_embeddings(limit=SWEEP_BATCH_SIZE):
+    with flask_app.app_context():
+        api_key = get_openai_chat_key(flask_app.config)
+        if not api_key:
+            logger.warning("Embedding sweep skipped: no OpenAI key")
+            return {"status": "skipped", "reason": "no_api_key"}
+
+        # Remove embeddings of deleted / opted-out nodes
+        stale = (
+            db.session.query(NodeEmbedding)
+            .join(Node, Node.id == NodeEmbedding.node_id)
+            .filter(or_(
+                Node.deleted_at.isnot(None),
+                ~Node.ai_usage.in_(AI_ALLOWED),
+            ))
+            .all()
+        )
+        for row in stale:
+            db.session.delete(row)
+        if stale:
+            db.session.commit()
+
+        candidates = _candidate_nodes(limit)
+        embedded = 0
+        for start in range(0, len(candidates), EMBED_API_BATCH):
+            batch = candidates[start:start + EMBED_API_BATCH]
+            texts = [text for _, _, text, _ in batch]
+            # Cost attribution: each node's owner pays for their content;
+            # one log row per batch under the first node's owner keeps it
+            # simple (alpha: typically a single-user sweep anyway).
+            vectors = embed_texts(
+                texts, api_key, user_id=batch[0][0].user_id)
+            for (node, emb, _text, digest), vector in zip(batch, vectors):
+                if emb is None:
+                    emb = NodeEmbedding(
+                        node_id=node.id,
+                        user_id=node.human_owner_id or node.user_id,
+                    )
+                    db.session.add(emb)
+                emb.user_id = node.human_owner_id or node.user_id
+                emb.model = EMBEDDING_MODEL
+                emb.content_hash = digest
+                emb.vector = pack_vector(vector)
+                embedded += 1
+            db.session.commit()
+
+        logger.info("Embedding sweep: %d embedded, %d stale removed",
+                    embedded, len(stale))
+        return {"status": "ok", "embedded": embedded,
+                "removed": len(stale)}

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -606,7 +606,8 @@ def _do_initial_generation(self, user, model_id, context_window,
 
 
 def _single_pass_generation(self, user, model_id, gen_template,
-                            export_result, api_keys):
+                            export_result, api_keys,
+                            max_output_tokens=None):
     """Single-pass profile generation when all data fits in budget."""
     self.update_state(state='PROGRESS', meta={
         'progress': 30, 'status': 'Preparing prompt'
@@ -616,7 +617,8 @@ def _single_pass_generation(self, user, model_id, gen_template,
     prompt = gen_template.replace("{user_export}", content)
 
     response = _call_llm_with_retries(
-        self, model_id, prompt, user.id, api_keys, progress_base=40
+        self, model_id, prompt, user.id, api_keys, progress_base=40,
+        max_tokens=max_output_tokens,
     )
 
     # Use actual input tokens from LLM response for accurate tracking
@@ -827,7 +829,8 @@ def _do_integration(self, user, model_id, last_iterative_profile_id,
 
 
 def _chunked_profile_loop(self, user, model_id, update_template,
-                          api_keys, initial_profile_content=None,
+                          api_keys, max_output_tokens=None,
+                          initial_profile_content=None,
                           initial_profile_id=None,
                           initial_source_tokens=0,
                           initial_cutoff=None,
@@ -903,7 +906,8 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         response = _call_llm_with_retries(
             self, model_id, prompt, user.id, api_keys,
             progress_base=progress,
-            status_label=f'{status_prefix}: Chunk {chunk_num}'
+            status_label=f'{status_prefix}: Chunk {chunk_num}',
+            max_tokens=max_output_tokens,
         )
 
         actual_chunk_tokens = response.get(

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -30,6 +30,28 @@ MIN_CHUNK_TOKENS = 80000
 # fed to the LLM — as the base for an incremental update or as the root of an
 # integration chain — so the model treats it as the user's own words rather
 # than a prior generated profile.
+def _dated_user_profile_block(profile):
+    """Render a user-written profile as a dated, don't-overindex block
+    for chronological regen injection (#183)."""
+    written_on = (profile.created_at.strftime("%Y-%m-%d")
+                  if profile.created_at else "an unknown date")
+    return (
+        f"---\n"
+        f"On {written_on}, the user wrote the following self-description "
+        f"themselves. Treat it as important input — their own words about "
+        f"who they are — but as one data point among the rest; don't "
+        f"overindex on it, and don't read data written before that date "
+        f"through it:\n\n{profile.get_content()}\n---"
+    )
+
+
+def _latest_user_written_profile(user_id):
+    """Latest profile the user wrote by hand (generated_by == 'user')."""
+    return UserProfile.query.filter_by(
+        user_id=user_id, generated_by="user"
+    ).order_by(UserProfile.created_at.desc()).first()
+
+
 USER_WRITTEN_PROFILE_NOTE = (
     "[NOTE: The profile below was written by the user themselves, not "
     "AI-generated. Treat it as their own self-description - important, but "
@@ -591,29 +613,45 @@ def _do_initial_generation(self, user, model_id, context_window,
 
     total_tokens = total_export["token_count"]
 
+    # #183: a full regen must not silently discard a profile the user
+    # wrote by hand. It's injected chronologically (see the per-branch
+    # mechanics) rather than seeded at the start, so older data isn't
+    # read through a future self-description.
+    user_written = _latest_user_written_profile(user.id)
+
     if total_tokens <= budget:
         # Single-pass generation
         return _single_pass_generation(
             self, user, model_id, gen_template, total_export,
-            api_keys, max_output_tokens
+            api_keys, max_output_tokens,
+            user_written_profile=user_written,
         )
     else:
         # Iterative build
         return _iterative_generation(
             self, user, model_id, gen_template, budget,
-            context_window, max_output_tokens, api_keys
+            context_window, max_output_tokens, api_keys,
+            user_written_profile=user_written
         )
 
 
 def _single_pass_generation(self, user, model_id, gen_template,
                             export_result, api_keys,
-                            max_output_tokens=None):
+                            max_output_tokens=None,
+                            user_written_profile=None):
     """Single-pass profile generation when all data fits in budget."""
     self.update_state(state='PROGRESS', meta={
         'progress': 30, 'status': 'Preparing prompt'
     })
 
     content = export_result["content"]
+    if user_written_profile is not None:
+        # #183 (single-pass): include the hand-written profile with its
+        # date and let the model weight it chronologically.
+        content = (
+            f"{content}\n\n"
+            f"{_dated_user_profile_block(user_written_profile)}"
+        )
     prompt = gen_template.replace("{user_export}", content)
 
     response = _call_llm_with_retries(
@@ -830,6 +868,7 @@ def _do_integration(self, user, model_id, last_iterative_profile_id,
 
 def _chunked_profile_loop(self, user, model_id, update_template,
                           api_keys, max_output_tokens=None,
+                          user_written_profile=None,
                           initial_profile_content=None,
                           initial_profile_id=None,
                           initial_source_tokens=0,
@@ -895,6 +934,20 @@ def _chunked_profile_loop(self, user, model_id, update_template,
             )
             break
 
+        # #183 (iterative): inject the hand-written profile into the
+        # first chunk whose data window reaches its creation time — not
+        # before, so older data isn't read through a future
+        # self-description.
+        if (user_written_profile is not None and latest_ts is not None
+                and user_written_profile.created_at is not None
+                and latest_ts >= user_written_profile.created_at):
+            chunk = dict(chunk)
+            chunk["content"] = (
+                f"{chunk['content']}\n\n"
+                f"{_dated_user_profile_block(user_written_profile)}"
+            )
+            user_written_profile = None  # injected once
+
         if is_first_with_gen:
             prompt = first_chunk_prompt_fn(chunk)
         else:
@@ -958,11 +1011,44 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         if not has_more:
             break
 
+    # #183 edge: every chunk predated the hand-written profile (it's
+    # newer than all data) — reconcile it in one final pass so it isn't
+    # dropped.
+    if (user_written_profile is not None
+            and current_profile_content is not None):
+        chunk_num += 1
+        prompt = build_chunk_prompt(
+            update_template, current_profile_content,
+            cumulative_source_tokens,
+            {"content": _dated_user_profile_block(user_written_profile),
+             "token_count": 0},
+        )
+        response = _call_llm_with_retries(
+            self, model_id, prompt, user.id, api_keys,
+            progress_base=88,
+            status_label=f'{status_prefix}: Reconciling self-description',
+            max_tokens=max_output_tokens,
+        )
+        profile = _save_profile(
+            user, model_id, response["content"], response,
+            source_tokens_used=cumulative_source_tokens,
+            source_data_cutoff=current_cutoff,
+            generation_type=generation_type,
+            parent_profile_id=current_profile_id,
+        )
+        current_profile_content = response["content"]
+        current_profile_id = profile.id
+        logger.info(
+            f"User {user.id}: reconciled user-written profile in a "
+            f"final pass (profile {profile.id})"
+        )
+
     return current_profile_id, chunk_num, cumulative_source_tokens
 
 
 def _iterative_generation(self, user, model_id, gen_template, budget,
-                          context_window, max_output_tokens, api_keys):
+                          context_window, max_output_tokens, api_keys,
+                          user_written_profile=None):
     """Iterative profile building: process data in chronological chunks."""
     budget = min(budget, CHUNK_BUDGET)
     logger.info(
@@ -982,6 +1068,7 @@ def _iterative_generation(self, user, model_id, gen_template, budget,
             generation_type="iterative",
             status_prefix="Generating profile",
             chunk_budget=budget,
+            user_written_profile=user_written_profile,
         )
 
     # Run integration over the iterative chain

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -244,7 +244,8 @@ def _load_prompt(name, user_id=None):
 
 def _call_llm_with_retries(self, model_id, prompt_text, user_id,
                             api_keys, progress_base=50,
-                            status_label='Generating profile'):
+                            status_label='Generating profile',
+                            max_tokens=None):
     """Call LLM with retry logic for prompt-too-long errors.
 
     Returns (response_dict, profile_text, input_tokens, output_tokens).
@@ -263,7 +264,8 @@ def _call_llm_with_retries(self, model_id, prompt_text, user_id,
 
         try:
             response = LLMProvider.get_completion(model_id, messages,
-                                                  api_keys)
+                                                  api_keys,
+                                                  max_tokens=max_tokens)
             return response
         except PromptTooLongError as e:
             if attempt == MAX_RETRIES:
@@ -499,12 +501,13 @@ def _do_incremental_update(self, user, model_id, previous_profile_id,
 
     return _do_iterative_incremental_update(
         self, user, model_id, prev_profile, update_template,
-        cutoff, api_keys
+        cutoff, api_keys, max_output_tokens=max_output_tokens
     )
 
 
 def _do_iterative_incremental_update(self, user, model_id, prev_profile,
-                                     update_template, cutoff, api_keys):
+                                     update_template, cutoff, api_keys,
+                                     max_output_tokens=None):
     """Incremental update with chunked processing."""
     logger.info(
         f"Starting iterative incremental update for user {user.id}, "
@@ -521,6 +524,7 @@ def _do_iterative_incremental_update(self, user, model_id, prev_profile,
     current_profile_id, chunk_num, cumulative_source_tokens = \
         _chunked_profile_loop(
             self, user, model_id, update_template, api_keys,
+            max_output_tokens=max_output_tokens,
             initial_profile_content=base_content,
             initial_profile_id=prev_profile.id,
             initial_source_tokens=prev_profile.source_tokens_used or 0,
@@ -591,7 +595,7 @@ def _do_initial_generation(self, user, model_id, context_window,
         # Single-pass generation
         return _single_pass_generation(
             self, user, model_id, gen_template, total_export,
-            api_keys
+            api_keys, max_output_tokens
         )
     else:
         # Iterative build
@@ -967,6 +971,7 @@ def _iterative_generation(self, user, model_id, gen_template, budget,
     current_profile_id, chunk_num, cumulative_source_tokens = \
         _chunked_profile_loop(
             self, user, model_id, update_template, api_keys,
+            max_output_tokens=max_output_tokens,
             first_chunk_prompt_fn=lambda chunk: gen_template.replace(
                 "{user_export}", chunk["content"]
             ),

--- a/backend/tasks/external_sync.py
+++ b/backend/tasks/external_sync.py
@@ -1,0 +1,109 @@
+"""Background sync of external content sources (#155 / Download).
+
+fetch_community_archive: pull a donated archive's tweets from the public
+Community Archive into ExternalItem rows (deduped per user+source+id).
+
+sync_twitter_bookmarks: pull the user's X bookmarks via their connected
+OAuth account (pay-per-use X API; env-gated by X_CLIENT_ID). Refreshes
+the access token when expired.
+"""
+from datetime import datetime, timedelta
+
+from celery.utils.log import get_task_logger
+
+from backend.celery_app import celery, flask_app
+from backend.extensions import db
+from backend.models import ExternalAccount, ExternalItem
+from backend.utils.external_content import (
+    ca_fetch_tweets, ca_lookup_account, x_fetch_bookmarks,
+    x_refresh_access_token,
+)
+
+logger = get_task_logger(__name__)
+
+
+def _upsert_items(user_id, source, items):
+    """Insert normalized items, skipping per-user duplicates. Returns
+    (created, skipped)."""
+    existing = {
+        row[0] for row in db.session.query(ExternalItem.external_id).filter_by(
+            user_id=user_id, source=source).all()
+    }
+    created = skipped = 0
+    for item in items:
+        if item["external_id"] in existing:
+            skipped += 1
+            continue
+        row = ExternalItem(
+            user_id=user_id,
+            source=source,
+            external_id=item["external_id"],
+            author_handle=item.get("author_handle"),
+            url=item.get("url"),
+            posted_at=item.get("posted_at"),
+        )
+        row.set_content(item["content"])
+        db.session.add(row)
+        existing.add(item["external_id"])
+        created += 1
+        if created % 200 == 0:
+            db.session.commit()
+    db.session.commit()
+    return created, skipped
+
+
+@celery.task(name='backend.tasks.external_sync.fetch_community_archive',
+             bind=True)
+def fetch_community_archive(self, user_id, username, max_items=2000):
+    with flask_app.app_context():
+        username = (username or "").strip().lstrip("@")
+        account_id = ca_lookup_account(username)
+        if account_id is None:
+            return {"status": "not_found", "username": username}
+        created, skipped = _upsert_items(
+            user_id, "community_archive",
+            ca_fetch_tweets(account_id, username, max_items=max_items),
+        )
+        logger.info(
+            "Community Archive fetch for user %s @%s: %d new, %d known",
+            user_id, username, created, skipped)
+        return {"status": "ok", "username": username,
+                "created": created, "skipped": skipped}
+
+
+@celery.task(name='backend.tasks.external_sync.sync_twitter_bookmarks',
+             bind=True)
+def sync_twitter_bookmarks(self, user_id, max_items=800):
+    with flask_app.app_context():
+        account = ExternalAccount.query.filter_by(
+            user_id=user_id, provider="twitter").first()
+        if account is None or not account.get_access_token():
+            return {"status": "not_connected"}
+
+        client_id = flask_app.config.get("X_CLIENT_ID")
+        # Refresh ahead of expiry when we can
+        if (client_id and account.token_expires_at
+                and account.token_expires_at
+                < datetime.utcnow() + timedelta(minutes=5)
+                and account.get_refresh_token()):
+            tokens = x_refresh_access_token(
+                client_id, account.get_refresh_token())
+            account.set_tokens(
+                tokens["access_token"], tokens.get("refresh_token"))
+            if tokens.get("expires_in"):
+                account.token_expires_at = (
+                    datetime.utcnow()
+                    + timedelta(seconds=int(tokens["expires_in"])))
+            db.session.commit()
+
+        created, skipped = _upsert_items(
+            user_id, "twitter_bookmark",
+            x_fetch_bookmarks(
+                account.get_access_token(), account.external_user_id,
+                max_items=max_items),
+        )
+        account.last_synced_at = datetime.utcnow()
+        db.session.commit()
+        logger.info("X bookmarks sync for user %s: %d new, %d known",
+                    user_id, created, skipped)
+        return {"status": "ok", "created": created, "skipped": skipped}

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -47,6 +47,7 @@ USER_AI_PREFERENCES_PLACEHOLDER = "{user_ai_preferences}"
 # Placeholders for user artifacts — LLM memory/scratchpad + index (#158)
 USER_MEMORY_PLACEHOLDER = "{user_memory}"
 USER_SCRATCHPAD_PLACEHOLDER = "{user_scratchpad}"
+USER_INTENTIONS_PLACEHOLDER = "{user_intentions}"
 USER_ARTIFACTS_INDEX_PLACEHOLDER = "{user_artifacts_index}"
 
 # ── Voice tool definitions ──────────────────────────────────────────────
@@ -122,8 +123,11 @@ VOICE_TOOLS = [
             "documents that survive across sessions. Built-in kinds: "
             "'memory' (durable facts and observations about the user "
             "worth remembering long-term — write here whenever you learn "
-            "something that future sessions should know) and 'scratchpad' "
-            "(your working notes for ongoing threads of work). You can "
+            "something that future sessions should know), 'scratchpad' "
+            "(your working notes for ongoing threads of work), and "
+            "'intentions' (the user's long-running aspirations you help "
+            "them clarify and track — see the Intentions section of your "
+            "instructions). You can "
             "also create new kinds for the user on request (e.g. "
             "'reading-list'). The updated_content must be the FULL new "
             "text of the artifact (not a diff) — it replaces the previous "
@@ -239,17 +243,19 @@ def get_user_artifacts_context(user_id, pinned_node=None):
 
     memory = artifacts.get("memory")
     scratchpad = artifacts.get("scratchpad")
+    intentions = artifacts.get("intentions")
     memory_content = memory.get_content() if memory else ""
     scratchpad_content = scratchpad.get_content() if scratchpad else ""
+    intentions_content = intentions.get_content() if intentions else ""
 
     index_lines = []
     for kind, artifact in sorted(artifacts.items()):
-        if kind in ("memory", "scratchpad"):
-            continue
+        if kind in ("memory", "scratchpad", "intentions"):
+            continue  # ambient via their own placeholders, not the index
         tokens = approximate_token_count(artifact.get_content() or "")
         index_lines.append(f"- {kind} — \"{artifact.title}\" (~{tokens} tokens)")
     index_text = "\n".join(index_lines) if index_lines else "(none)"
-    return memory_content, scratchpad_content, index_text
+    return memory_content, scratchpad_content, intentions_content, index_text
 
 
 def get_user_ai_preferences_content(user_id, pinned_node=None):
@@ -927,11 +933,13 @@ def render_system_message(system_node, user_id):
                 user_id, pinned_node=system_node) or "")
     if (USER_MEMORY_PLACEHOLDER in text
             or USER_SCRATCHPAD_PLACEHOLDER in text
+            or USER_INTENTIONS_PLACEHOLDER in text
             or USER_ARTIFACTS_INDEX_PLACEHOLDER in text):
-        memory, scratchpad, index = get_user_artifacts_context(
+        memory, scratchpad, intentions, index = get_user_artifacts_context(
             user_id, pinned_node=system_node)
         text = text.replace(USER_MEMORY_PLACEHOLDER, memory or "")
         text = text.replace(USER_SCRATCHPAD_PLACEHOLDER, scratchpad or "")
+        text = text.replace(USER_INTENTIONS_PLACEHOLDER, intentions or "")
         text = text.replace(
             USER_ARTIFACTS_INDEX_PLACEHOLDER, index or "(none)")
     return text
@@ -1175,11 +1183,13 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             artifacts_node = (
                 _placeholder_node(USER_MEMORY_PLACEHOLDER)
                 or _placeholder_node(USER_SCRATCHPAD_PLACEHOLDER)
+                or _placeholder_node(USER_INTENTIONS_PLACEHOLDER)
                 or _placeholder_node(USER_ARTIFACTS_INDEX_PLACEHOLDER)
             )
             needs_artifacts = artifacts_node is not None
             user_memory_content = None
             user_scratchpad_content = None
+            user_intentions_content = None
             user_artifacts_index = None
 
             # Check if any node contains {quote:ID} placeholders
@@ -1231,6 +1241,7 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
 
             if needs_artifacts:
                 (user_memory_content, user_scratchpad_content,
+                 user_intentions_content,
                  user_artifacts_index) = get_user_artifacts_context(
                     user_id, pinned_node=artifacts_node
                 )
@@ -1502,6 +1513,11 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                             message_text = message_text.replace(
                                 USER_SCRATCHPAD_PLACEHOLDER,
                                 user_scratchpad_content or ""
+                            )
+                        if USER_INTENTIONS_PLACEHOLDER in message_text:
+                            message_text = message_text.replace(
+                                USER_INTENTIONS_PLACEHOLDER,
+                                user_intentions_content or ""
                             )
                         if USER_ARTIFACTS_INDEX_PLACEHOLDER in message_text:
                             message_text = message_text.replace(

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from backend.celery_app import celery, flask_app
 from backend.models import (
     Node, User, UserProfile, UserRecentContext, UserTodo, APICostLog,
-    UserAIPreferences, Draft,
+    UserAIPreferences, UserArtifact, UserFeedback, Draft,
 )
 from backend.extensions import db
 from backend.llm_providers import LLMProvider, PromptTooLongError
@@ -44,6 +44,10 @@ USER_RECENT_PLACEHOLDER = "{user_recent}"
 USER_RECENT_RAW_PLACEHOLDER = "{user_recent_raw}"
 # Placeholder for AI interaction preferences
 USER_AI_PREFERENCES_PLACEHOLDER = "{user_ai_preferences}"
+# Placeholders for user artifacts — LLM memory/scratchpad + index (#158)
+USER_MEMORY_PLACEHOLDER = "{user_memory}"
+USER_SCRATCHPAD_PLACEHOLDER = "{user_scratchpad}"
+USER_ARTIFACTS_INDEX_PLACEHOLDER = "{user_artifacts_index}"
 
 # ── Voice tool definitions ──────────────────────────────────────────────
 
@@ -111,7 +115,141 @@ VOICE_TOOLS = [
             "required": ["updated_preferences"],
         },
     },
+    {
+        "name": "update_artifact",
+        "description": (
+            "Create or update one of the user's artifacts — persistent "
+            "documents that survive across sessions. Built-in kinds: "
+            "'memory' (durable facts and observations about the user "
+            "worth remembering long-term — write here whenever you learn "
+            "something that future sessions should know) and 'scratchpad' "
+            "(your working notes for ongoing threads of work). You can "
+            "also create new kinds for the user on request (e.g. "
+            "'reading-list'). The updated_content must be the FULL new "
+            "text of the artifact (not a diff) — it replaces the previous "
+            "version, and old versions stay in history. Call proactively "
+            "for memory-worthy facts; no confirmation is needed. Always "
+            "produce a text response alongside the call."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "description": (
+                        "Artifact slug: 'memory', 'scratchpad', or a "
+                        "short lowercase dash-separated name for a "
+                        "custom artifact."
+                    ),
+                },
+                "updated_content": {
+                    "type": "string",
+                    "description": (
+                        "The complete new artifact text as markdown. "
+                        "Carry forward everything still relevant from "
+                        "the current version."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Display title. Only needed when creating a new "
+                        "custom artifact."
+                    ),
+                },
+            },
+            "required": ["kind", "updated_content"],
+        },
+    },
+    {
+        "name": "read_artifact",
+        "description": (
+            "Request the full content of one of the user's artifacts "
+            "listed in the artifacts index. The content is NOT returned "
+            "immediately — it will be injected into your context at the "
+            "start of the NEXT turn. Use this when the index shows an "
+            "artifact relevant to the conversation that you don't already "
+            "see (memory and scratchpad are always in context — never "
+            "read those). Tell the user you're pulling it up. Always "
+            "produce a text response alongside the call."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "description": "Slug of the artifact to read.",
+                },
+            },
+            "required": ["kind"],
+        },
+    },
+    {
+        "name": "submit_feedback",
+        "description": (
+            "Submit feedback about Loore itself to its creators on the "
+            "user's behalf. Call this when the user expresses feedback "
+            "about the product — praise, frustration, confusion, ideas — "
+            "and either asks you to pass it on or agrees when you offer. "
+            "For concrete bugs or feature requests prefer proposing a "
+            "GitHub issue instead; feedback is for everything that "
+            "doesn't fit an issue. Quote or faithfully summarize the "
+            "user's own words. Always produce a text response alongside "
+            "the call."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": (
+                        "The feedback text, faithful to what the user "
+                        "expressed."
+                    ),
+                },
+                "category": {
+                    "type": "string",
+                    "enum": ["praise", "frustration", "idea", "other"],
+                    "description": "Best-fit category.",
+                },
+            },
+            "required": ["content"],
+        },
+    },
 ]
+
+
+_ARTIFACT_KIND_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,47}$')
+
+
+def get_user_artifacts_context(user_id, pinned_node=None):
+    """Resolve user artifacts for the agentic prompt (#158).
+
+    Returns (memory_content, scratchpad_content, index_text). Pinned to the
+    per-session snapshot recorded on *pinned_node* (#191 semantics), falling
+    back to latest for legacy nodes. ai_usage is re-checked on resolved rows.
+    """
+    artifacts = pinned_node.get_user_artifacts() if pinned_node else {}
+    if not artifacts:
+        artifacts = UserArtifact.latest_per_kind(user_id)
+    artifacts = {
+        kind: a for kind, a in artifacts.items()
+        if a.ai_usage in AI_ALLOWED
+    }
+
+    memory = artifacts.get("memory")
+    scratchpad = artifacts.get("scratchpad")
+    memory_content = memory.get_content() if memory else ""
+    scratchpad_content = scratchpad.get_content() if scratchpad else ""
+
+    index_lines = []
+    for kind, artifact in sorted(artifacts.items()):
+        if kind in ("memory", "scratchpad"):
+            continue
+        tokens = approximate_token_count(artifact.get_content() or "")
+        index_lines.append(f"- {kind} — \"{artifact.title}\" (~{tokens} tokens)")
+    index_text = "\n".join(index_lines) if index_lines else "(none)"
+    return memory_content, scratchpad_content, index_text
 
 
 def get_user_ai_preferences_content(user_id, pinned_node=None):
@@ -269,6 +407,37 @@ def _scan_proposal_statuses(node_chain):
 
             elif name == "update_ai_preferences" and not reported:
                 notes.append("[AI preferences were updated.]")
+                to_mark.append((node, name))
+
+            elif name == "update_artifact" and not reported:
+                if entry.get("status") == "success":
+                    kind = entry.get("kind", "?")
+                    verb = ("created" if entry.get("created")
+                            else "updated")
+                    notes.append(f"[Artifact '{kind}' was {verb}.]")
+                to_mark.append((node, name))
+
+            elif name == "read_artifact" and not reported:
+                if entry.get("status") == "success":
+                    artifact = UserArtifact.query.get(
+                        entry.get("artifact_id"))
+                    if artifact is not None:
+                        # Resolved fresh from the encrypted row — content
+                        # is never stored in tool_calls_meta.
+                        notes.append(
+                            f"[Contents of artifact "
+                            f"'{entry.get('kind', '?')}' you requested:\n"
+                            f"{artifact.get_content()}]"
+                        )
+                else:
+                    err = entry.get("error", "unknown error")
+                    notes.append(f"[read_artifact failed — {err}]")
+                to_mark.append((node, name))
+
+            elif name == "submit_feedback" and not reported:
+                if entry.get("status") == "success":
+                    notes.append(
+                        "[Feedback was submitted to the Loore team.]")
                 to_mark.append((node, name))
 
     return notes, to_mark
@@ -486,6 +655,67 @@ def _execute_tool_calls(tool_calls, llm_node, node_chain, user_id):
                 db.session.flush()
                 result["status"] = "success"
                 result["preferences_id"] = prefs.id
+
+            elif name == "update_artifact":
+                kind = (inp.get("kind") or "").strip().lower()
+                if not _ARTIFACT_KIND_RE.match(kind):
+                    result["status"] = "error"
+                    result["error"] = (
+                        f"Invalid artifact kind: {kind!r}. Use a short "
+                        "lowercase slug (letters, digits, dashes)."
+                    )
+                else:
+                    previous = UserArtifact.latest_for(user_id, kind)
+                    title = (inp.get("title") or "").strip()
+                    if not title:
+                        title = (
+                            previous.title if previous
+                            else UserArtifact.DEFAULT_KINDS.get(
+                                kind, kind.replace("-", " ").title())
+                        )
+                    artifact = UserArtifact(
+                        user_id=user_id,
+                        kind=kind,
+                        title=title[:128],
+                        generated_by=llm_node.llm_model or "agentic_session",
+                        tokens_used=0,
+                    )
+                    artifact.set_content(inp["updated_content"])
+                    db.session.add(artifact)
+                    db.session.flush()
+                    result["status"] = "success"
+                    result["artifact_id"] = artifact.id
+                    result["kind"] = kind
+                    result["created"] = previous is None
+
+            elif name == "read_artifact":
+                kind = (inp.get("kind") or "").strip().lower()
+                artifact = UserArtifact.latest_for(user_id, kind)
+                if artifact is None or artifact.ai_usage not in AI_ALLOWED:
+                    result["status"] = "error"
+                    result["error"] = f"No readable artifact of kind {kind!r}"
+                else:
+                    # Content is NOT stored in tool meta (plaintext column)
+                    # — _scan_proposal_statuses re-resolves it from the
+                    # encrypted row and injects it next turn.
+                    result["status"] = "success"
+                    result["artifact_id"] = artifact.id
+                    result["kind"] = kind
+
+            elif name == "submit_feedback":
+                category = inp.get("category") or "other"
+                if category not in ("praise", "frustration", "idea", "other"):
+                    category = "other"
+                feedback = UserFeedback(
+                    user_id=user_id,
+                    category=category,
+                    source="llm",
+                )
+                feedback.set_content(inp["content"])
+                db.session.add(feedback)
+                db.session.flush()
+                result["status"] = "success"
+                result["feedback_id"] = feedback.id
 
             elif name in ("propose_todo", "propose_github_issue"):
                 # These are no longer tools — proposals are auto-detected
@@ -760,6 +990,18 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             needs_ai_prefs = ai_prefs_node is not None
             user_ai_preferences_content = None
 
+            # User artifacts (#158) — memory/scratchpad content + index.
+            # All three placeholders resolve from one pinned snapshot.
+            artifacts_node = (
+                _placeholder_node(USER_MEMORY_PLACEHOLDER)
+                or _placeholder_node(USER_SCRATCHPAD_PLACEHOLDER)
+                or _placeholder_node(USER_ARTIFACTS_INDEX_PLACEHOLDER)
+            )
+            needs_artifacts = artifacts_node is not None
+            user_memory_content = None
+            user_scratchpad_content = None
+            user_artifacts_index = None
+
             # Check if any node contains {quote:ID} placeholders
             needs_quotes = any(
                 has_quotes(node.get_content())
@@ -805,6 +1047,12 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             if needs_ai_prefs:
                 user_ai_preferences_content = get_user_ai_preferences_content(
                     user_id, pinned_node=ai_prefs_node
+                )
+
+            if needs_artifacts:
+                (user_memory_content, user_scratchpad_content,
+                 user_artifacts_index) = get_user_artifacts_context(
+                    user_id, pinned_node=artifacts_node
                 )
 
             # Detect if this is an agentic session (enables tools)
@@ -1038,6 +1286,22 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                             message_text = message_text.replace(
                                 USER_AI_PREFERENCES_PLACEHOLDER,
                                 user_ai_preferences_content or ""
+                            )
+                        # Replace artifact placeholders — pinned snapshot
+                        if USER_MEMORY_PLACEHOLDER in message_text:
+                            message_text = message_text.replace(
+                                USER_MEMORY_PLACEHOLDER,
+                                user_memory_content or ""
+                            )
+                        if USER_SCRATCHPAD_PLACEHOLDER in message_text:
+                            message_text = message_text.replace(
+                                USER_SCRATCHPAD_PLACEHOLDER,
+                                user_scratchpad_content or ""
+                            )
+                        if USER_ARTIFACTS_INDEX_PLACEHOLDER in message_text:
+                            message_text = message_text.replace(
+                                USER_ARTIFACTS_INDEX_PLACEHOLDER,
+                                user_artifacts_index or "(none)"
                             )
                         # Resolve {quote:ID} placeholders if present
                         if needs_quotes and has_quotes(message_text):

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -1076,6 +1076,54 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         mode_note = mode_labels.get(source_mode)
                         if mode_note:
                             agentic_notes.append(mode_note)
+                # Semantic retrieval (#155): surface relevant archive
+                # snippets for the latest user message via the notes
+                # channel (after the stable prefix — cache-friendly).
+                # Failures never break a completion.
+                if is_agentic and flask_app.config.get(
+                        "RAG_AGENTIC_INJECTION", True):
+                    try:
+                        from backend.utils.api_keys import (
+                            get_openai_chat_key,
+                        )
+                        from backend.utils.embeddings import (
+                            retrieve_relevant_snippets,
+                        )
+                        latest_user_node = next(
+                            (n for n in reversed(node_chain)
+                             if n.node_type != "llm"
+                             and n.llm_model is None
+                             and n.deleted_at is None), None)
+                        rag_key = get_openai_chat_key(flask_app.config)
+                        query_text = (latest_user_node.get_content() or ""
+                                      ).strip() if latest_user_node else ""
+                        if rag_key and len(query_text) >= 20:
+                            chain_ids = [n.id for n in node_chain]
+                            snippets = retrieve_relevant_snippets(
+                                user_id, query_text[-4000:], chain_ids,
+                                rag_key,
+                                k=flask_app.config.get("RAG_TOP_K", 4),
+                                min_score=flask_app.config.get(
+                                    "RAG_MIN_SCORE", 0.35),
+                            )
+                            if snippets:
+                                lines = [
+                                    "[Possibly relevant entries from the "
+                                    "user's archive (retrieved by semantic "
+                                    "similarity to their latest message — "
+                                    "use only if actually relevant):"
+                                ]
+                                for nid, created, snip, score in snippets:
+                                    stamp = local_stamp(created, user_tz)
+                                    lines.append(
+                                        f"- {stamp} (node {nid}): {snip}")
+                                lines.append("]")
+                                agentic_notes.append("\n".join(lines))
+                    except Exception:
+                        logger.warning(
+                            "Semantic retrieval failed; continuing "
+                            "without it", exc_info=True)
+
                 if is_agentic and agentic_notes:
                     # Synthetic system-side note injected after the latest real
                     # message; stamp it with "now" so the model's most-recent

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -878,8 +878,159 @@ class LLMCompletionTask(Task):
                     logger.error(f"LLM completion failed for node {llm_node_id}: {exc}")
 
 
+def render_system_message(system_node, user_id):
+    """Render the system node's full message text exactly as the
+    generation loop would (#192/#187).
+
+    Used by the finalize pre-warm so the provider-cache warm and the
+    real generation share byte-identical prefixes: the result is stored
+    in the #192 Redis cache, and generation prefers those cached bytes.
+    Only valid for prompts without volatile placeholders ({user_export},
+    {quote:..}) — callers must check first.
+    """
+    owner = User.query.get(user_id)
+    user_tz = owner.timezone if owner and owner.timezone else "UTC"
+    author = system_node.user.username if system_node.user else "Unknown"
+    time_prefix = local_stamp(
+        system_node.updated_at or system_node.created_at, user_tz)
+    text = f"{time_prefix} author {author}: {system_node.get_content()}"
+
+    if USER_PROFILE_PLACEHOLDER in text:
+        profile_obj = get_user_profile_content(
+            user_id, pinned_node=system_node)
+        text = text.replace(
+            USER_PROFILE_PLACEHOLDER,
+            profile_obj.get_content() if profile_obj else "")
+    if USER_TODO_PLACEHOLDER in text:
+        text = text.replace(
+            USER_TODO_PLACEHOLDER,
+            get_user_todo_content(user_id, pinned_node=system_node) or "")
+    if USER_RECENT_PLACEHOLDER in text:
+        rc = get_user_recent_content(user_id, pinned_node=system_node)
+        text = text.replace(
+            USER_RECENT_PLACEHOLDER, rc.get_content() if rc else "")
+    if USER_RECENT_RAW_PLACEHOLDER in text:
+        raw_result = get_user_recent_raw_content(
+            user_id, created_before=system_node.created_at)
+        raw_text = ""
+        if raw_result:
+            raw_text = format_date_metadata(
+                covers_start=raw_result.get("earliest"),
+                covers_end=raw_result.get("latest"),
+                tokens=raw_result.get("token_count"),
+            ) + raw_result["content"]
+        text = text.replace(USER_RECENT_RAW_PLACEHOLDER, raw_text)
+    if USER_AI_PREFERENCES_PLACEHOLDER in text:
+        text = text.replace(
+            USER_AI_PREFERENCES_PLACEHOLDER,
+            get_user_ai_preferences_content(
+                user_id, pinned_node=system_node) or "")
+    if (USER_MEMORY_PLACEHOLDER in text
+            or USER_SCRATCHPAD_PLACEHOLDER in text
+            or USER_ARTIFACTS_INDEX_PLACEHOLDER in text):
+        memory, scratchpad, index = get_user_artifacts_context(
+            user_id, pinned_node=system_node)
+        text = text.replace(USER_MEMORY_PLACEHOLDER, memory or "")
+        text = text.replace(USER_SCRATCHPAD_PLACEHOLDER, scratchpad or "")
+        text = text.replace(
+            USER_ARTIFACTS_INDEX_PLACEHOLDER, index or "(none)")
+    return text
+
+
+@celery.task(name='backend.tasks.llm_completion.prewarm_anthropic_cache')
+def prewarm_anthropic_cache(system_node_id, user_id, model_id,
+                            transcript_so_far, recording_stamp_iso):
+    """Pre-warm the Anthropic prompt cache during voice finalize (#187).
+
+    Fired at the START of finalize for fresh voice threads, overlapping
+    the trailing-batch transcription. Renders the system prefix (storing
+    it in the #192 cache so generation reuses the exact bytes), then
+    sends a max_tokens=1 request with cache breakpoints on the system
+    block and the transcript-so-far block. Generation then reads those
+    entries at 0.1x and prefills only the final batch.
+
+    Every failure path is silent — a missed warm just means today's
+    uncached behavior.
+    """
+    with flask_app.app_context():
+        try:
+            system_node = Node.query.get(system_node_id)
+            if system_node is None:
+                return {"status": "skipped", "reason": "no_system_node"}
+            sys_content = system_node.get_content() or ""
+            if USER_EXPORT_PATTERN.search(sys_content)                     or has_quotes(sys_content):
+                return {"status": "skipped", "reason": "volatile_prompt"}
+
+            model_config = flask_app.config["SUPPORTED_MODELS"].get(model_id)
+            if not model_config or model_config["provider"] != "anthropic":
+                return {"status": "skipped", "reason": "not_anthropic"}
+
+            from backend.utils.prompt_cache import (
+                get_cached_render, store_render,
+            )
+            sys_text = get_cached_render(flask_app.config, system_node)
+            if sys_text is None:
+                sys_text = render_system_message(system_node, user_id)
+                store_render(flask_app.config, system_node, sys_text)
+
+            owner = User.query.get(user_id)
+            user_tz = (owner.timezone if owner and owner.timezone
+                       else "UTC")
+            author = owner.username if owner else "Unknown"
+            stamp = local_stamp(
+                datetime.fromisoformat(recording_stamp_iso), user_tz)
+            transcript_block = (
+                f"{stamp} author {author}: {transcript_so_far}")
+
+            key_type = determine_api_key_type([system_node], logger=logger)
+            api_keys = get_api_keys_for_usage(flask_app.config, key_type)
+            if not api_keys.get("anthropic"):
+                return {"status": "skipped", "reason": "no_key"}
+
+            response = LLMProvider._call_anthropic(
+                model_config["api_model"],
+                [
+                    {"role": "user", "content": [
+                        {"type": "text", "text": sys_text,
+                         "cache_control": {"type": "ephemeral"}},
+                    ]},
+                    {"role": "user", "content": [
+                        {"type": "text", "text": transcript_block,
+                         "cache_control": {"type": "ephemeral"}},
+                    ]},
+                ],
+                api_keys["anthropic"],
+                max_tokens=1,
+                tools=VOICE_TOOLS,
+            )
+            cache_write = response.get("cache_creation_input_tokens", 0)
+            cost = calculate_llm_cost_microdollars(
+                model_id, response.get("input_tokens", 0),
+                response.get("output_tokens", 0),
+                cache_read_tokens=response.get(
+                    "cache_read_input_tokens", 0),
+                cache_write_tokens=cache_write,
+            )
+            db.session.add(APICostLog(
+                user_id=user_id,
+                model_id=model_id,
+                request_type="cache_warm",
+                input_tokens=response.get("input_tokens", 0) + cache_write,
+                output_tokens=response.get("output_tokens", 0),
+                cost_microdollars=cost,
+            ))
+            db.session.commit()
+            logger.info("Cache pre-warm wrote %d tokens (node %s)",
+                        cache_write, system_node_id)
+            return {"status": "ok", "cache_write_tokens": cache_write}
+        except Exception:
+            logger.warning("Cache pre-warm failed; generation proceeds "
+                           "uncached", exc_info=True)
+            return {"status": "failed"}
+
+
 @celery.task(base=LLMCompletionTask, bind=True)
-def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id: str, user_id: int, source_mode: str = None):
+def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id: str, user_id: int, source_mode: str = None, cache_split_offset: int = None):
     """
     Asynchronously generate an LLM response and update a placeholder node.
 
@@ -889,6 +1040,9 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
         model_id: Model identifier (e.g., "gpt-5", "claude-sonnet-4.5").
         user_id: ID of the user requesting the completion.
         source_mode: 'voice' or 'textmode' — which mode triggered this call.
+        cache_split_offset: char offset splitting the latest voice
+            transcript into [already-warmed prefix][final batch] blocks
+            for provider prompt caching (#187). None = no split.
     """
     logger.info(f"Starting LLM completion task for parent {parent_node_id}, updating node {llm_node_id}, model={model_id}")
 
@@ -965,8 +1119,34 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             # drifted mid-thread; only the 10k-raw window was pinned (and it
             # still is, via recent_raw_node.created_at — it's a rolling
             # token window, not a single versioned row).
+            # #192: the system node's rendered text is byte-identical
+            # across turns (#191 pinning), so render once and reuse via
+            # Redis. A hit also lets us skip the heavy artifact fetches
+            # when their placeholders live only in the system prompt.
+            from backend.utils.prompt_cache import (
+                get_cached_render, store_render,
+            )
+            system_node = next(
+                (n for n in node_chain
+                 if n.deleted_at is None and n.has_artifact("prompt")),
+                None)
+            system_render_cacheable = False
+            cached_system_render = None
+            if system_node is not None:
+                _sys_text = system_node.get_content() or ""
+                # Exclude prompts carrying per-call volatile placeholders.
+                system_render_cacheable = (
+                    not USER_EXPORT_PATTERN.search(_sys_text)
+                    and not has_quotes(_sys_text)
+                )
+                if system_render_cacheable:
+                    cached_system_render = get_cached_render(
+                        flask_app.config, system_node)
+
             def _placeholder_node(placeholder):
                 for n in node_chain:
+                    if cached_system_render is not None and n is system_node:
+                        continue  # already rendered — no fetch needed
                     if _alive(n) and placeholder in n.get_content():
                         return n
                 return None
@@ -1181,10 +1361,24 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                            else "UTC")
 
                 messages = []
+                system_msg_index = None
+                last_assistant_index = None
+                latest_user_msg_index = None
                 for node in node_chain:
                     author = node.user.username if node.user else "Unknown"
                     is_llm_node = node.node_type == "llm" or (node.llm_model is not None)
                     time_prefix = local_stamp(node.updated_at or node.created_at, user_tz)
+
+                    # #192: reuse the cached system-prompt render verbatim.
+                    if (node is system_node
+                            and cached_system_render is not None):
+                        system_msg_index = len(messages)
+                        messages.append({
+                            "role": "user",
+                            "content": [{"type": "text",
+                                         "text": cached_system_render}],
+                        })
+                        continue
 
                     # Soft-deleted ancestor: scrub content so the AI doesn't
                     # ingest deleted user data. We still include the node so
@@ -1309,6 +1503,39 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                             if resolved_ids:
                                 logger.info(f"Resolved quotes for node IDs: {resolved_ids}")
 
+                    if (node.id == parent_node_id and not is_llm_node
+                            and cache_split_offset
+                            and node.deleted_at is None):
+                        # #187: two-block transcript split. Block A is the
+                        # prefix the finalize pre-warm already cached
+                        # (byte-identical incl. the recording-start stamp);
+                        # block B is the final transcribed batch.
+                        head_len = len(message_text) - len(node_content) \
+                            + cache_split_offset
+                        if 0 < head_len < len(message_text):
+                            latest_user_msg_index = len(messages)
+                            messages.append({
+                                "role": role,
+                                "content": [
+                                    {"type": "text",
+                                     "text": message_text[:head_len]},
+                                    {"type": "text",
+                                     "text": message_text[head_len:]},
+                                ],
+                            })
+                            continue
+
+                    if node.id == parent_node_id and not is_llm_node:
+                        latest_user_msg_index = len(messages)
+                    if node is system_node:
+                        system_msg_index = len(messages)
+                        if (system_render_cacheable
+                                and cached_system_render is None
+                                and attempt == 0):
+                            store_render(
+                                flask_app.config, system_node, message_text)
+                    if role == "assistant":
+                        last_assistant_index = len(messages)
                     messages.append({
                         "role": role,
                         "content": [{"type": "text", "text": message_text}]
@@ -1402,6 +1629,23 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         "content": [{"type": "text", "text": injected_text}]
                     })
 
+                # #187: provider-side prompt caching (Anthropic). Mark
+                # cache breakpoints: one on the rendered system prompt
+                # (the big stable prefix) and one on the last assistant
+                # reply (caches the whole prior conversation). Everything
+                # after the last breakpoint — the new user message and the
+                # volatile notes — prefills fresh each turn. Byte-identity
+                # of the prefix across turns is guaranteed by #191/#192.
+                if provider == "anthropic" and is_agentic:
+                    for idx in (system_msg_index, last_assistant_index,
+                                latest_user_msg_index):
+                        if idx is None:
+                            continue
+                        blocks = messages[idx].get("content")
+                        if isinstance(blocks, list) and blocks:
+                            blocks[-1]["cache_control"] = {
+                                "type": "ephemeral"}
+
                 # Step 3: Call LLM API
                 self.update_state(state='PROGRESS', meta={'progress': 40, 'status': 'Generating response'})
                 llm_node.llm_task_progress = 40
@@ -1434,6 +1678,9 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             total_tokens = response["total_tokens"]
             input_tokens = response.get("input_tokens", 0)
             output_tokens = response.get("output_tokens", 0)
+            cache_read_tokens = response.get("cache_read_input_tokens", 0)
+            cache_write_tokens = response.get(
+                "cache_creation_input_tokens", 0)
             response_tool_calls = response.get("tool_calls", [])
             response_truncated = response.get("truncated", False)
 
@@ -1444,12 +1691,23 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
             llm_node.llm_task_progress = 90
             db.session.commit()
 
-            cost = calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens)
+            cost = calculate_llm_cost_microdollars(
+                model_id, input_tokens, output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            )
+            if cache_read_tokens or cache_write_tokens:
+                logger.info(
+                    "Prompt cache usage: read=%d write=%d uncached=%d",
+                    cache_read_tokens, cache_write_tokens, input_tokens)
             cost_log = APICostLog(
                 user_id=user_id,
                 model_id=model_id,
                 request_type="conversation",
-                input_tokens=input_tokens,
+                # Full prompt size for visibility (uncached + cached reads
+                # + cache writes); pricing already accounted above.
+                input_tokens=(input_tokens + cache_read_tokens
+                              + cache_write_tokens),
                 output_tokens=output_tokens,
                 cost_microdollars=cost,
             )

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -1349,6 +1349,7 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 replaced_profile = False
                 replaced_recent = False
                 replaced_recent_raw = False
+                replaced_export = False  # #139: first occurrence only
 
                 # Temporal grounding (#130): every message is prefixed with an
                 # absolute local-time stamp derived from the node's updated_at
@@ -1423,12 +1424,22 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         message_text = (
                             f"{time_prefix} author {author}: {node_content}"
                         )
-                        # Replace {user_export} placeholder if present
+                        # Replace {user_export} — first occurrence gets
+                        # the archive, repeats get a stub (#139): the
+                        # export is the heaviest placeholder and
+                        # duplicating it doubles prompt cost.
                         if user_export_content and export_placeholder_match:
-                            message_text = message_text.replace(
-                                export_placeholder_match,
-                                user_export_content
-                            )
+                            if export_placeholder_match in message_text:
+                                if not replaced_export:
+                                    message_text = message_text.replace(
+                                        export_placeholder_match,
+                                        user_export_content, 1
+                                    )
+                                    replaced_export = True
+                                message_text = message_text.replace(
+                                    export_placeholder_match,
+                                    "(see archive above)"
+                                )
                         # Replace {user_profile} — first occurrence
                         # gets content, subsequent get emptied (dedup)
                         if USER_PROFILE_PLACEHOLDER in message_text:

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -18,7 +18,7 @@ from backend.utils.tokens import (
     approximate_token_count, reduce_export_tokens, format_date_metadata,
 )
 from backend.utils.quotes import resolve_quotes, has_quotes
-from backend.utils.timefmt import local_stamp
+from backend.utils.timefmt import local_stamp, strip_edge_timestamps
 from backend.utils.api_keys import determine_api_key_type, get_api_keys_for_usage
 from backend.utils.cost import calculate_llm_cost_microdollars
 from backend.utils.tool_meta import update_tool_meta, parse_github_issue
@@ -1691,6 +1691,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                         f"(attempt {attempt + 2}/{MAX_RETRIES + 1})"
                     )
             llm_text = response["content"]
+            # #179: strip hallucinated context-timestamp echoes from the
+            # response edges before anything stores or speaks the text.
+            scrubbed = strip_edge_timestamps(llm_text)
+            if scrubbed != llm_text:
+                logger.info(
+                    "Stripped edge timestamp(s) from LLM response "
+                    "(model=%s, node=%s)", model_id, llm_node_id)
+                llm_text = scrubbed
             total_tokens = response["total_tokens"]
             input_tokens = response.get("input_tokens", 0)
             output_tokens = response.get("output_tokens", 0)

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -1657,9 +1657,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 logger.info(f"Calling LLM API: model_id={model_id}, api_model={api_model}, provider={provider}, key_type={key_type}, estimated_tokens={estimated_tokens}, total_chars={len(total_content)}")
 
                 try:
+                    # #189: stable per-thread key improves OpenAI's
+                    # automatic prefix-cache routing.
+                    thread_root_id = (node_chain[0].id if node_chain
+                                      else parent_node_id)
                     response = LLMProvider.get_completion(
                         model_id, messages, api_keys,
                         tools=agentic_tools,
+                        prompt_cache_key=f"loore-t{thread_root_id}",
                     )
                     break  # Success
                 except PromptTooLongError as e:
@@ -1695,6 +1700,7 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 model_id, input_tokens, output_tokens,
                 cache_read_tokens=cache_read_tokens,
                 cache_write_tokens=cache_write_tokens,
+                cached_input_tokens=response.get("cached_tokens", 0),
             )
             if cache_read_tokens or cache_write_tokens:
                 logger.info(

--- a/backend/tasks/spend_monitor.py
+++ b/backend/tasks/spend_monitor.py
@@ -1,0 +1,22 @@
+"""Hourly Celery beat task for API spend monitoring (issue #85).
+
+Thin wrapper — the testable logic lives in backend/utils/spend.py.
+Disabled unless ANTHROPIC_SPEND_LIMIT_USD is set to a positive value.
+"""
+from celery.utils.log import get_task_logger
+
+from backend.celery_app import celery, flask_app
+from backend.utils.spend import check_and_alert
+
+logger = get_task_logger(__name__)
+
+
+@celery.task(name='backend.tasks.spend_monitor.check_api_spend')
+def check_api_spend():
+    with flask_app.app_context():
+        result = check_and_alert(flask_app.config)
+        if result.get("fired"):
+            logger.warning("Spend alert(s) fired: %s", result)
+        else:
+            logger.info("Spend check: %s", result)
+        return result

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -840,6 +840,36 @@ def finalize_draft_streaming(self, session_id: str, total_chunks: int,
         if not draft:
             raise ValueError(f"Draft not found for session {session_id}")
 
+        # #187: pre-warm the Anthropic prompt cache while the trailing
+        # chunks transcribe. Fresh Voice threads only (for an ongoing
+        # thread the prior turn's cache is usually still warm). The
+        # system node is created early — here instead of in the chain
+        # start — so the warm renders against real pinned artifacts and
+        # the cached bytes (#192) are exactly what generation reuses.
+        cache_split_offset = None
+        if (parent_id is None and user_id and model
+                and label == 'Voice'):
+            try:
+                transcript_so_far = draft.get_content() or ""
+                model_cfg = flask_app.config["SUPPORTED_MODELS"].get(model)
+                if (len(transcript_so_far) >= 500 and model_cfg
+                        and model_cfg["provider"] == "anthropic"):
+                    parent_id = _create_system_node_early(
+                        user_id, label.lower(), draft)
+                    cache_split_offset = len(transcript_so_far)
+                    from backend.tasks.llm_completion import (
+                        prewarm_anthropic_cache,
+                    )
+                    prewarm_anthropic_cache.delay(
+                        parent_id, user_id, model, transcript_so_far,
+                        (draft.created_at or datetime.utcnow()).isoformat(),
+                    )
+            except Exception:
+                logger.warning(
+                    "Cache pre-warm setup failed; continuing without it",
+                    exc_info=True)
+                cache_split_offset = None
+
         # Trigger transcription of any remaining stored chunks (< 20, so
         # they didn't hit the batch threshold during recording). This is a
         # synchronous call to the batch task so we can wait for completion.
@@ -963,6 +993,7 @@ def finalize_draft_streaming(self, session_id: str, total_chunks: int,
                 _start_server_side_llm_chain(
                     draft, session_id, full_transcript,
                     user_id, parent_id, model, label,
+                    cache_split_offset=cache_split_offset,
                 )
             except Exception as e:
                 logger.error(
@@ -991,8 +1022,38 @@ def finalize_draft_streaming(self, session_id: str, total_chunks: int,
         }
 
 
+def _create_system_node_early(user_id, prompt_key, draft):
+    """Create the thread's system node at finalize START (#187) so the
+    cache pre-warm renders against real pinned artifacts. Returns its id.
+
+    Mirrors the fresh-thread branch of _start_server_side_llm_chain,
+    which then simply receives this node as parent_id.
+    """
+    from backend.models import Node
+    from backend.utils.prompts import get_user_prompt_record
+    from backend.utils.context_artifacts import attach_context_artifacts
+
+    prompt_record = get_user_prompt_record(user_id, prompt_key)
+    system_node = Node(
+        user_id=user_id,
+        human_owner_id=user_id,
+        parent_id=None,
+        node_type="user",
+        privacy_level="private",
+        ai_usage=draft.ai_usage or "none",
+    )
+    db.session.add(system_node)
+    db.session.flush()
+    attach_context_artifacts(
+        system_node.id, user_id, prompt_record=prompt_record,
+    )
+    db.session.commit()
+    return system_node.id
+
+
 def _start_server_side_llm_chain(draft, session_id, transcript,
-                                 user_id, parent_id, model, label):
+                                 user_id, parent_id, model, label,
+                                 cache_split_offset=None):
     """
     Create nodes and kick off LLM + TTS generation server-side.
 
@@ -1053,6 +1114,11 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
         token_count=approximate_token_count(transcript),
     )
     user_node.set_content(transcript)
+    # #187: stamp the voice node at recording START (constant for the
+    # whole recording) so the message time-prefix is byte-identical
+    # between the finalize pre-warm and the generation.
+    if draft.created_at:
+        user_node.created_at = draft.created_at
     db.session.add(user_node)
     db.session.flush()
 
@@ -1121,6 +1187,7 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
         generate_llm_response.si(
             user_node.id, llm_node.id, model, user_id,
             source_mode='voice',
+            cache_split_offset=cache_split_offset,
         ),
         generate_tts_audio.si(
             llm_node.id, str(audio_storage_root),

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -566,9 +566,11 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
 
         chunk_dir = audio_storage_root / f"drafts/{draft.user_id}/{session_id}"
 
-        # Collect and decrypt chunk files
+        # Collect and decrypt chunk files (keyed by index — sub-batch
+        # partitioning below needs per-chunk paths, #124)
         temp_files = []
-        decrypted_paths = []
+        paths_by_idx = {}
+        merged_by_subbatch = []  # [(sub_indices, merged_path)] (#124)
 
         try:
             for idx in sorted(chunk_indices):
@@ -579,96 +581,147 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 if enc_path.exists():
                     temp_path = decrypt_file_to_temp(str(enc_path))
                     temp_files.append(temp_path)
-                    decrypted_paths.append(temp_path)
+                    paths_by_idx[idx] = temp_path
                 elif chunk_path.exists():
-                    decrypted_paths.append(str(chunk_path))
+                    paths_by_idx[idx] = str(chunk_path)
                 else:
                     logger.warning(
                         f"Chunk file not found for session {session_id}, "
                         f"index {idx}: {chunk_path}"
                     )
 
-            if not decrypted_paths:
+            if not paths_by_idx:
                 raise FileNotFoundError(
                     f"No chunk files found for session {session_id}, "
                     f"indices {chunk_indices}"
                 )
 
-            # If this batch doesn't include chunk 0, decrypt the cached
-            # init segment so concat_fragmented_media can prepend it —
-            # only chunk 0 carries the format-specific header (WebM:
-            # EBML/Segment/Tracks; fMP4: ftyp+moov), so later batches
-            # would otherwise be header-less fragment data that ffmpeg
-            # can't remux.
-            first_chunk = min(chunk_indices) if chunk_indices else 0
-            init_segment_path = None
-            if first_chunk > 0:
-                init_enc = chunk_dir / f"init{ext}.enc"
-                init_plain = chunk_dir / f"init{ext}"
-                if init_enc.exists():
-                    init_segment_path = decrypt_file_to_temp(str(init_enc))
-                    temp_files.append(init_segment_path)
-                elif init_plain.exists():
-                    init_segment_path = str(init_plain)
+            # Partition into subsessions (#124): a resumed recording's
+            # chunks come from a fresh MediaRecorder whose stream is not
+            # byte-concat-compatible with the chunks before it. The
+            # upload route persists `init.{N}{ext}` for every chunk N>0
+            # that opens a new stream; those N are split points. Each
+            # sub-batch is merged + transcribed independently and the
+            # transcripts are joined — instead of one merged file with a
+            # second init mid-stream, which made ffmpeg silently drop
+            # everything before it.
+            present = sorted(paths_by_idx)
+            boundaries = {
+                idx for idx in present
+                if idx > 0 and (
+                    (chunk_dir / f"init.{idx}{ext}").exists()
+                    or (chunk_dir / f"init.{idx}{ext}.enc").exists()
+                )
+            }
+            sub_batches = []
+            current = []
+            for idx in present:
+                if idx in boundaries and current:
+                    sub_batches.append(current)
+                    current = []
+                current.append(idx)
+            if current:
+                sub_batches.append(current)
+            if len(sub_batches) > 1:
+                logger.info(
+                    f"Session {session_id}: batch {min(present)}-"
+                    f"{max(present)} spans {len(sub_batches)} subsessions "
+                    f"(boundaries at {sorted(boundaries)})"
+                )
+
+            def _resolve_init(sub_indices):
+                """Init segment for a sub-batch, or None.
+
+                A sub-batch starting at a subsession boundary N uses its
+                own `init.{N}{ext}`; a sub-batch starting at chunk 0
+                needs none (chunk 0 self-carries the header); any other
+                start uses the legacy chunk-0 init (`init{ext}`).
+                """
+                start = sub_indices[0]
+                if start in boundaries:
+                    candidates = [
+                        chunk_dir / f"init.{start}{ext}.enc",
+                        chunk_dir / f"init.{start}{ext}",
+                    ]
+                elif start > 0:
+                    candidates = [
+                        chunk_dir / f"init{ext}.enc",
+                        chunk_dir / f"init{ext}",
+                    ]
                 else:
-                    logger.warning(
-                        f"No init segment found for session {session_id} "
-                        f"batch starting at chunk {first_chunk}; "
-                        "concat will likely fail"
-                    )
+                    return None
+                for cand in candidates:
+                    if not cand.exists():
+                        continue
+                    if cand.suffix == '.enc':
+                        path = decrypt_file_to_temp(str(cand))
+                        temp_files.append(path)
+                        return path
+                    return str(cand)
+                logger.warning(
+                    f"No init segment found for session {session_id} "
+                    f"sub-batch starting at chunk {start}; "
+                    "concat will likely fail"
+                )
+                return None
 
-            # Merge MediaRecorder fragments into a single valid file.
-            # Binary-append the fragments and remux — see
-            # concat_fragmented_media for the full rationale. Same code
-            # path handles both Matroska/WebM and fMP4.
-            merged_path = concat_fragmented_media(
-                decrypted_paths,
-                init_segment_path=init_segment_path,
-                output_suffix=ext,
-            )
-            merge_input = merged_path
+            # Merge + transcribe each subsession independently (#124).
+            # Binary-append the fragments and remux per sub-batch — see
+            # concat_fragmented_media for the rationale. Same code path
+            # handles both Matroska/WebM and fMP4.
+            api_key = get_openai_chat_key(flask_app.config)
+            if not api_key:
+                raise ValueError("OpenAI API key not configured")
+            client = OpenAI(api_key=api_key)
 
-            # Compress if needed (no-op for already-compressed WebM/MP4)
-            merge_input_path = pathlib.Path(merge_input)
-            processed_path = compress_audio_if_needed(merge_input_path, logger)
+            transcripts = []
+            batch_duration_sec = 0.0
+            for sub_indices in sub_batches:
+                merged_path = concat_fragmented_media(
+                    [paths_by_idx[i] for i in sub_indices],
+                    init_segment_path=_resolve_init(sub_indices),
+                    output_suffix=ext,
+                )
+                merged_by_subbatch.append((sub_indices, merged_path))
 
-            # Measure duration for cost tracking
-            batch_duration_sec = get_audio_duration(processed_path, logger)
+                # Compress if needed (no-op for compressed WebM/MP4)
+                merge_input_path = pathlib.Path(merged_path)
+                processed_path = compress_audio_if_needed(
+                    merge_input_path, logger)
 
-            try:
-                # Transcribe via gpt-4o-transcribe
-                api_key = get_openai_chat_key(flask_app.config)
-                if not api_key:
-                    raise ValueError(
-                        "OpenAI API key not configured"
-                    )
+                batch_duration_sec += get_audio_duration(
+                    processed_path, logger)
 
-                client = OpenAI(api_key=api_key)
-                with open(processed_path, "rb") as audio_file:
-                    # Pass an explicit (name, file) tuple so the API
-                    # infers the format from `ext` rather than from the
-                    # tempfile's auto-generated suffix.
-                    resp = client.audio.transcriptions.create(
-                        model="gpt-4o-transcribe",
-                        file=(f"audio{ext}", audio_file),
-                        response_format="text"
-                    )
-
-                    if hasattr(resp, "text"):
-                        transcript = resp.text
-                    elif isinstance(resp, dict):
-                        transcript = (
-                            resp.get("text") or resp.get("transcript") or ""
+                try:
+                    with open(processed_path, "rb") as audio_file:
+                        # Explicit (name, file) tuple so the API infers
+                        # the format from `ext` rather than the
+                        # tempfile's auto-generated suffix.
+                        resp = client.audio.transcriptions.create(
+                            model="gpt-4o-transcribe",
+                            file=(f"audio{ext}", audio_file),
+                            response_format="text"
                         )
-                    else:
-                        transcript = str(resp)
 
-            finally:
-                if processed_path != merge_input_path:
-                    try:
-                        os.unlink(processed_path)
-                    except Exception:
-                        pass
+                        if hasattr(resp, "text"):
+                            sub_text = resp.text
+                        elif isinstance(resp, dict):
+                            sub_text = (
+                                resp.get("text")
+                                or resp.get("transcript") or ""
+                            )
+                        else:
+                            sub_text = str(resp)
+                    if sub_text and sub_text.strip():
+                        transcripts.append(sub_text.strip())
+                finally:
+                    if processed_path != merge_input_path:
+                        try:
+                            os.unlink(processed_path)
+                        except Exception:
+                            pass
+
+            transcript = "\n\n".join(transcripts)
 
             # Store transcript in the first chunk of the batch;
             # mark all batch chunks as completed
@@ -702,23 +755,26 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                 )
                 db.session.add(cost_log)
 
-            # Encrypt the merged audio and store as a batch file;
-            # delete individual chunk .enc files.
+            # Encrypt the merged audio and store as batch files — one
+            # per subsession (#124); delete individual chunk .enc files
+            # only for sub-batches whose merge succeeded.
             # IMPORTANT: do this BEFORE committing chunk status to DB,
             # because finalize_draft_streaming polls for completed chunks
             # and may move/delete the directory once all are done.
-            if merged_path and os.path.exists(merged_path):
+            from backend.utils.encryption import encrypt_file
+            for sub_indices, sub_merged in merged_by_subbatch:
+                if not (sub_merged and os.path.exists(sub_merged)):
+                    continue
                 batch_filename = (
-                    f"batch_{min(chunk_indices):04d}-"
-                    f"{max(chunk_indices):04d}{ext}"
+                    f"batch_{min(sub_indices):04d}-"
+                    f"{max(sub_indices):04d}{ext}"
                 )
                 batch_dest = chunk_dir / batch_filename
-                shutil.move(merged_path, str(batch_dest))
-                from backend.utils.encryption import encrypt_file
+                shutil.move(sub_merged, str(batch_dest))
                 encrypt_file(str(batch_dest))
 
-                # Delete individual encrypted chunk files in the batch
-                for idx in chunk_indices:
+                # Delete individual encrypted chunk files in the sub-batch
+                for idx in sub_indices:
                     for chunk_name in [
                         f"chunk_{idx:04d}{ext}.enc",
                         f"chunk_{idx:04d}{ext}",
@@ -785,12 +841,14 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
                     os.unlink(tf)
                 except Exception:
                     pass
-            # Clean up merged file if still around
-            if merged_path and os.path.exists(merged_path):
-                try:
-                    os.unlink(merged_path)
-                except Exception:
-                    pass
+            # Clean up any merged files still around (one per
+            # subsession, #124; moved away on success)
+            for _, sub_merged in merged_by_subbatch:
+                if sub_merged and os.path.exists(sub_merged):
+                    try:
+                        os.unlink(sub_merged)
+                    except Exception:
+                        pass
 
 
 class DraftFinalizationTask(Task):

--- a/backend/tasks/tts.py
+++ b/backend/tasks/tts.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from backend.celery_app import celery, flask_app
 from backend.models import Node, UserProfile, TTSChunk, APICostLog
 from backend.extensions import db
-from backend.utils.audio_processing import adaptive_chunk_text
+from backend.utils.audio_processing import section_aware_chunk_text
 from backend.utils.api_keys import get_openai_chat_key
 from backend.utils.encryption import encrypt_file
 from backend.utils.cost import calculate_audio_cost_microdollars
@@ -138,17 +138,24 @@ def _generate_tts_chunks(task, entity, text, target_dir, audio_storage_root,
     entity.tts_task_progress = 30
     db.session.commit()
 
-    chunks = adaptive_chunk_text(text)
+    chunk_specs = section_aware_chunk_text(text)
+    chunks = [c for c, _title, _idx in chunk_specs]
     logger.info(
         f"Text split into {len(chunks)} chunks for TTS "
-        f"for {entity_label} (sizes: {[len(c) for c in chunks]})"
+        f"for {entity_label} (sizes: {[len(c) for c in chunks]}, "
+        f"sections: {len({s for _, _, s in chunk_specs})})"
     )
 
-    # Create TTSChunk records for streaming playback
+    # Create TTSChunk records for streaming playback (with chapter
+    # metadata, #145)
     chunk_fk = {chunk_fk_attr: entity.id}
     created_chunks = []
-    for i in range(len(chunks)):
-        tts_chunk = TTSChunk(chunk_index=i, status='pending', **chunk_fk)
+    for i, (_chunk, section_title, section_index) in enumerate(chunk_specs):
+        tts_chunk = TTSChunk(
+            chunk_index=i, status='pending',
+            section_index=section_index,
+            section_title=section_title,
+            **chunk_fk)
         db.session.add(tts_chunk)
         created_chunks.append(tts_chunk)
     db.session.commit()

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -1,0 +1,343 @@
+"""Tests for user artifacts + agentic artifact/feedback tools (issue #158).
+
+Covers: model versioning, latest_per_kind, REST routes (list/get/put/
+versions), tool executor handlers (update_artifact, read_artifact,
+submit_feedback), status-note injection, and session pinning.
+
+Patterned after test_tts_invalidation.py: sqlite in-memory, minimal
+Flask app, ENCRYPTION_DISABLED.
+"""
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import (  # noqa: E402
+    User, Node, NodeContextArtifact, UserArtifact, UserFeedback,
+)
+
+# ── Import the real llm_completion against stub glue ─────────────────────
+# (same pattern as test_context_artifact_pinning.py: stub celery_app +
+# llm_providers, drop any cached/mocked task module, import, restore.)
+_GLUE = ("backend.celery_app", "backend.llm_providers",
+         "backend.tasks.llm_completion")
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules["backend.llm_providers"] = MagicMock()
+sys.modules.pop("backend.tasks.llm_completion", None)
+
+from backend.tasks.llm_completion import (  # noqa: E402
+    _execute_tool_calls, _scan_proposal_statuses, _mark_status_reported,
+    get_user_artifacts_context,
+)
+
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+
+def _make_app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.artifacts import artifacts_bp
+    app.register_blueprint(artifacts_bp, url_prefix="/api/artifacts")
+    return app
+
+
+@pytest.fixture
+def app():
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    client = app.test_client()
+    user = User.query.first()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    return client
+
+
+def _mk_artifact(user_id, kind, content, title=None):
+    artifact = UserArtifact(
+        user_id=user_id, kind=kind,
+        title=title or kind.title(), generated_by="test",
+    )
+    artifact.set_content(content)
+    _db.session.add(artifact)
+    _db.session.commit()
+    return artifact
+
+
+# ── Model ────────────────────────────────────────────────────────────────
+
+def test_latest_for_returns_newest_version(app):
+    with app.app_context():
+        uid = User.query.first().id
+        _mk_artifact(uid, "memory", "v1")
+        _mk_artifact(uid, "memory", "v2")
+        latest = UserArtifact.latest_for(uid, "memory")
+        assert latest.get_content() == "v2"
+
+
+def test_latest_per_kind(app):
+    with app.app_context():
+        uid = User.query.first().id
+        _mk_artifact(uid, "memory", "m1")
+        _mk_artifact(uid, "memory", "m2")
+        _mk_artifact(uid, "reading-list", "books", title="Reading List")
+        latest = UserArtifact.latest_per_kind(uid)
+        assert set(latest) == {"memory", "reading-list"}
+        assert latest["memory"].get_content() == "m2"
+
+
+# ── Routes ───────────────────────────────────────────────────────────────
+
+def test_list_includes_empty_defaults(app, client):
+    resp = client.get("/api/artifacts/")
+    assert resp.status_code == 200
+    kinds = {a["kind"] for a in resp.get_json()["artifacts"]}
+    assert {"memory", "scratchpad"} <= kinds
+
+
+def test_put_creates_versions_and_get_returns_latest(app, client):
+    r1 = client.put("/api/artifacts/memory", json={"content": "first"})
+    assert r1.status_code == 200
+    r2 = client.put("/api/artifacts/memory", json={"content": "second"})
+    assert r2.get_json()["artifact"]["version_number"] == 2
+
+    got = client.get("/api/artifacts/memory").get_json()["artifact"]
+    assert got["content"] == "second"
+
+    versions = client.get(
+        "/api/artifacts/memory/versions").get_json()["versions"]
+    assert len(versions) == 2
+    assert versions[0]["version_number"] == 2
+
+
+def test_put_custom_kind_with_title(app, client):
+    resp = client.put("/api/artifacts/reading-list", json={
+        "content": "- book", "title": "Reading List"})
+    artifact = resp.get_json()["artifact"]
+    assert artifact["kind"] == "reading-list"
+    assert artifact["title"] == "Reading List"
+
+
+def test_put_rejects_bad_kind(app, client):
+    assert client.put(
+        "/api/artifacts/Bad Kind!", json={"content": "x"}
+    ).status_code == 400
+
+
+def test_get_unknown_custom_kind_404(app, client):
+    assert client.get("/api/artifacts/nope").status_code == 404
+
+
+def test_version_ownership_enforced(app, client):
+    with app.app_context():
+        other = User(username="other")
+        _db.session.add(other)
+        _db.session.commit()
+        foreign = _mk_artifact(other.id, "memory", "secret")
+        foreign_id = foreign.id
+    assert client.get(
+        f"/api/artifacts/versions/{foreign_id}").status_code == 403
+
+
+# ── Tool executor ────────────────────────────────────────────────────────
+
+def _run_tool(app, name, inp, uid):
+    llm_node = MagicMock()
+    llm_node.llm_model = "test-model"
+    results = _execute_tool_calls(
+        [{"name": name, "input": inp}], llm_node, [], uid)
+    return results[0]
+
+
+def test_update_artifact_tool_creates_and_versions(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r1 = _run_tool(app, "update_artifact",
+                       {"kind": "memory", "updated_content": "fact A"}, uid)
+        assert r1["status"] == "success"
+        assert r1["created"] is True
+
+        r2 = _run_tool(app, "update_artifact",
+                       {"kind": "memory", "updated_content": "fact A+B"}, uid)
+        assert r2["created"] is False
+        assert UserArtifact.latest_for(uid, "memory").get_content() == "fact A+B"
+        assert UserArtifact.query.filter_by(
+            user_id=uid, kind="memory").count() == 2
+
+
+def test_update_artifact_tool_rejects_bad_kind(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r = _run_tool(app, "update_artifact",
+                      {"kind": "NOT OK", "updated_content": "x"}, uid)
+        assert r["status"] == "error"
+
+
+def test_read_artifact_tool_returns_ref_not_content(app):
+    with app.app_context():
+        uid = User.query.first().id
+        artifact = _mk_artifact(uid, "reading-list", "secret-books")
+        r = _run_tool(app, "read_artifact", {"kind": "reading-list"}, uid)
+        assert r["status"] == "success"
+        assert r["artifact_id"] == artifact.id
+        # Content must never sit in tool meta (plaintext column)
+        assert "secret-books" not in json.dumps(r)
+
+
+def test_read_artifact_tool_unknown_kind(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r = _run_tool(app, "read_artifact", {"kind": "ghost"}, uid)
+        assert r["status"] == "error"
+
+
+def test_submit_feedback_tool(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r = _run_tool(app, "submit_feedback",
+                      {"content": "love the voice mode", "category": "praise"},
+                      uid)
+        assert r["status"] == "success"
+        row = UserFeedback.query.get(r["feedback_id"])
+        assert row.get_content() == "love the voice mode"
+        assert row.category == "praise"
+        assert row.status == "new"
+
+
+# ── Status notes ─────────────────────────────────────────────────────────
+
+def _node_with_meta(uid, meta):
+    node = Node(user_id=uid, node_type="llm")
+    node.set_content("resp")
+    node.tool_calls_meta = json.dumps(meta)
+    _db.session.add(node)
+    _db.session.commit()
+    return node
+
+
+def test_scan_statuses_reports_artifact_tools_once(app):
+    with app.app_context():
+        uid = User.query.first().id
+        artifact = _mk_artifact(uid, "reading-list", "the actual books")
+        node = _node_with_meta(uid, [
+            {"name": "update_artifact", "status": "success",
+             "kind": "memory", "created": False},
+            {"name": "read_artifact", "status": "success",
+             "kind": "reading-list", "artifact_id": artifact.id},
+            {"name": "submit_feedback", "status": "success",
+             "feedback_id": 1},
+        ])
+        notes, to_mark = _scan_proposal_statuses([node])
+        joined = "\n".join(notes)
+        assert "Artifact 'memory' was updated." in joined
+        assert "the actual books" in joined  # read_artifact content delivery
+        assert "Feedback was submitted" in joined
+        assert len(to_mark) == 3
+
+        _mark_status_reported(to_mark)
+        _db.session.commit()
+        notes2, to_mark2 = _scan_proposal_statuses([node])
+        assert notes2 == []
+        assert to_mark2 == []
+
+
+# ── Pinning ──────────────────────────────────────────────────────────────
+
+def test_attach_pins_artifacts_and_node_resolves_them(app):
+    from backend.utils.context_artifacts import attach_context_artifacts
+    with app.app_context():
+        uid = User.query.first().id
+        _mk_artifact(uid, "memory", "pinned-memory-v1")
+        node = Node(user_id=uid, node_type="system")
+        node.set_content("{user_memory}")
+        _db.session.add(node)
+        _db.session.flush()
+
+        attach_context_artifacts(node.id, uid)
+        _db.session.commit()
+
+        pinned = node.get_user_artifacts()
+        assert set(pinned) == {"memory"}
+        assert pinned["memory"].get_content() == "pinned-memory-v1"
+
+        # New version after pinning must not change the pinned snapshot
+        _mk_artifact(uid, "memory", "newer")
+        assert node.get_user_artifacts()["memory"].get_content() == \
+            "pinned-memory-v1"
+
+
+def test_artifacts_context_resolution_pinned_vs_latest(app):
+    with app.app_context():
+        uid = User.query.first().id
+        v1 = _mk_artifact(uid, "memory", "mem-v1")
+        _mk_artifact(uid, "scratchpad", "pad-v1")
+        _mk_artifact(uid, "reading-list", "books", title="Reading List")
+
+        node = Node(user_id=uid, node_type="system")
+        node.set_content("{user_memory}")
+        _db.session.add(node)
+        _db.session.flush()
+        _db.session.add(NodeContextArtifact(
+            node_id=node.id, artifact_type="user_artifact",
+            artifact_id=v1.id))
+        _db.session.commit()
+
+        # Pinned: only memory v1 (the node binding wins)
+        memory, scratchpad, index = get_user_artifacts_context(
+            uid, pinned_node=node)
+        assert memory == "mem-v1"
+        assert scratchpad == ""
+
+        # Fallback (no pinned node): latest of everything
+        memory, scratchpad, index = get_user_artifacts_context(uid)
+        assert memory == "mem-v1"
+        assert scratchpad == "pad-v1"
+        assert "reading-list" in index

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -140,7 +140,7 @@ def test_list_includes_empty_defaults(app, client):
     resp = client.get("/api/artifacts/")
     assert resp.status_code == 200
     kinds = {a["kind"] for a in resp.get_json()["artifacts"]}
-    assert {"memory", "scratchpad"} <= kinds
+    assert {"memory", "scratchpad", "intentions"} <= kinds
 
 
 def test_put_creates_versions_and_get_returns_latest(app, client):
@@ -331,13 +331,41 @@ def test_artifacts_context_resolution_pinned_vs_latest(app):
         _db.session.commit()
 
         # Pinned: only memory v1 (the node binding wins)
-        memory, scratchpad, index = get_user_artifacts_context(
+        memory, scratchpad, intentions, index = get_user_artifacts_context(
             uid, pinned_node=node)
         assert memory == "mem-v1"
         assert scratchpad == ""
+        assert intentions == ""
 
         # Fallback (no pinned node): latest of everything
-        memory, scratchpad, index = get_user_artifacts_context(uid)
+        memory, scratchpad, intentions, index = get_user_artifacts_context(uid)
         assert memory == "mem-v1"
         assert scratchpad == "pad-v1"
         assert "reading-list" in index
+
+
+def test_intentions_ambient_not_in_index(app):
+    """Intentions (#150) resolve via their own placeholder and stay out
+    of the read_artifact index, like memory/scratchpad."""
+    with app.app_context():
+        uid = User.query.first().id
+        _mk_artifact(uid, "intentions",
+                     "## Write daily\n*held since 2026-06-10 — active*")
+        memory, scratchpad, intentions, index = \
+            get_user_artifacts_context(uid)
+        assert "Write daily" in intentions
+        assert "intentions" not in index
+
+
+def test_update_artifact_tool_handles_intentions(app):
+    with app.app_context():
+        uid = User.query.first().id
+        r = _run_tool(app, "update_artifact", {
+            "kind": "intentions",
+            "updated_content": "## Morning pages\n*held since "
+                               "2026-06-10 — active*\nWrite 3 pages.",
+        }, uid)
+        assert r["status"] == "success"
+        latest = UserArtifact.latest_for(uid, "intentions")
+        assert latest.title == "Intentions"
+        assert "Morning pages" in latest.get_content()

--- a/backend/tests/test_external_content.py
+++ b/backend/tests/test_external_content.py
@@ -1,0 +1,223 @@
+"""Tests for the external-content substrate (#155 component 2 / Download).
+
+Covers: normalization (CA rows, X bookmark objects, import-file shapes),
+per-user dedupe on upsert, the items/import routes, env-gating of the X
+connect flow, and external items in semantic search. All network calls
+mocked — no CA/X traffic.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import (  # noqa: E402
+    User, ExternalItem, ExternalItemEmbedding,
+)
+from backend.utils.external_content import (  # noqa: E402
+    normalize_ca_tweet, normalize_x_bookmark,
+)
+
+# Glue-import the sync task helpers
+_GLUE = ("backend.celery_app", "backend.tasks.external_sync")
+_saved = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules.pop("backend.tasks.external_sync", None)
+from backend.tasks.external_sync import _upsert_items  # noqa: E402
+for _k, _v in _saved.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+
+@pytest.fixture
+def app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    app.config["OPENAI_API_KEY_CHAT"] = "fake-key"
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.external import external_bp
+    from backend.routes.search import search_bp
+    app.register_blueprint(external_bp, url_prefix="/api/external")
+    app.register_blueprint(search_bp, url_prefix="/api")
+
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    client = app.test_client()
+    user = User.query.first()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    return client
+
+
+# ── Normalization ────────────────────────────────────────────────────────
+
+def test_normalize_ca_tweet_field_tolerance():
+    a = normalize_ca_tweet(
+        {"tweet_id": 123, "full_text": "hello", "created_at":
+         "2024-08-01T12:00:00+00:00"}, "alice")
+    assert a["external_id"] == "123"
+    assert a["content"] == "hello"
+    assert a["url"].endswith("/alice/status/123")
+    assert a["posted_at"].year == 2024
+
+    b = normalize_ca_tweet({"id": "9", "text": "alt names"}, "bob")
+    assert b["external_id"] == "9"
+
+    assert normalize_ca_tweet({"tweet_id": 1}, "x") is None  # no text
+    assert normalize_ca_tweet({"full_text": "t"}, "x") is None  # no id
+
+
+def test_normalize_x_bookmark():
+    item = normalize_x_bookmark(
+        {"id": "55", "text": "saved tweet", "author_id": "7",
+         "created_at": "2025-01-01T00:00:00.000Z"},
+        {"7": {"username": "carol"}})
+    assert item["author_handle"] == "carol"
+    assert item["url"].endswith("/carol/status/55")
+    # Unknown author still produces a working status URL
+    anon = normalize_x_bookmark({"id": "56", "text": "x"}, {})
+    assert "/i/status/56" in anon["url"]
+
+
+# ── Upsert / dedupe ──────────────────────────────────────────────────────
+
+def test_upsert_dedupes_per_user_and_source(app):
+    with app.app_context():
+        uid = User.query.first().id
+        items = [
+            {"external_id": "1", "content": "a", "author_handle": "x",
+             "url": None, "posted_at": None},
+            {"external_id": "2", "content": "b", "author_handle": "x",
+             "url": None, "posted_at": None},
+        ]
+        created, skipped = _upsert_items(uid, "community_archive", items)
+        assert (created, skipped) == (2, 0)
+        created, skipped = _upsert_items(uid, "community_archive", items)
+        assert (created, skipped) == (0, 2)
+        # Same external_id under a different source is a separate item
+        created, _ = _upsert_items(uid, "twitter_bookmark", items[:1])
+        assert created == 1
+        assert ExternalItem.query.count() == 3
+
+
+# ── Routes ───────────────────────────────────────────────────────────────
+
+def test_items_route_lists_and_counts(app, client):
+    with app.app_context():
+        uid = User.query.first().id
+        _upsert_items(uid, "community_archive", [
+            {"external_id": "1", "content": "tweet one " * 60,
+             "author_handle": "x", "url": "https://t.co/1",
+             "posted_at": None},
+        ])
+    body = client.get("/api/external/items").get_json()
+    assert body["total"] == 1
+    assert body["counts"] == {"community_archive": 1}
+    assert body["items"][0]["preview"].endswith("…")
+
+
+def test_bookmarks_json_import_shapes(app, client):
+    payload = [
+        {"id": "10", "text": "direct shape", "author": "a"},
+        {"url": "https://twitter.com/b/status/11?s=20",
+         "full_text": "url-derived id", "screen_name": "b"},
+        {"text": "no id — skipped"},
+        "not even a dict",
+    ]
+    body = client.post("/api/external/bookmarks/import",
+                       json={"bookmarks": payload}).get_json()
+    assert body["created"] == 2
+    assert body["unrecognized"] == 2
+    with app.app_context():
+        ids = {i.external_id for i in ExternalItem.query.all()}
+        assert ids == {"10", "11"}
+
+
+def test_twitter_connect_env_gated(app, client):
+    assert client.get(
+        "/api/external/twitter/connect").status_code == 503
+    status = client.get("/api/external/twitter/status").get_json()
+    assert status == {"configured": False, "connected": False,
+                      "handle": None, "last_synced_at": None}
+
+
+def test_ca_fetch_requires_username(app, client):
+    assert client.post("/api/external/community-archive/fetch",
+                       json={}).status_code == 400
+
+
+# ── Semantic search inclusion ────────────────────────────────────────────
+
+def test_semantic_search_includes_external(app, client, monkeypatch):
+    from backend.utils.embeddings import pack_vector, content_hash
+    with app.app_context():
+        uid = User.query.first().id
+        _upsert_items(uid, "twitter_bookmark", [
+            {"external_id": "42", "content": "a bookmarked gem about gardens",
+             "author_handle": "gardener", "url": "https://t.co/42",
+             "posted_at": None},
+        ])
+        item = ExternalItem.query.first()
+        _db.session.add(ExternalItemEmbedding(
+            item_id=item.id, user_id=uid,
+            model="text-embedding-3-small",
+            content_hash=content_hash(item.get_content()),
+            vector=pack_vector([1.0, 0.0])))
+        _db.session.commit()
+
+    import backend.utils.embeddings as emb_module
+    monkeypatch.setattr(
+        emb_module, "embed_texts",
+        lambda texts, key, **kw: [[1.0, 0.05] for _ in texts])
+
+    body = client.get("/api/search/semantic?q=gardening").get_json()
+    assert body["total"] == 1
+    result = body["results"][0]
+    assert result["kind"] == "external"
+    assert result["source"] == "twitter_bookmark"
+    assert result["author_handle"] == "gardener"
+
+    # Opt-out flag excludes references
+    body2 = client.get(
+        "/api/search/semantic?q=gardening&include_external=0").get_json()
+    assert body2["results"] == []

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,80 @@
+"""Tests for /health and /ready endpoints (roadmap Phase 0).
+
+Minimal Flask app + sqlite in-memory; redis reachability is monkeypatched
+(no real Redis in the test environment).
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+import backend.routes.health as health_module  # noqa: E402
+from backend.routes.health import health_bp  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    app.register_blueprint(health_bp)
+    app.register_blueprint(health_bp, url_prefix="/api", name="health_api_bp")
+    with app.app_context():
+        _db.create_all()
+        yield app.test_client()
+
+
+def test_health_always_ok(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_health_under_api_prefix(client):
+    assert client.get("/api/health").status_code == 200
+
+
+def test_ready_ok_when_deps_up(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: True)
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ready"
+    assert body["database"] is True
+    assert body["redis"] is True
+
+
+def test_ready_503_when_redis_down(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: False)
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    body = resp.get_json()
+    assert body["status"] == "not_ready"
+    assert body["redis"] is False
+
+
+def test_ready_503_when_db_down(client, monkeypatch):
+    monkeypatch.setattr(health_module, "_check_redis", lambda: True)
+    monkeypatch.setattr(health_module, "_check_db", lambda: False)
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.get_json()["database"] is False

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -1,0 +1,68 @@
+"""Tests for first-login onboarding completion tracking (#147)."""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    from flask_login import LoginManager
+    from backend.routes.dashboard import dashboard_bp
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    app.register_blueprint(dashboard_bp, url_prefix="/api/dashboard")
+    with app.app_context():
+        _db.create_all()
+        user = User(username="newbie", approved=True)
+        _db.session.add(user)
+        _db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(user.id)
+            sess["_fresh"] = True
+        yield client
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def test_complete_endpoint_idempotent(client):
+    r1 = client.post("/api/dashboard/onboarding/complete")
+    assert r1.status_code == 200
+    user = User.query.first()
+    first_stamp = user.onboarding_completed_at
+    assert first_stamp is not None
+
+    r2 = client.post("/api/dashboard/onboarding/complete")
+    assert r2.status_code == 200
+    assert User.query.first().onboarding_completed_at == first_stamp

--- a/backend/tests/test_profile_regen_resume.py
+++ b/backend/tests/test_profile_regen_resume.py
@@ -301,3 +301,139 @@ def test_null_cutoff_high_data_still_triggers(app, monkeypatch):
     exports.maybe_trigger_incremental_profile_update(user)
     assert "yes" in called              # crossed threshold -> triggered
     assert called["yes"][0][0] == user.id
+
+
+# ── #183: full regen preserves user-written profiles ─────────────────────
+
+def _mk_user_profile(user, content, created_at, generated_by="user"):
+    profile = UserProfile(
+        user_id=user.id, generated_by=generated_by, tokens_used=0,
+    )
+    profile.set_content(content)
+    _db.session.add(profile)
+    _db.session.commit()
+    if created_at:
+        profile.created_at = created_at
+        _db.session.commit()
+    return profile
+
+
+def test_183_iterative_injects_at_chronological_chunk(app, monkeypatch):
+    """The hand-written profile lands in the first chunk whose window
+    reaches its creation date — not in earlier chunks."""
+    import backend.tasks.exports as exports
+
+    user = User(username="writer", plan="alpha", approved=True)
+    _db.session.add(user)
+    _db.session.commit()
+    _mk_user_profile(user, "MY HAND-WRITTEN SELF-DESCRIPTION",
+                     datetime(2025, 6, 1))
+
+    chunks = [
+        {"content": "old data", "token_count": 90000,
+         "latest_node_created_at": datetime(2025, 1, 1)},
+        {"content": "newer data", "token_count": 90000,
+         "latest_node_created_at": datetime(2025, 12, 1)},
+        None,
+    ]
+    calls = iter(chunks)
+    monkeypatch.setattr(
+        exports, "build_user_export_content",
+        lambda *a, **k: next(calls))
+
+    prompts = []
+
+    def fake_llm(self_, model_id, prompt, uid, keys, **kw):
+        prompts.append(prompt)
+        return {"content": f"profile v{len(prompts)}", "total_tokens": 1,
+                "input_tokens": 1, "output_tokens": 1}
+
+    monkeypatch.setattr(exports, "_call_llm_with_retries", fake_llm)
+
+    exports._chunked_profile_loop(
+        MagicMock(), user, "test-model", "{existing_profile}{new_data}",
+        {}, first_chunk_prompt_fn=lambda c: "GEN:" + c["content"],
+        user_written_profile=exports._latest_user_written_profile(user.id),
+    )
+
+    assert len(prompts) == 2
+    # Chunk 1 (Jan 2025) predates the profile (Jun 2025) → no injection
+    assert "HAND-WRITTEN" not in prompts[0]
+    # Chunk 2 (Dec 2025) reaches it → injected with the dated note
+    assert "HAND-WRITTEN" in prompts[1]
+    assert "2025-06-01" in prompts[1]
+
+
+def test_183_reconciles_when_profile_newer_than_all_data(app, monkeypatch):
+    """All data predates the hand-written profile → one extra
+    reconciliation pass at the end instead of dropping it."""
+    import backend.tasks.exports as exports
+
+    user = User(username="writer2", plan="alpha", approved=True)
+    _db.session.add(user)
+    _db.session.commit()
+    _mk_user_profile(user, "LATE SELF-DESCRIPTION", datetime(2026, 1, 1))
+
+    chunks = [
+        {"content": "only old data", "token_count": 90000,
+         "latest_node_created_at": datetime(2025, 1, 1)},
+        None,
+    ]
+    calls = iter(chunks)
+    monkeypatch.setattr(
+        exports, "build_user_export_content",
+        lambda *a, **k: next(calls))
+
+    prompts = []
+
+    def fake_llm(self_, model_id, prompt, uid, keys, **kw):
+        prompts.append(prompt)
+        return {"content": f"profile v{len(prompts)}", "total_tokens": 1,
+                "input_tokens": 1, "output_tokens": 1}
+
+    monkeypatch.setattr(exports, "_call_llm_with_retries", fake_llm)
+
+    profile_id, chunk_num, _ = exports._chunked_profile_loop(
+        MagicMock(), user, "test-model", "{existing_profile}|{new_data}",
+        {}, first_chunk_prompt_fn=lambda c: "GEN:" + c["content"],
+        user_written_profile=exports._latest_user_written_profile(user.id),
+    )
+
+    assert len(prompts) == 2  # data chunk + reconciliation pass
+    assert "LATE SELF-DESCRIPTION" in prompts[1]
+    assert "2026-01-01" in prompts[1]
+    assert chunk_num == 2
+    # The reconciliation result is the saved head profile
+    # (_save_profile prepends a coverage-metadata header)
+    head = UserProfile.query.get(profile_id)
+    assert head.get_content().endswith("profile v2")
+
+
+def test_183_single_pass_includes_dated_block(app, monkeypatch):
+    import backend.tasks.exports as exports
+
+    user = User(username="writer3", plan="alpha", approved=True)
+    _db.session.add(user)
+    _db.session.commit()
+    profile = _mk_user_profile(
+        user, "SINGLE PASS SELF-DESC", datetime(2025, 3, 3))
+
+    prompts = []
+
+    def fake_llm(self_, model_id, prompt, uid, keys, **kw):
+        prompts.append(prompt)
+        return {"content": "generated", "total_tokens": 1,
+                "input_tokens": 1, "output_tokens": 1}
+
+    monkeypatch.setattr(exports, "_call_llm_with_retries", fake_llm)
+
+    exports._single_pass_generation(
+        MagicMock(), user, "test-model", "TPL:{user_export}",
+        {"content": "all the data", "token_count": 10,
+         "latest_node_created_at": datetime(2025, 1, 1)},
+        {}, user_written_profile=profile,
+    )
+    assert len(prompts) == 1
+    assert "SINGLE PASS SELF-DESC" in prompts[0]
+    assert "2025-03-03" in prompts[0]
+    assert "all the data" in prompts[0]

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -232,3 +232,30 @@ def test_call_anthropic_preserves_blocks_and_cache_usage(app, monkeypatch):
     assert result["cache_read_input_tokens"] == 5000
     assert result["cache_creation_input_tokens"] == 300
     assert result["input_tokens"] == 100
+
+
+# ── OpenAI cached-input pricing (#189) ───────────────────────────────────
+
+def test_openai_cached_input_discount(app):
+    app.config["SUPPORTED_MODELS"]["gpt-5.5"] = {
+        "provider": "openai", "api_model": "gpt-5.5",
+        "input_price_per_mtok": 5.00, "output_price_per_mtok": 30.00,
+        "cached_input_multiplier": 0.25,
+    }
+    with app.app_context():
+        # 1M prompt tokens, 800k of them cached at 0.25x
+        cost = calculate_llm_cost_microdollars(
+            "gpt-5.5", 1_000_000, 0, cached_input_tokens=800_000)
+        assert cost == round(200_000 * 5 + 800_000 * 5 * 0.25)
+        # Default multiplier (0.5) when model doesn't specify one
+        app.config["SUPPORTED_MODELS"]["gpt-5.4"] = {
+            "provider": "openai", "api_model": "gpt-5.4",
+            "input_price_per_mtok": 2.50, "output_price_per_mtok": 15.00,
+        }
+        cost54 = calculate_llm_cost_microdollars(
+            "gpt-5.4", 1_000_000, 0, cached_input_tokens=1_000_000)
+        assert cost54 == round(1_000_000 * 2.5 * 0.5)
+        # cached subset can never exceed input_tokens
+        capped = calculate_llm_cost_microdollars(
+            "gpt-5.5", 100, 0, cached_input_tokens=10_000)
+        assert capped == round(100 * 5 * 0.25)

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -1,0 +1,234 @@
+"""Tests for prompt caching (#187 provider-side, #192 backend cache).
+
+Covers: cache-aware cost math, the Redis-backed system-prompt render
+cache (fake client), render_system_message placeholder resolution against
+pinned artifacts, and _call_anthropic content-block passthrough with
+cache_control survival + cache usage fields (mocked Anthropic client).
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import (  # noqa: E402
+    User, Node, NodeContextArtifact, UserTodo,
+)
+import backend.utils.prompt_cache as prompt_cache  # noqa: E402
+from backend.utils.cost import calculate_llm_cost_microdollars  # noqa: E402
+
+_GLUE = ("backend.celery_app", "backend.llm_providers",
+         "backend.tasks.llm_completion")
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules["backend.llm_providers"] = MagicMock()
+sys.modules.pop("backend.tasks.llm_completion", None)
+from backend.tasks.llm_completion import render_system_message  # noqa: E402
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+SUPPORTED_MODELS = {
+    "claude-opus-4.6": {
+        "provider": "anthropic", "api_model": "claude-opus-4-6",
+        "input_price_per_mtok": 5.00, "output_price_per_mtok": 25.00,
+    },
+}
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    app.config["SUPPORTED_MODELS"] = SUPPORTED_MODELS
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        user.timezone = "UTC"
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+# ── Cost math (#187) ─────────────────────────────────────────────────────
+
+def test_cost_cache_multipliers(app):
+    with app.app_context():
+        # Uncached baseline: 1M input = $5 = 5_000_000 microdollars
+        base = calculate_llm_cost_microdollars(
+            "claude-opus-4.6", 1_000_000, 0)
+        assert base == 5_000_000
+        # Cache read bills at 0.1x
+        read = calculate_llm_cost_microdollars(
+            "claude-opus-4.6", 0, 0, cache_read_tokens=1_000_000)
+        assert read == 500_000
+        # Cache write bills at 1.25x
+        write = calculate_llm_cost_microdollars(
+            "claude-opus-4.6", 0, 0, cache_write_tokens=1_000_000)
+        assert write == 6_250_000
+        # Mixed adds up
+        mixed = calculate_llm_cost_microdollars(
+            "claude-opus-4.6", 100_000, 10_000,
+            cache_read_tokens=900_000, cache_write_tokens=50_000)
+        assert mixed == (round(100_000 * 5 + 10_000 * 25
+                               + 900_000 * 5 * 0.1 + 50_000 * 5 * 1.25))
+
+
+# ── Backend render cache (#192) ──────────────────────────────────────────
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+
+
+def test_render_cache_roundtrip_and_key_busting(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(prompt_cache, "_client", lambda config: fake)
+    with app.app_context():
+        uid = User.query.first().id
+        node = Node(user_id=uid, node_type="user")
+        node.set_content("prompt")
+        _db.session.add(node)
+        _db.session.commit()
+
+        assert prompt_cache.get_cached_render(app.config, node) is None
+        prompt_cache.store_render(app.config, node, "rendered bytes")
+        assert prompt_cache.get_cached_render(
+            app.config, node) == "rendered bytes"
+
+        # Editing the node (updated_at changes) busts the key naturally
+        from datetime import datetime
+        node.updated_at = datetime(2030, 1, 1)
+        _db.session.commit()
+        assert prompt_cache.get_cached_render(app.config, node) is None
+
+
+def test_render_cache_fails_open(app, monkeypatch):
+    def boom(config):
+        raise ConnectionError("redis down")
+    monkeypatch.setattr(prompt_cache, "_client", boom)
+    with app.app_context():
+        uid = User.query.first().id
+        node = Node(user_id=uid, node_type="user")
+        node.set_content("prompt")
+        _db.session.add(node)
+        _db.session.commit()
+        # Both directions silently degrade
+        assert prompt_cache.get_cached_render(app.config, node) is None
+        prompt_cache.store_render(app.config, node, "x")  # no raise
+
+
+# ── render_system_message (#187 byte-identity source) ────────────────────
+
+def test_render_system_message_resolves_pinned_placeholders(app):
+    with app.app_context():
+        uid = User.query.first().id
+        todo = UserTodo(user_id=uid, generated_by="test", ai_usage="chat")
+        todo.set_content("- [ ] pinned todo content")
+        _db.session.add(todo)
+        _db.session.flush()
+
+        node = Node(user_id=uid, human_owner_id=uid, node_type="user")
+        node.set_content("Prompt start. <todo>{user_todo}</todo> End.")
+        _db.session.add(node)
+        _db.session.flush()
+        _db.session.add(NodeContextArtifact(
+            node_id=node.id, artifact_type="todo", artifact_id=todo.id))
+        _db.session.commit()
+
+        text = render_system_message(node, uid)
+        assert "pinned todo content" in text
+        assert "{user_todo}" not in text
+        assert "author tester:" in text
+        # Deterministic: same call, same bytes
+        assert render_system_message(node, uid) == text
+
+
+# ── Provider block passthrough (#187) ────────────────────────────────────
+
+def test_call_anthropic_preserves_blocks_and_cache_usage(app, monkeypatch):
+    # Import the real provider module fresh (it may be mocked globally)
+    sys.modules.pop("backend.llm_providers", None)
+    import backend.llm_providers as providers
+
+    captured = {}
+
+    class FakeUsage:
+        input_tokens = 100
+        output_tokens = 10
+        cache_read_input_tokens = 5000
+        cache_creation_input_tokens = 300
+
+    class FakeBlock:
+        type = "text"
+        text = "hello"
+
+    class FakeResponse:
+        content = [FakeBlock()]
+        usage = FakeUsage()
+        stop_reason = "end_turn"
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return FakeResponse()
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(providers, "Anthropic", FakeClient)
+
+    messages = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "big stable prefix",
+             "cache_control": {"type": "ephemeral"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "text", "text": "part A"},
+            {"type": "text", "text": "part B",
+             "cache_control": {"type": "ephemeral"}},
+        ]},
+    ]
+    result = providers.LLMProvider._call_anthropic(
+        "claude-opus-4-6", messages, "fake-key")
+
+    sent = captured["messages"]
+    # Blocks passed through, not flattened; markers survive
+    assert isinstance(sent[0]["content"], list)
+    assert sent[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    assert len(sent[1]["content"]) == 2
+    assert sent[1]["content"][1]["cache_control"] == {"type": "ephemeral"}
+    # Cache usage surfaced
+    assert result["cache_read_input_tokens"] == 5000
+    assert result["cache_creation_input_tokens"] == 300
+    assert result["input_tokens"] == 100

--- a/backend/tests/test_resume_subsessions.py
+++ b/backend/tests/test_resume_subsessions.py
@@ -1,0 +1,220 @@
+"""Tests for resumed-recording subsession handling (#124).
+
+A recording resumed after a refresh comes from a fresh MediaRecorder
+whose stream is not byte-concat-compatible with earlier chunks. These
+tests cover the pieces that make the fix: init-bearing detection,
+suffixed init persistence, and sub-batch partitioning/init resolution
+inside transcribe_chunk_batch (exercised with synthetic WebM/MP4-shaped
+fixtures and a mocked transcription API — no ffmpeg, no OpenAI).
+"""
+import os
+import pathlib
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+import pytest  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.utils.webm_utils import (  # noqa: E402
+    WEBM_MAGIC, chunk_is_init_bearing, init_segment_name,
+)
+
+# fMP4 chunk head: [4-byte size]["ftyp"]...; WebM: EBML magic first.
+MP4_INIT_HEAD = b"\x00\x00\x00\x20ftypisom-rest-of-box"
+WEBM_INIT_HEAD = WEBM_MAGIC + b"\x9fB\x86\x81\x01-rest"
+FRAGMENT_HEAD = b"\x00\x00\x01\x10moofdata-no-init-here"
+
+
+def _write(tmp_path, name, data):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return p
+
+
+# ── Detection ────────────────────────────────────────────────────────────
+
+def test_detects_mp4_and_webm_init_chunks(tmp_path):
+    assert chunk_is_init_bearing(_write(tmp_path, "a.mp4", MP4_INIT_HEAD))
+    assert chunk_is_init_bearing(_write(tmp_path, "a.webm", WEBM_INIT_HEAD))
+
+
+def test_fragment_chunks_not_init_bearing(tmp_path):
+    assert not chunk_is_init_bearing(
+        _write(tmp_path, "b.mp4", FRAGMENT_HEAD))
+    assert not chunk_is_init_bearing(_write(tmp_path, "tiny.webm", b"abc"))
+    assert not chunk_is_init_bearing(tmp_path / "missing.webm")
+
+
+def test_init_segment_name_suffixing():
+    assert init_segment_name(".webm") == "init.webm"
+    assert init_segment_name(".mp4", 7) == "init.7.mp4"
+
+
+# ── Batch partitioning inside transcribe_chunk_batch ─────────────────────
+
+def _run_batch(tmp_path, monkeypatch, chunk_indices, boundary_indices,
+               ext=".webm"):
+    """Run transcribe_chunk_batch against synthetic fixtures.
+
+    Returns (concat_calls, stored_text) where concat_calls captures
+    (paths, init_segment_path) per sub-batch merge.
+    """
+    from flask import Flask
+    from backend.extensions import db as _db
+    from backend.models import User, Draft, NodeTranscriptChunk
+
+    _GLUE = ("backend.celery_app", "backend.tasks.streaming_transcription")
+    saved = {k: sys.modules.get(k) for k in _GLUE}
+    fake_celery_app = MagicMock()
+
+    # @celery.task(...) must return the real function, not a MagicMock,
+    # so the test can invoke the task body directly.
+    def _passthrough_task(*args, **kwargs):
+        def deco(f):
+            return f
+        return deco
+    fake_celery_app.celery.task = _passthrough_task
+
+    sys.modules["backend.celery_app"] = fake_celery_app
+    sys.modules.pop("backend.tasks.streaming_transcription", None)
+    import backend.tasks.streaming_transcription as st
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    fake_celery_app.flask_app = app
+    st.flask_app = app
+
+    session_id = "sess-124"
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.flush()
+        draft = Draft(user_id=user.id, session_id=session_id,
+                      streaming_status='recording',
+                      streaming_mime_type=(
+                          "audio/mp4" if ext == ".mp4" else "audio/webm"))
+        draft.set_content("")
+        _db.session.add(draft)
+        for idx in chunk_indices:
+            chunk = NodeTranscriptChunk(
+                session_id=session_id, chunk_index=idx, status='stored')
+            _db.session.add(chunk)
+        _db.session.commit()
+
+        # Fixture files: plaintext chunks + suffixed inits at boundaries
+        chunk_dir = tmp_path / f"drafts/{user.id}/{session_id}"
+        chunk_dir.mkdir(parents=True)
+        for idx in chunk_indices:
+            head = (MP4_INIT_HEAD if ext == ".mp4" else WEBM_INIT_HEAD) \
+                if (idx == 0 or idx in boundary_indices) else FRAGMENT_HEAD
+            (chunk_dir / f"chunk_{idx:04d}{ext}").write_bytes(
+                head + b"payload%d" % idx)
+        (chunk_dir / f"init{ext}").write_bytes(b"INIT0")
+        for b in boundary_indices:
+            (chunk_dir / f"init.{b}{ext}").write_bytes(b"INIT%d" % b)
+
+        monkeypatch.setenv("AUDIO_STORAGE_PATH", str(tmp_path))
+
+        concat_calls = []
+
+        def fake_concat(paths, init_segment_path=None, output_suffix=None):
+            concat_calls.append((list(paths), init_segment_path))
+            out = tmp_path / f"merged_{len(concat_calls)}{output_suffix}"
+            out.write_bytes(b"merged")
+            return str(out)
+
+        monkeypatch.setattr(st, "concat_fragmented_media", fake_concat)
+        monkeypatch.setattr(st, "compress_audio_if_needed",
+                            lambda p, log: p)
+        monkeypatch.setattr(st, "get_audio_duration", lambda p, log: 15.0)
+        monkeypatch.setattr(st, "get_openai_chat_key", lambda cfg: "key")
+
+        class FakeTranscriptions:
+            def __init__(self):
+                self.n = 0
+
+            def create(self, **kwargs):
+                self.n += 1
+                return type("R", (), {"text": f"part{self.n}"})()
+
+        fake_openai = MagicMock()
+        fake_openai.return_value.audio.transcriptions = FakeTranscriptions()
+        monkeypatch.setattr(st, "OpenAI", fake_openai)
+
+        # Call the task body directly (bind=True → self first)
+        st.transcribe_chunk_batch(MagicMock(), session_id,
+                                  list(chunk_indices))
+
+        stored = NodeTranscriptChunk.query.filter_by(
+            session_id=session_id,
+            chunk_index=min(chunk_indices)).first()
+        stored_text = stored.get_text() if stored else None
+        _db.session.rollback()
+        _db.drop_all()
+
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+    return concat_calls, stored_text
+
+
+def test_resumed_batch_splits_at_boundary(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2, 3], boundary_indices=[2])
+    # Two independent merges: [0,1] with no init (chunk 0 self-carries),
+    # [2,3] with the suffixed subsession init.
+    assert len(concat_calls) == 2
+    (paths1, init1), (paths2, init2) = concat_calls
+    assert len(paths1) == 2 and init1 is None
+    assert len(paths2) == 2 and init2 is not None
+    assert "init.2" in init2
+    # Both subsessions' transcripts present, in order
+    assert stored == "part1\n\npart2"
+
+
+def test_unresumed_batch_single_merge(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2], boundary_indices=[])
+    assert len(concat_calls) == 1
+    assert concat_calls[0][1] is None  # starts at 0 → no init prefix
+    assert stored == "part1"
+
+
+def test_later_batch_without_boundary_uses_legacy_init(tmp_path,
+                                                       monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[20, 21], boundary_indices=[])
+    assert len(concat_calls) == 1
+    assert concat_calls[0][1] is not None
+    assert concat_calls[0][1].endswith("init.webm")
+
+
+def test_mp4_resumed_batch_splits(tmp_path, monkeypatch):
+    concat_calls, stored = _run_batch(
+        tmp_path, monkeypatch,
+        chunk_indices=[0, 1, 2, 3], boundary_indices=[2], ext=".mp4")
+    assert len(concat_calls) == 2
+    assert "init.2" in concat_calls[1][1]

--- a/backend/tests/test_semantic_search.py
+++ b/backend/tests/test_semantic_search.py
@@ -1,0 +1,237 @@
+"""Tests for semantic search / embeddings (#155).
+
+Covers: vector pack/unpack + cosine, top-k ranking, sweep candidate
+selection (privacy + staleness), the /api/search/semantic endpoint
+(ownership scoping, no-key 503), and the agentic retrieval helper.
+OpenAI is never called — embed_texts is monkeypatched everywhere.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, Node, NodeEmbedding  # noqa: E402
+from backend.utils.embeddings import (  # noqa: E402
+    content_hash, cosine_similarity, pack_vector, unpack_vector,
+    top_k_similar, retrieve_relevant_snippets,
+)
+
+# Import the sweep candidate selector against stub glue
+_GLUE = ("backend.celery_app", "backend.tasks.embeddings")
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules.pop("backend.tasks.embeddings", None)
+from backend.tasks.embeddings import _candidate_nodes  # noqa: E402
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+
+def _make_app():
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    app.config["OPENAI_API_KEY_CHAT"] = "fake-key"
+
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.search import search_bp
+    app.register_blueprint(search_bp, url_prefix="/api")
+    return app
+
+
+@pytest.fixture
+def app():
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    client = app.test_client()
+    user = User.query.first()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    return client
+
+
+def _mk_node(uid, content, ai_usage="chat", node_type="text"):
+    node = Node(user_id=uid, human_owner_id=uid, node_type=node_type,
+                ai_usage=ai_usage)
+    node.set_content(content)
+    _db.session.add(node)
+    _db.session.commit()
+    return node
+
+
+def _mk_embedding(node, vector):
+    emb = NodeEmbedding(
+        node_id=node.id,
+        user_id=node.human_owner_id or node.user_id,
+        model="text-embedding-3-small",
+        content_hash=content_hash(node.get_content()),
+        vector=pack_vector(vector),
+    )
+    _db.session.add(emb)
+    _db.session.commit()
+    return emb
+
+
+# ── Pure vector math ─────────────────────────────────────────────────────
+
+def test_pack_unpack_roundtrip():
+    values = [0.1, -0.5, 0.0, 2.5]
+    out = list(unpack_vector(pack_vector(values)))
+    assert out == pytest.approx(values, abs=1e-6)
+
+
+def test_cosine_similarity():
+    assert cosine_similarity([1, 0], [1, 0]) == pytest.approx(1.0)
+    assert cosine_similarity([1, 0], [0, 1]) == pytest.approx(0.0)
+    assert cosine_similarity([1, 0], [-1, 0]) == pytest.approx(-1.0)
+    assert cosine_similarity([0, 0], [1, 0]) == 0.0
+
+
+def test_top_k_similar_ranks_and_filters():
+    rows = [
+        (1, pack_vector([1.0, 0.0])),
+        (2, pack_vector([0.9, 0.1])),
+        (3, pack_vector([0.0, 1.0])),
+    ]
+    ranked = top_k_similar([1.0, 0.0], rows, k=2, min_score=0.5)
+    assert [nid for nid, _ in ranked] == [1, 2]
+    assert ranked[0][1] > ranked[1][1]
+
+
+# ── Sweep candidate selection ────────────────────────────────────────────
+
+def test_candidates_respect_privacy_and_staleness(app):
+    with app.app_context():
+        uid = User.query.first().id
+        fresh = _mk_node(uid, "embed me")
+        private = _mk_node(uid, "never send", ai_usage="none")
+        stale = _mk_node(uid, "old content")
+        _mk_embedding(stale, [1.0, 0.0])
+        stale.set_content("edited content")  # hash now differs
+        _db.session.commit()
+        current = _mk_node(uid, "already embedded")
+        _mk_embedding(current, [0.5, 0.5])
+
+        out = _candidate_nodes(50)
+        ids = {node.id for node, _, _, _ in out}
+        assert fresh.id in ids       # missing embedding → candidate
+        assert stale.id in ids       # hash mismatch → candidate
+        assert private.id not in ids  # ai_usage none → never embedded
+        assert current.id not in ids  # up to date → skipped
+
+
+# ── Semantic endpoint ────────────────────────────────────────────────────
+
+def _patch_query_embedding(monkeypatch, vector):
+    import backend.routes.search as search_module  # noqa: F401
+    import backend.utils.embeddings as emb_module
+    monkeypatch.setattr(
+        emb_module, "embed_texts",
+        lambda texts, key, **kw: [vector for _ in texts])
+
+
+def test_semantic_search_ranks_own_nodes(app, client, monkeypatch):
+    with app.app_context():
+        uid = User.query.first().id
+        close = _mk_node(uid, "a note about gardening tomatoes")
+        far = _mk_node(uid, "quarterly tax filing notes")
+        _mk_embedding(close, [1.0, 0.0])
+        _mk_embedding(far, [0.0, 1.0])
+        close_id = close.id
+
+    _patch_query_embedding(monkeypatch, [1.0, 0.05])
+    resp = client.get("/api/search/semantic?q=growing vegetables")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["mode"] == "semantic"
+    assert [r["id"] for r in body["results"]] == [close_id]
+    assert body["results"][0]["score"] > 0.9
+
+
+def test_semantic_search_excludes_other_users(app, client, monkeypatch):
+    with app.app_context():
+        other = User(username="other")
+        _db.session.add(other)
+        _db.session.commit()
+        foreign = _mk_node(other.id, "someone else's note")
+        _mk_embedding(foreign, [1.0, 0.0])
+
+    _patch_query_embedding(monkeypatch, [1.0, 0.0])
+    resp = client.get("/api/search/semantic?q=note")
+    assert resp.status_code == 200
+    assert resp.get_json()["results"] == []
+
+
+def test_semantic_search_requires_query(app, client):
+    assert client.get("/api/search/semantic").status_code == 400
+
+
+def test_semantic_search_503_without_key(app, client):
+    app.config["OPENAI_API_KEY_CHAT"] = None
+    resp = client.get("/api/search/semantic?q=x")
+    assert resp.status_code == 503
+
+
+# ── Agentic retrieval helper ─────────────────────────────────────────────
+
+def test_retrieve_relevant_snippets_excludes_chain(app, monkeypatch):
+    with app.app_context():
+        uid = User.query.first().id
+        in_chain = _mk_node(uid, "already in the conversation")
+        archive = _mk_node(uid, "an older relevant entry " + "x" * 500)
+        _mk_embedding(in_chain, [1.0, 0.0])
+        _mk_embedding(archive, [0.95, 0.05])
+
+        import backend.utils.embeddings as emb_module
+        monkeypatch.setattr(
+            emb_module, "embed_texts",
+            lambda texts, key, **kw: [[1.0, 0.0] for _ in texts])
+
+        results = retrieve_relevant_snippets(
+            uid, "query", [in_chain.id], "fake-key",
+            k=4, min_score=0.3, snippet_chars=100)
+        assert [nid for nid, _, _, _ in results] == [archive.id]
+        # Snippet is truncated with ellipsis
+        assert results[0][2].endswith("…")
+        assert len(results[0][2]) <= 101

--- a/backend/tests/test_spend_monitor.py
+++ b/backend/tests/test_spend_monitor.py
@@ -1,0 +1,186 @@
+"""Tests for API spend monitoring (issue #85).
+
+Covers month-to-date aggregation with provider attribution, threshold
+parsing, alert firing + per-month dedupe, email-failure retry semantics,
+and the disabled-by-default behavior.
+
+Patterned after test_tts_invalidation.py: sqlite in-memory, minimal
+Flask app, no celery import (logic lives in backend/utils/spend.py).
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, APICostLog, SpendAlert  # noqa: E402
+from backend.utils.spend import (  # noqa: E402
+    check_and_alert, get_month_spend_microdollars, parse_thresholds,
+)
+
+SUPPORTED_MODELS = {
+    "claude-opus-4.6": {"provider": "anthropic"},
+    "gpt-5.5": {"provider": "openai"},
+}
+
+
+def _base_config(limit=100.0, thresholds="0.5,0.8,0.95"):
+    return {
+        "SUPPORTED_MODELS": SUPPORTED_MODELS,
+        "ANTHROPIC_SPEND_LIMIT_USD": limit,
+        "SPEND_ALERT_THRESHOLDS": thresholds,
+        "SPEND_ALERT_EMAIL": "alerts@example.com",
+    }
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _log_cost(user_id, model_id, usd, created_at=None):
+    row = APICostLog(
+        user_id=user_id,
+        model_id=model_id,
+        request_type="llm",
+        cost_microdollars=int(usd * 1_000_000),
+    )
+    if created_at is not None:
+        row.created_at = created_at
+    _db.session.add(row)
+    _db.session.commit()
+    return row
+
+
+NOW = datetime(2026, 6, 10, 3, 0, 0)
+
+
+def test_parse_thresholds():
+    assert parse_thresholds("0.5,0.8,0.95") == [0.5, 0.8, 0.95]
+    assert parse_thresholds(" 0.8 , bogus, 1.5, 0.5 ") == [0.5, 0.8]
+    assert parse_thresholds("") == []
+    assert parse_thresholds(None) == []
+
+
+def test_month_spend_provider_attribution(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 10.0, NOW)
+        _log_cost(user_id, "claude-fable-5", 5.0, NOW)  # prefix fallback
+        _log_cost(user_id, "gpt-5.5", 3.0, NOW)
+        _log_cost(user_id, "gpt-4o-transcribe", 1.0, NOW)
+        # Previous month — excluded.
+        _log_cost(user_id, "claude-opus-4.6", 99.0, datetime(2026, 5, 31))
+
+        config = _base_config()
+        total = get_month_spend_microdollars(config, now=NOW)
+        anthropic = get_month_spend_microdollars(
+            config, provider="anthropic", now=NOW)
+        openai = get_month_spend_microdollars(
+            config, provider="openai", now=NOW)
+
+        assert total == 19_000_000
+        assert anthropic == 15_000_000
+        assert openai == 4_000_000
+
+
+def test_disabled_when_no_limit(app):
+    with app.app_context():
+        result = check_and_alert(_base_config(limit=0), now=NOW)
+        assert result == {"status": "disabled"}
+
+
+def test_alerts_fire_once_per_month(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 85.0, NOW)  # 85% of $100
+
+        sent = []
+
+        def fake_send(**kwargs):
+            sent.append(kwargs)
+
+        config = _base_config()
+        result = check_and_alert(config, now=NOW, send_email=fake_send)
+        # 0.5 and 0.8 crossed; 0.95 not.
+        assert result["fired"] == [0.5, 0.8]
+        assert len(sent) == 2
+        assert sent[0]["to_email"] == "alerts@example.com"
+        assert sent[0]["limit_usd"] == 100.0
+
+        # Second run: nothing new fires.
+        result2 = check_and_alert(config, now=NOW, send_email=fake_send)
+        assert result2["fired"] == []
+        assert len(sent) == 2
+
+        # Spend grows past 95% → only the new threshold fires.
+        _log_cost(user_id, "claude-opus-4.6", 11.0, NOW)
+        result3 = check_and_alert(config, now=NOW, send_email=fake_send)
+        assert result3["fired"] == [0.95]
+        assert len(sent) == 3
+
+        assert SpendAlert.query.count() == 3
+
+
+def test_openai_spend_does_not_trigger_anthropic_alerts(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "gpt-5.5", 95.0, NOW)
+
+        sent = []
+        result = check_and_alert(
+            _base_config(), now=NOW,
+            send_email=lambda **kw: sent.append(kw))
+        assert result["fired"] == []
+        assert sent == []
+
+
+def test_email_failure_retries_next_run(app):
+    with app.app_context():
+        user_id = User.query.first().id
+        _log_cost(user_id, "claude-opus-4.6", 60.0, NOW)
+
+        def broken_send(**kwargs):
+            raise RuntimeError("smtp down")
+
+        config = _base_config()
+        result = check_and_alert(config, now=NOW, send_email=broken_send)
+        assert result["fired"] == []
+        assert SpendAlert.query.count() == 0
+
+        # SMTP recovers → alert goes out on the next run.
+        sent = []
+        result2 = check_and_alert(
+            config, now=NOW, send_email=lambda **kw: sent.append(kw))
+        assert result2["fired"] == [0.5]
+        assert len(sent) == 1

--- a/backend/tests/test_timefmt.py
+++ b/backend/tests/test_timefmt.py
@@ -103,3 +103,43 @@ def test_is_valid_timezone_rejects_garbage():
 def test_is_valid_timezone_rejects_empty_and_none():
     assert is_valid_timezone("") is False
     assert is_valid_timezone(None) is False
+
+
+class TestStripEdgeTimestamps:
+    def test_leading_stamp_removed(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "[2026-06-01 20:39 CEST] Okay, hot takes, no hedging."
+        ) == "Okay, hot takes, no hedging."
+
+    def test_trailing_stamp_removed(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "One sentence to set it down.\n\n[2026-06-10 08:27 UTC]"
+        ) == "One sentence to set it down."
+
+    def test_both_edges_and_repeats(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps(
+            "[2026-06-10 08:27 UTC] [2026-06-10 08:28 UTC] body "
+            "[2026-06-10 08:29 UTC]"
+        ) == "body"
+
+    def test_unknown_time_marker(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps("[unknown time] hi") == "hi"
+
+    def test_mid_text_untouched(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        text = "We met at [2026-06-01 20:39 CEST] according to the log."
+        assert strip_edge_timestamps(text) == text
+
+    def test_legit_brackets_untouched(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        text = "[important] remember this [note]"
+        assert strip_edge_timestamps(text) == text
+
+    def test_empty_and_none(self):
+        from backend.utils.timefmt import strip_edge_timestamps
+        assert strip_edge_timestamps("") == ""
+        assert strip_edge_timestamps(None) is None

--- a/backend/tests/test_tts_chapters.py
+++ b/backend/tests/test_tts_chapters.py
@@ -1,0 +1,168 @@
+"""Tests for section-aware TTS chunking + chapters (#145, #140)."""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+import pytest  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.utils.audio_processing import (  # noqa: E402
+    MIN_FIRST_CHUNK_CHARS, section_aware_chunk_text, split_sections,
+)
+
+LONG = ("This is a reasonably long sentence used to pad sections so the "
+        "chunker has real material to work with. " * 12)
+
+
+# ── split_sections ───────────────────────────────────────────────────────
+
+def test_split_sections_h1_h2_are_chapters():
+    text = f"Preamble text.\n\n# Alpha\n{LONG}\n## Beta\n{LONG}\n### gamma\nstays"
+    sections = split_sections(text)
+    titles = [t for t, _ in sections]
+    assert titles == [None, "Alpha", "Beta"]
+    # h3 stays inside Beta's body
+    assert "### gamma" in sections[2][1]
+
+
+def test_split_sections_no_headings():
+    assert split_sections("just text") == [(None, "just text")]
+    assert split_sections("") == []
+
+
+def test_split_sections_heading_line_not_in_body():
+    sections = split_sections("# Title\nBody here")
+    assert sections == [("Title", "Body here")]
+
+
+# ── section_aware_chunk_text ─────────────────────────────────────────────
+
+def test_chunks_never_cross_sections():
+    text = f"# One\n{LONG}\n# Two\n{LONG}"
+    chunks = section_aware_chunk_text(text)
+    for _text, title, idx in chunks:
+        assert title in ("One", "Two")
+    # Contiguous non-decreasing section indices
+    indices = [idx for _, _, idx in chunks]
+    assert indices == sorted(indices)
+    assert set(indices) == {0, 1}
+
+
+def test_first_chunk_stays_small_globally():
+    text = f"# One\n{LONG}\n# Two\n{LONG}"
+    chunks = section_aware_chunk_text(text)
+    assert len(chunks[0][0]) <= 320  # fast-start budget
+    assert any(len(c) > 1000 for c, _, _ in chunks[1:])  # later are big
+
+
+def test_no_heading_text_single_section_matches_legacy_sizing():
+    chunks = section_aware_chunk_text(LONG * 3)
+    assert all(title is None and idx == 0 for _, title, idx in chunks)
+    assert len(chunks) >= 3
+
+
+def test_empty_sections_skipped():
+    chunks = section_aware_chunk_text("# Empty\n# Full\ncontent here")
+    assert [(t, i) for _, t, i in chunks] == [("Full", 1)]
+
+
+def test_140_tiny_first_sentence_falls_back_to_word_split():
+    # First sentence is tiny ("Hi.") — sentence split would give a
+    # sub-MIN chunk; the fallback splits word-aware near the budget.
+    text = "Hi. " + ("word " * 400)
+    chunks = section_aware_chunk_text(text)
+    first = chunks[0][0]
+    assert len(first) >= MIN_FIRST_CHUNK_CHARS
+    assert not first.endswith("wor")  # never mid-word
+
+
+# ── chapters endpoint ────────────────────────────────────────────────────
+
+def test_chapters_endpoint(tmp_path):
+    from flask import Flask
+    from backend.extensions import db as _db
+    from backend.models import User, Node, TTSChunk
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.nodes import nodes_bp
+    app.register_blueprint(nodes_bp, url_prefix="/api/nodes")
+
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.flush()
+        node = Node(user_id=user.id, human_owner_id=user.id,
+                    node_type="text")
+        node.set_content("x")
+        _db.session.add(node)
+        _db.session.flush()
+        specs = [
+            (0, None, None, 10.0),
+            (1, 0, "Intro part", None),     # legacy row w/o duration
+            (2, 1, "Chapter A", 20.0),
+            (3, 1, "Chapter A", 30.0),
+            (4, 2, "Chapter B", 5.0),
+        ]
+        # Row 0 simulates pre-#145 chunks (no section metadata)
+        for idx, s_idx, s_title, dur in specs:
+            _db.session.add(TTSChunk(
+                node_id=node.id, chunk_index=idx, status='completed',
+                section_index=s_idx, section_title=s_title, duration=dur))
+        _db.session.commit()
+
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(user.id)
+            sess["_fresh"] = True
+
+        body = client.get(
+            f"/api/nodes/{node.id}/tts-chapters").get_json()
+        chapters = body["chapters"]
+        assert [c["title"] for c in chapters] == [
+            "Intro part", "Chapter A", "Chapter B"]
+        assert [c["chunk_index"] for c in chapters] == [1, 2, 4]
+        # Start times accumulate prior durations (None counts as 0)
+        assert [c["start_time"] for c in chapters] == [10.0, 10.0, 60.0]
+
+        # Single/no sections → empty list (no chapter UI)
+        node2 = Node(user_id=user.id, human_owner_id=user.id,
+                     node_type="text")
+        node2.set_content("y")
+        _db.session.add(node2)
+        _db.session.flush()
+        _db.session.add(TTSChunk(node_id=node2.id, chunk_index=0,
+                                 status='completed', duration=5.0))
+        _db.session.commit()
+        assert client.get(
+            f"/api/nodes/{node2.id}/tts-chapters"
+        ).get_json()["chapters"] == []
+
+        _db.session.rollback()
+        _db.drop_all()

--- a/backend/tests/test_wave6_backend.py
+++ b/backend/tests/test_wave6_backend.py
@@ -126,3 +126,17 @@ def test_call_llm_with_retries_forwards_max_tokens(app):
         finally:
             exports_module.LLMProvider = original
         assert captured["max_tokens"] == 1234
+
+
+def test_generation_helpers_accept_max_output_tokens():
+    """Regression for the staging-caught TypeError: every #104 call site
+    passes max_output_tokens — the defs must accept it."""
+    import inspect
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._single_pass_generation).parameters
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._chunked_profile_loop).parameters
+    assert "max_output_tokens" in inspect.signature(
+        exports_module._do_iterative_incremental_update).parameters
+    assert "max_tokens" in inspect.signature(
+        exports_module._call_llm_with_retries).parameters

--- a/backend/tests/test_wave6_backend.py
+++ b/backend/tests/test_wave6_backend.py
@@ -1,0 +1,128 @@
+"""Tests for Wave-6 backend leftovers (#110, #104, #139).
+
+#110 — export preselection includes the user's replies inside other
+users' threads. #104 — _call_llm_with_retries forwards max_tokens to the
+provider. #139 — covered here at the unit level for the dedup stub text;
+the loop wiring mirrors the long-standing profile dedup.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, Node  # noqa: E402
+
+# Glue import for the celery-tainted modules
+_GLUE = ("backend.celery_app", "backend.llm_providers",
+         "backend.tasks.exports")
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules.pop("backend.tasks.exports", None)
+import backend.tasks.exports as exports_module  # noqa: E402
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        a = User(username="alice")
+        b = User(username="bob")
+        _db.session.add_all([a, b])
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _mk_node(user, parent=None, content="x", human_owner=None):
+    node = Node(
+        user_id=user.id,
+        human_owner_id=(human_owner or user).id,
+        parent_id=parent.id if parent else None,
+        node_type="user",
+        token_count=10,
+        privacy_level="private",
+        ai_usage="chat",
+    )
+    node.set_content(content)
+    _db.session.add(node)
+    _db.session.commit()
+    return node
+
+
+# ── #110: preselection includes replies in foreign threads ───────────────
+
+def test_preselect_includes_replies_in_foreign_threads(app):
+    from backend.routes.export_data import _preselect_node_ids
+    with app.app_context():
+        alice = User.query.filter_by(username="alice").first()
+        bob = User.query.filter_by(username="bob").first()
+
+        own_root = _mk_node(alice, content="alice's own thread")
+        bob_root = _mk_node(bob, content="bob's thread")
+        alice_reply = _mk_node(alice, parent=bob_root,
+                               content="alice replying to bob")
+        reply_child = _mk_node(bob, parent=alice_reply,
+                               human_owner=alice,
+                               content="bob under alice's reply")
+
+        ids = set(_preselect_node_ids(alice.id, budget=10_000))
+        assert own_root.id in ids
+        # The fix (#110): alice's reply inside bob's thread is included,
+        # along with the sub-thread beneath it.
+        assert alice_reply.id in ids
+        assert reply_child.id in ids
+        # Bob's own root is not seeded by alice's export.
+        assert bob_root.id not in ids
+
+
+# ── #104: max_tokens forwarded to the provider ───────────────────────────
+
+def test_call_llm_with_retries_forwards_max_tokens(app):
+    captured = {}
+
+    def fake_get_completion(model_id, messages, api_keys, max_tokens=None,
+                            **kwargs):
+        captured["max_tokens"] = max_tokens
+        return {"content": "ok", "total_tokens": 1,
+                "input_tokens": 1, "output_tokens": 0}
+
+    with app.app_context():
+        original = exports_module.LLMProvider
+        exports_module.LLMProvider = MagicMock(
+            get_completion=fake_get_completion)
+        try:
+            task_self = MagicMock()
+            exports_module._call_llm_with_retries(
+                task_self, "claude-opus-4.6", "prompt", 1, {},
+                max_tokens=1234)
+        finally:
+            exports_module.LLMProvider = original
+        assert captured["max_tokens"] == 1234

--- a/backend/utils/audio_processing.py
+++ b/backend/utils/audio_processing.py
@@ -4,6 +4,7 @@ Extracted from routes/nodes.py to be shared between API and Celery tasks.
 """
 import os
 import pathlib
+import re
 import tempfile
 import ffmpeg
 from pydub import AudioSegment
@@ -304,3 +305,96 @@ def adaptive_chunk_text(text: str, first_chunk_gen_secs: float = 3.0) -> list:
         remaining = remaining[split_point:].strip()
 
     return chunks
+
+
+# Minimum sensible first chunk (#140): a tiny first sentence ("Okay.")
+# produces a sub-second clip — an audible stitch artifact and a wasted
+# API round-trip. Below this size we split word-aware at the target
+# instead of at the sentence boundary.
+MIN_FIRST_CHUNK_CHARS = 80
+
+_CHAPTER_HEADING_RE = re.compile(r'^(#{1,2})\s+(.+?)\s*$', re.MULTILINE)
+
+
+def split_sections(text):
+    """Split markdown into chapter sections at h1/h2 headings (#145).
+
+    Returns [(title_or_None, body)]. Content before the first heading
+    becomes a section with title None. Heading lines themselves are NOT
+    part of the body (v0 decision: chapter titles are visual labels, not
+    read aloud). h3+ headings stay inside their section's body.
+    """
+    matches = list(_CHAPTER_HEADING_RE.finditer(text or ""))
+    if not matches:
+        return [(None, (text or "").strip())] if (text or "").strip() else []
+
+    sections = []
+    preamble = text[:matches[0].start()].strip()
+    if preamble:
+        sections.append((None, preamble))
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[m.end():end].strip()
+        sections.append((m.group(2).strip(), body))
+    return sections
+
+
+def section_aware_chunk_text(text, first_chunk_gen_secs: float = 3.0):
+    """Chunk text for streaming TTS without crossing chapter boundaries.
+
+    Returns [(chunk_text, section_title, section_index)]. The adaptive
+    size schedule (small first chunk → medium second → full-size rest)
+    applies GLOBALLY across sections so playback still starts fast, while
+    every chunk belongs to exactly one section — the prerequisite for
+    chapter-accurate jumping in the player (#145).
+
+    Sections whose body is empty (e.g. a heading directly followed by
+    another heading) are skipped — they'd produce zero-length audio.
+    """
+    gen_chars_per_sec = 106.0
+    audio_secs_per_char = 0.062
+    overhead_secs = 2.0
+
+    first_chunk_chars = min(
+        int(first_chunk_gen_secs * gen_chars_per_sec), TTS_MAX_CHARS)
+    first_play_secs = first_chunk_chars * audio_secs_per_char
+    next_budget_secs = max(first_play_secs - overhead_secs, 2.0)
+    second_chunk_chars = min(
+        int(next_budget_secs * gen_chars_per_sec), TTS_MAX_CHARS)
+
+    def _budget(global_idx):
+        if global_idx == 0:
+            return first_chunk_chars
+        if global_idx == 1:
+            return second_chunk_chars
+        return TTS_MAX_CHARS
+
+    out = []
+    for section_index, (title, body) in enumerate(split_sections(text)):
+        remaining = body
+        while remaining:
+            budget = _budget(len(out))
+            if len(remaining) <= budget:
+                out.append((remaining, title, section_index))
+                break
+            split_point = _split_at_sentence(remaining, budget)
+            # #140: a tiny first chunk (short opening sentence) falls
+            # back to a word-aware split at the full budget.
+            if len(out) == 0 and split_point < MIN_FIRST_CHUNK_CHARS:
+                split_point = _split_at_word(remaining, budget)
+            chunk = remaining[:split_point].strip()
+            if chunk:
+                out.append((chunk, title, section_index))
+            remaining = remaining[split_point:].strip()
+    return out
+
+
+def _split_at_word(text, max_chars):
+    """Last word boundary within max_chars (never mid-word)."""
+    if len(text) <= max_chars:
+        return len(text)
+    chunk = text[:max_chars]
+    best = chunk.rfind(' ')
+    for sep in ('\n', '\t'):
+        best = max(best, chunk.rfind(sep))
+    return best + 1 if best > 0 else max_chars

--- a/backend/utils/context_artifacts.py
+++ b/backend/utils/context_artifacts.py
@@ -4,7 +4,7 @@ import re
 from backend.extensions import db
 from backend.models import (
     NodeContextArtifact, UserProfile, UserRecentContext, UserTodo,
-    UserAIPreferences,
+    UserAIPreferences, UserArtifact,
 )
 from backend.utils.privacy import AI_ALLOWED
 
@@ -14,6 +14,10 @@ PLACEHOLDER_TO_ARTIFACT = {
     'user_todo': 'todo',
     'user_recent': 'recent_context',
     'user_ai_preferences': 'ai_preferences',
+    # All three artifact placeholders pin the same multi-row type (#158)
+    'user_memory': 'user_artifact',
+    'user_scratchpad': 'user_artifact',
+    'user_artifacts_index': 'user_artifact',
 }
 
 _PLACEHOLDER_RE = re.compile(
@@ -86,6 +90,16 @@ def attach_context_artifacts(node_id, user_id, prompt_record=None):
             artifact_id=todo.id,
         ))
 
+    # Latest version of every user artifact (memory, scratchpad, custom)
+    # the AI is allowed to see — one row per kind (#158).
+    for artifact in UserArtifact.latest_per_kind(user_id).values():
+        if artifact.ai_usage in AI_ALLOWED:
+            db.session.add(NodeContextArtifact(
+                node_id=node_id,
+                artifact_type="user_artifact",
+                artifact_id=artifact.id,
+            ))
+
     # Latest AI preferences that the AI is allowed to see
     ai_prefs = (
         UserAIPreferences.query
@@ -115,22 +129,35 @@ def sync_context_artifacts(node_id, user_id, content):
         artifact_type = PLACEHOLDER_TO_ARTIFACT[match.group(1)]
         needed.add(artifact_type)
 
-    # Get existing non-prompt artifacts
+    # Get existing non-prompt artifacts. 'user_artifact' is a multi-row
+    # type (one row per artifact kind), so collect rows in lists.
     existing = NodeContextArtifact.query.filter_by(
         node_id=node_id
     ).filter(
         NodeContextArtifact.artifact_type != 'prompt'
     ).all()
-    existing_types = {row.artifact_type: row for row in existing}
+    existing_types = {}
+    for row in existing:
+        existing_types.setdefault(row.artifact_type, []).append(row)
 
     # Remove artifacts no longer referenced
-    for artifact_type, row in existing_types.items():
+    for artifact_type, rows in existing_types.items():
         if artifact_type not in needed:
-            db.session.delete(row)
+            for row in rows:
+                db.session.delete(row)
 
     # Add missing artifacts
     for artifact_type in needed:
         if artifact_type in existing_types:
+            continue
+        if artifact_type == 'user_artifact':
+            for artifact in UserArtifact.latest_per_kind(user_id).values():
+                if artifact.ai_usage in AI_ALLOWED:
+                    db.session.add(NodeContextArtifact(
+                        node_id=node_id,
+                        artifact_type='user_artifact',
+                        artifact_id=artifact.id,
+                    ))
             continue
         artifact_id = _resolve_latest_artifact(
             artifact_type, user_id

--- a/backend/utils/cost.py
+++ b/backend/utils/cost.py
@@ -7,13 +7,24 @@ floating-point precision issues while supporting sub-cent costs.
 from flask import current_app
 
 
+# Anthropic prompt-caching multipliers on the input price (#187):
+# cache reads bill at 0.1x, cache writes (5-min TTL) at 1.25x.
+CACHE_READ_MULTIPLIER = 0.1
+CACHE_WRITE_MULTIPLIER = 1.25
+
+
 def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
-                                    batch=False):
+                                    batch=False, cache_read_tokens=0,
+                                    cache_write_tokens=0):
     """
     Calculate LLM API cost in microdollars.
 
     Formula: input_tokens * input_price_per_mtok + output_tokens * output_price_per_mtok
     (the million factors in microdollars and per-million-token pricing cancel out)
+
+    input_tokens must be the UNCACHED portion (what the provider reports in
+    usage.input_tokens); cache reads/writes are passed separately and billed
+    at their multipliers (#187).
 
     batch=True applies the Batch API discount (~50% of synchronous pricing,
     issue #173). Long-context multipliers still apply to the per-call input
@@ -25,10 +36,14 @@ def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
     input_price = config.get("input_price_per_mtok", 0)
     output_price = config.get("output_price_per_mtok", 0)
     threshold = config.get("long_context_threshold")
-    if threshold and input_tokens > threshold:
+    total_prompt = input_tokens + cache_read_tokens + cache_write_tokens
+    if threshold and total_prompt > threshold:
         input_price *= config.get("long_context_input_multiplier", 1)
         output_price *= config.get("long_context_output_multiplier", 1)
-    cost = input_tokens * input_price + output_tokens * output_price
+    cost = (input_tokens * input_price
+            + cache_read_tokens * input_price * CACHE_READ_MULTIPLIER
+            + cache_write_tokens * input_price * CACHE_WRITE_MULTIPLIER
+            + output_tokens * output_price)
     if batch:
         cost *= 0.5
     return round(cost)

--- a/backend/utils/cost.py
+++ b/backend/utils/cost.py
@@ -15,16 +15,22 @@ CACHE_WRITE_MULTIPLIER = 1.25
 
 def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
                                     batch=False, cache_read_tokens=0,
-                                    cache_write_tokens=0):
+                                    cache_write_tokens=0,
+                                    cached_input_tokens=0):
     """
     Calculate LLM API cost in microdollars.
 
     Formula: input_tokens * input_price_per_mtok + output_tokens * output_price_per_mtok
     (the million factors in microdollars and per-million-token pricing cancel out)
 
-    input_tokens must be the UNCACHED portion (what the provider reports in
-    usage.input_tokens); cache reads/writes are passed separately and billed
-    at their multipliers (#187).
+    Anthropic (#187): input_tokens must be the UNCACHED portion (what the
+    provider reports in usage.input_tokens); cache reads/writes are passed
+    separately and billed at their multipliers.
+
+    OpenAI (#189): cached_input_tokens is the cached SUBSET of
+    input_tokens (usage.prompt_tokens_details.cached_tokens), billed at
+    the model's cached_input_multiplier (default 0.5). Fixes the prior
+    over-count where the auto-cache discount was ignored.
 
     batch=True applies the Batch API discount (~50% of synchronous pricing,
     issue #173). Long-context multipliers still apply to the per-call input
@@ -40,7 +46,10 @@ def calculate_llm_cost_microdollars(model_id, input_tokens, output_tokens,
     if threshold and total_prompt > threshold:
         input_price *= config.get("long_context_input_multiplier", 1)
         output_price *= config.get("long_context_output_multiplier", 1)
-    cost = (input_tokens * input_price
+    cached_subset = min(cached_input_tokens or 0, input_tokens)
+    cached_multiplier = config.get("cached_input_multiplier", 0.5)
+    cost = ((input_tokens - cached_subset) * input_price
+            + cached_subset * input_price * cached_multiplier
             + cache_read_tokens * input_price * CACHE_READ_MULTIPLIER
             + cache_write_tokens * input_price * CACHE_WRITE_MULTIPLIER
             + output_tokens * output_price)

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -147,6 +147,77 @@ def send_welcome_email(to_email, magic_link_url):
         raise
 
 
+def send_spend_alert_email(to_email, provider, spend_usd, limit_usd, threshold):
+    """Alert the admin that month-to-date API spend crossed a threshold
+    of the configured limit (issue #85)."""
+    config = current_app.config
+    sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")
+    percent = int(round(threshold * 100))
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = (
+        f"Loore spend alert: {provider} at {percent}% of monthly limit"
+    )
+    msg["From"] = sender
+    msg["To"] = to_email
+
+    text_body = (
+        f"API spend alert\n\n"
+        f"Provider: {provider}\n"
+        f"Month-to-date spend: ${spend_usd:,.2f}\n"
+        f"Monthly limit: ${limit_usd:,.2f}\n"
+        f"Threshold crossed: {percent}%\n\n"
+        f"Review usage in the admin dashboard: https://loore.org/admin\n"
+    )
+
+    html_body = f"""\
+<html>
+<body style="font-family: 'Outfit', -apple-system, sans-serif; background: #0e0d0b; color: #ede8dd; padding: 40px 20px; margin: 0;">
+  <div style="max-width: 460px; margin: 0 auto; background: #181714; border-radius: 10px; border: 1px solid #302c27; padding: 48px 40px;">
+    <div style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-size: 14px; font-weight: 300; text-transform: uppercase; letter-spacing: 0.3em; color: #736b5f; margin-bottom: 32px;">
+      Loore
+    </div>
+    <h2 style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-weight: 300; font-size: 28px; color: #ede8dd; margin: 0 0 12px 0;">
+      Spend alert: {percent}%
+    </h2>
+    <p style="font-size: 15px; font-weight: 300; color: #a89f91; margin: 0 0 8px 0; line-height: 1.6;">
+      <strong style="color: #ede8dd;">{provider}</strong> month-to-date spend is
+      <strong style="color: #c4956a;">${spend_usd:,.2f}</strong>
+      of the <strong style="color: #ede8dd;">${limit_usd:,.2f}</strong> monthly limit.
+    </p>
+    <a href="https://loore.org/admin"
+       style="display: inline-block; margin-top: 20px; padding: 12px 32px; background: transparent; color: #c4956a;
+              text-decoration: none; border-radius: 6px; border: 1px solid #c4956a;
+              font-family: 'Outfit', -apple-system, sans-serif; font-size: 14px; font-weight: 400;
+              letter-spacing: 0.04em;">
+      Open admin dashboard
+    </a>
+  </div>
+</body>
+</html>"""
+
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    server = config.get("MAIL_SERVER", "localhost")
+    port = config.get("MAIL_PORT", 587)
+    use_tls = config.get("MAIL_USE_TLS", True)
+    username = config.get("MAIL_USERNAME")
+    password = config.get("MAIL_PASSWORD")
+
+    try:
+        with smtplib.SMTP(server, port) as smtp:
+            if use_tls:
+                smtp.starttls()
+            if username and password:
+                smtp.login(username, password)
+            smtp.sendmail(sender, to_email, msg.as_string())
+        logger.info(f"Spend alert email sent to {to_email} ({percent}%)")
+    except Exception:
+        logger.exception(f"Failed to send spend alert email to {to_email}")
+        raise
+
+
 def send_admin_signup_notification(username, user_email):
     config = current_app.config
     sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")

--- a/backend/utils/embeddings.py
+++ b/backend/utils/embeddings.py
@@ -1,0 +1,139 @@
+"""Embedding generation + similarity for semantic search (#155).
+
+Vectors are packed float32 blobs (stdlib struct/array — no numpy, no
+pgvector). Cosine similarity is brute-force in Python: at alpha scale
+(thousands of nodes x 1536 dims) a full scan is tens of milliseconds.
+
+Embedding calls use the OpenAI chat key (retrieval is 'chat' usage) and
+log cost to APICostLog like every other provider call.
+"""
+import hashlib
+import logging
+import math
+from array import array
+
+from backend.extensions import db
+from backend.models import APICostLog
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_PRICE_PER_MTOK = 0.02
+# text-embedding-3-small accepts 8191 tokens; stay safely under it.
+MAX_EMBED_CHARS = 30000
+
+
+def content_hash(text):
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def pack_vector(values):
+    return array("f", values).tobytes()
+
+
+def unpack_vector(blob):
+    vec = array("f")
+    vec.frombytes(blob)
+    return vec
+
+
+def cosine_similarity(a, b):
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / math.sqrt(norm_a * norm_b)
+
+
+def embed_texts(texts, api_key, user_id=None, request_type="embedding"):
+    """Embed a batch of texts via OpenAI. Returns list of float lists.
+
+    Logs cost per call (attributed to *user_id* when given). Raises on
+    API errors — callers decide whether to retry or skip.
+    """
+    from openai import OpenAI
+
+    client = OpenAI(api_key=api_key)
+    inputs = [(t or "")[:MAX_EMBED_CHARS] for t in texts]
+    response = client.embeddings.create(model=EMBEDDING_MODEL, input=inputs)
+
+    tokens = response.usage.total_tokens if response.usage else 0
+    if user_id is not None:
+        cost = int(tokens * EMBEDDING_PRICE_PER_MTOK)  # microdollars/Mtok
+        db.session.add(APICostLog(
+            user_id=user_id,
+            model_id=EMBEDDING_MODEL,
+            request_type=request_type,
+            input_tokens=tokens,
+            output_tokens=0,
+            cost_microdollars=cost,
+        ))
+
+    # API returns embeddings in input order
+    return [item.embedding for item in response.data]
+
+
+def top_k_similar(query_vector, rows, k=10, min_score=0.0):
+    """Score (node_id, vector_blob) rows against *query_vector*.
+
+    Returns [(node_id, score)] sorted desc, filtered by *min_score*.
+    """
+    scored = []
+    for node_id, blob in rows:
+        score = cosine_similarity(query_vector, unpack_vector(blob))
+        if score >= min_score:
+            scored.append((node_id, score))
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:k]
+
+
+def retrieve_relevant_snippets(user_id, query_text, exclude_node_ids,
+                               api_key, k=4, min_score=0.35,
+                               snippet_chars=400):
+    """Top-k archive snippets relevant to *query_text* for agentic context
+    injection (#155). Returns [(node_id, created_at, snippet, score)].
+
+    Excludes nodes already present in the conversation. Any failure is the
+    caller's to swallow — retrieval must never break a completion.
+    """
+    from backend.models import Node, NodeEmbedding
+
+    query_vector = embed_texts(
+        [query_text], api_key, user_id=user_id,
+        request_type="embedding_query",
+    )[0]
+
+    rows = db.session.query(
+        NodeEmbedding.node_id, NodeEmbedding.vector
+    ).filter(
+        NodeEmbedding.user_id == user_id,
+        ~NodeEmbedding.node_id.in_(exclude_node_ids or [-1]),
+    ).all()
+
+    ranked = top_k_similar(query_vector, rows, k=k, min_score=min_score)
+    if not ranked:
+        return []
+
+    nodes_by_id = {
+        n.id: n for n in Node.query.filter(
+            Node.id.in_([nid for nid, _ in ranked]),
+            Node.deleted_at.is_(None),
+        ).all()
+    }
+    results = []
+    for node_id, score in ranked:
+        node = nodes_by_id.get(node_id)
+        if node is None:
+            continue
+        text = (node.get_content() or "").strip()
+        if not text:
+            continue
+        snippet = text[:snippet_chars] + (
+            "…" if len(text) > snippet_chars else "")
+        results.append((node_id, node.created_at, snippet, score))
+    return results

--- a/backend/utils/external_content.py
+++ b/backend/utils/external_content.py
@@ -1,0 +1,194 @@
+"""Clients for external content sources (#155 component 2 / Download).
+
+Community Archive: the public open tweet database
+(https://github.com/TheExGenesis/community-archive) — a Supabase
+PostgREST API readable with a published anon key. No user credentials
+involved; only accounts that donated their archives are present.
+
+Twitter/X bookmarks: X API v2 (pay-per-use tier), OAuth 2.0 PKCE user
+context with bookmark.read scope. Env-gated until credentials/credits
+are configured (X_CLIENT_ID etc.).
+"""
+import logging
+from datetime import datetime
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Public Community Archive instance (anon key is published in their docs
+# for read access — not a secret).
+CA_BASE_URL = "https://fabxmporizzqflnftavs.supabase.co"
+CA_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZhYnhtcG9yaXp6cWZsbmZ0YXZzIiwicm9sZSI6"
+    "ImFub24iLCJpYXQiOjE3MjIyNDQ5MTIsImV4cCI6MjAzNzgyMDkxMn0."
+    "UIEJiUNkLsW28tBHmG-RQDW-I5JNlJLt62CSk9D_qG8"
+)
+CA_PAGE_SIZE = 500
+CA_TIMEOUT = 20
+
+X_API_BASE = "https://api.twitter.com/2"
+X_BOOKMARKS_PAGE_SIZE = 100
+
+
+def _ca_headers():
+    return {
+        "apikey": CA_ANON_KEY,
+        "Authorization": f"Bearer {CA_ANON_KEY}",
+    }
+
+
+def ca_lookup_account(username):
+    """Resolve a Community Archive username to its account_id, or None."""
+    resp = requests.get(
+        f"{CA_BASE_URL}/rest/v1/account",
+        params={"username": f"ilike.{username}", "select": "account_id,username"},
+        headers=_ca_headers(), timeout=CA_TIMEOUT,
+    )
+    resp.raise_for_status()
+    rows = resp.json()
+    return rows[0]["account_id"] if rows else None
+
+
+def _parse_tweet_dt(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")
+                                      ).replace(tzinfo=None)
+    except (ValueError, TypeError):
+        return None
+
+
+def normalize_ca_tweet(row, username):
+    """Map a Community Archive tweets row to ExternalItem fields.
+
+    Tolerant of column-name drift: tries the documented/likely names for
+    id and text, skips rows where neither resolves.
+    """
+    tweet_id = (row.get("tweet_id") or row.get("id")
+                or row.get("status_id"))
+    text = (row.get("full_text") or row.get("text")
+            or row.get("tweet_text"))
+    if not tweet_id or not text or not str(text).strip():
+        return None
+    return {
+        "external_id": str(tweet_id),
+        "author_handle": username,
+        "content": str(text),
+        "url": f"https://twitter.com/{username}/status/{tweet_id}",
+        "posted_at": _parse_tweet_dt(
+            row.get("created_at") or row.get("created at")),
+    }
+
+
+def ca_fetch_tweets(account_id, username, max_items=2000):
+    """Fetch up to *max_items* tweets for a CA account, newest first.
+
+    Yields normalized item dicts; paginates via PostgREST offset.
+    """
+    fetched = 0
+    offset = 0
+    while fetched < max_items:
+        page_size = min(CA_PAGE_SIZE, max_items - fetched)
+        resp = requests.get(
+            f"{CA_BASE_URL}/rest/v1/tweets",
+            params={
+                "account_id": f"eq.{account_id}",
+                "select": "*",
+                "order": "created_at.desc",
+                "limit": str(page_size),
+                "offset": str(offset),
+            },
+            headers=_ca_headers(), timeout=CA_TIMEOUT,
+        )
+        resp.raise_for_status()
+        rows = resp.json()
+        if not rows:
+            break
+        for row in rows:
+            item = normalize_ca_tweet(row, username)
+            if item is not None:
+                yield item
+                fetched += 1
+                if fetched >= max_items:
+                    break
+        offset += len(rows)
+        if len(rows) < page_size:
+            break
+
+
+def normalize_x_bookmark(tweet, authors_by_id):
+    """Map an X API v2 bookmarks tweet object to ExternalItem fields."""
+    text = tweet.get("text")
+    tweet_id = tweet.get("id")
+    if not tweet_id or not text:
+        return None
+    author = authors_by_id.get(tweet.get("author_id"), {})
+    handle = author.get("username")
+    return {
+        "external_id": str(tweet_id),
+        "author_handle": handle,
+        "content": text,
+        "url": (f"https://twitter.com/{handle}/status/{tweet_id}"
+                if handle else f"https://twitter.com/i/status/{tweet_id}"),
+        "posted_at": _parse_tweet_dt(tweet.get("created_at")),
+    }
+
+
+def x_fetch_bookmarks(access_token, x_user_id, max_items=800):
+    """Fetch the user's X bookmarks (newest first, paginated).
+
+    X API v2: GET /2/users/:id/bookmarks — OAuth2 user context with
+    bookmark.read; max 800 most recent per X's own cap.
+    """
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params = {
+        "max_results": X_BOOKMARKS_PAGE_SIZE,
+        "tweet.fields": "created_at,author_id",
+        "expansions": "author_id",
+        "user.fields": "username",
+    }
+    fetched = 0
+    next_token = None
+    while fetched < max_items:
+        if next_token:
+            params["pagination_token"] = next_token
+        resp = requests.get(
+            f"{X_API_BASE}/users/{x_user_id}/bookmarks",
+            params=params, headers=headers, timeout=30,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        tweets = payload.get("data") or []
+        users = (payload.get("includes") or {}).get("users") or []
+        authors_by_id = {u["id"]: u for u in users}
+        for tweet in tweets:
+            item = normalize_x_bookmark(tweet, authors_by_id)
+            if item is not None:
+                yield item
+                fetched += 1
+                if fetched >= max_items:
+                    break
+        next_token = (payload.get("meta") or {}).get("next_token")
+        if not next_token:
+            break
+
+
+def x_refresh_access_token(client_id, refresh_token):
+    """OAuth2 refresh-token grant for X (PKCE public client).
+
+    Returns the token-endpoint JSON ({access_token, refresh_token, ...}).
+    """
+    resp = requests.post(
+        "https://api.twitter.com/2/oauth2/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/utils/prompt_cache.py
+++ b/backend/utils/prompt_cache.py
@@ -1,0 +1,62 @@
+"""Backend cache of the assembled agentic system prompt (#192).
+
+Since #191 pinned all context artifacts to a per-session snapshot, the
+system node's fully-rendered text is byte-identical on every turn of a
+session. We render it once, store it in Redis (encrypted — it embeds
+profile/todo/memory content that is encrypted at rest in the DB), and
+reuse the exact bytes on subsequent turns. Reusing identical bytes also
+guarantees the byte-stable prefix that provider-side prompt caching
+(#187) requires — re-rendering each turn risks subtle nondeterminism.
+
+Write-once per (node_id, updated_at): one-off prompt edits change
+updated_at and so naturally take a fresh key. TTL bounds growth; an
+expired entry just means one re-render.
+"""
+import logging
+
+from backend.utils.encryption import decrypt_content, encrypt_content
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 24 * 3600
+_KEY_PREFIX = "wop:sysprompt:"
+
+
+def _client(config):
+    import redis
+    url = config.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    return redis.Redis.from_url(
+        url, socket_connect_timeout=2, socket_timeout=2)
+
+
+def _key(node):
+    stamp = (node.updated_at or node.created_at)
+    return f"{_KEY_PREFIX}{node.id}:{stamp.isoformat() if stamp else '0'}"
+
+
+def get_cached_render(config, node):
+    """Return the cached rendered text for *node*, or None.
+
+    Any Redis/decrypt failure degrades to a cache miss — the caller
+    re-renders as before #192.
+    """
+    try:
+        blob = _client(config).get(_key(node))
+        if blob is None:
+            return None
+        return decrypt_content(blob.decode("utf-8"))
+    except Exception:
+        logger.warning("Prompt cache read failed; re-rendering",
+                       exc_info=True)
+        return None
+
+
+def store_render(config, node, rendered_text):
+    """Store the rendered text (encrypted). Failures are non-fatal."""
+    try:
+        _client(config).setex(
+            _key(node), CACHE_TTL_SECONDS,
+            encrypt_content(rendered_text).encode("utf-8"),
+        )
+    except Exception:
+        logger.warning("Prompt cache write failed", exc_info=True)

--- a/backend/utils/spend.py
+++ b/backend/utils/spend.py
@@ -1,0 +1,124 @@
+"""Month-to-date API spend aggregation + spend-limit alerting (issue #85).
+
+Core logic lives here (plain functions, app context assumed active) so it
+is unit-testable without importing the Celery app. The hourly beat task in
+backend/tasks/spend_monitor.py is a thin wrapper around check_and_alert().
+
+Spend source of truth is APICostLog (cost_microdollars), which every
+LLM/transcription/TTS task already writes. Provider attribution derives
+from SUPPORTED_MODELS config with a "claude*" prefix fallback so rows for
+models that have since been removed from config still count correctly.
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import func, or_
+
+from backend.extensions import db
+from backend.models import APICostLog, SpendAlert
+
+logger = logging.getLogger(__name__)
+
+
+def month_start(now=None):
+    now = now or datetime.utcnow()
+    return datetime(now.year, now.month, 1)
+
+
+def _anthropic_filter(config):
+    ids = {
+        model_id
+        for model_id, cfg in (config.get("SUPPORTED_MODELS") or {}).items()
+        if cfg.get("provider") == "anthropic"
+    }
+    return or_(APICostLog.model_id.in_(ids),
+               APICostLog.model_id.like("claude%"))
+
+
+def get_month_spend_microdollars(config, provider=None, now=None):
+    """Month-to-date spend in microdollars, optionally filtered by provider
+    ("anthropic" / "openai")."""
+    q = db.session.query(
+        func.coalesce(func.sum(APICostLog.cost_microdollars), 0)
+    ).filter(APICostLog.created_at >= month_start(now))
+    if provider == "anthropic":
+        q = q.filter(_anthropic_filter(config))
+    elif provider == "openai":
+        q = q.filter(~_anthropic_filter(config))
+    return int(q.scalar() or 0)
+
+
+def parse_thresholds(raw):
+    """Parse "0.5,0.8,0.95" into a sorted list of floats in (0, 1]."""
+    thresholds = []
+    for part in (raw or "").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            value = float(part)
+        except ValueError:
+            logger.warning("Ignoring invalid spend threshold %r", part)
+            continue
+        if 0 < value <= 1:
+            thresholds.append(value)
+    return sorted(set(thresholds))
+
+
+def check_and_alert(config, now=None, send_email=None):
+    """Compare month-to-date Anthropic spend against the configured limit
+    and alert once per (month, threshold) crossed.
+
+    Returns a dict summary (also useful as the Celery task result).
+    `send_email` is injectable for tests; defaults to the real sender.
+    """
+    limit_usd = config.get("ANTHROPIC_SPEND_LIMIT_USD") or 0
+    if limit_usd <= 0:
+        return {"status": "disabled"}
+
+    if send_email is None:
+        from backend.utils.email import send_spend_alert_email
+        send_email = send_spend_alert_email
+
+    now = now or datetime.utcnow()
+    month = now.strftime("%Y-%m")
+    spend_usd = get_month_spend_microdollars(
+        config, provider="anthropic", now=now) / 1_000_000
+    thresholds = parse_thresholds(config.get("SPEND_ALERT_THRESHOLDS"))
+
+    fired = []
+    for threshold in thresholds:
+        if spend_usd < limit_usd * threshold:
+            continue
+        already = SpendAlert.query.filter_by(
+            provider="anthropic", month=month, threshold=threshold
+        ).first()
+        if already:
+            continue
+        try:
+            send_email(
+                to_email=config.get("SPEND_ALERT_EMAIL"),
+                provider="anthropic",
+                spend_usd=spend_usd,
+                limit_usd=limit_usd,
+                threshold=threshold,
+            )
+        except Exception:
+            # Don't record the alert as sent — retry next run.
+            logger.exception(
+                "Failed to send spend alert (threshold %.2f)", threshold)
+            continue
+        db.session.add(SpendAlert(
+            provider="anthropic", month=month,
+            threshold=threshold, spend_usd=spend_usd,
+        ))
+        db.session.commit()
+        fired.append(threshold)
+
+    return {
+        "status": "ok",
+        "month": month,
+        "spend_usd": round(spend_usd, 4),
+        "limit_usd": limit_usd,
+        "fired": fired,
+    }

--- a/backend/utils/timefmt.py
+++ b/backend/utils/timefmt.py
@@ -12,6 +12,8 @@ an explicit ``"Z"`` (Zulu / UTC) suffix when the value is naive, and otherwise
 relies on the offset already produced by ``.isoformat()`` for aware datetimes.
 """
 
+import re
+
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -93,3 +95,31 @@ def is_valid_timezone(tz_name: Optional[str]) -> bool:
         return True
     except (ZoneInfoNotFoundError, ValueError, KeyError):
         return False
+
+
+# Matches the local_stamp format (and the [unknown time] fallback) at a
+# message edge, e.g. "[2026-06-10 08:27 UTC]" / "[2026-06-01 20:39 CEST]".
+_EDGE_STAMP_RE = (
+    r'\[(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2} [A-Za-z+\-0-9:]{1,6}'
+    r'|unknown time)\]'
+)
+_LEADING_STAMPS_RE = re.compile(r'^(?:\s*' + _EDGE_STAMP_RE + r')+\s*')
+_TRAILING_STAMPS_RE = re.compile(r'\s*(?:' + _EDGE_STAMP_RE + r'\s*)+$')
+
+
+def strip_edge_timestamps(text):
+    """Remove hallucinated context timestamps from a response's edges
+    (#179 + trailing variant).
+
+    Every context message carries a local_stamp prefix for temporal
+    grounding (#130); some models mimic it — leading stamps (#179, all
+    models occasionally; confirmed on Fable 5) or trailing ones (Opus
+    4.8). The stamp is system metadata and must never reach the user or
+    TTS. Only edge stamps are removed — in-content mentions of dates or
+    bracketed text are left alone.
+    """
+    if not text:
+        return text
+    text = _LEADING_STAMPS_RE.sub('', text)
+    text = _TRAILING_STAMPS_RE.sub('', text)
+    return text

--- a/backend/utils/webm_utils.py
+++ b/backend/utils/webm_utils.py
@@ -113,12 +113,45 @@ def _ebml_read_vint(data: bytes, offset: int, keep_marker: bool):
     return value, length, is_unknown
 
 
+WEBM_MAGIC = b'\x1aE\xdf\xa3'  # EBML header
+
+
+def chunk_is_init_bearing(chunk_path: pathlib.Path) -> bool:
+    """True if the chunk starts its own media stream (#124).
+
+    A chunk N>0 that begins with an fMP4 `ftyp` box or a WebM EBML
+    header came from a fresh MediaRecorder instance — i.e. the user
+    resumed a recovered recording. Such chunks open a new "subsession"
+    that must be transcribed separately from the chunks before it.
+    """
+    try:
+        with open(chunk_path, 'rb') as f:
+            head = f.read(8)
+    except OSError:
+        return False
+    if len(head) < 8:
+        return False
+    return head[4:8] == b'ftyp' or head[:4] == WEBM_MAGIC
+
+
+def init_segment_name(ext: str, index: int = None) -> str:
+    """Filename for a persisted init segment.
+
+    Chunk 0's init keeps the legacy name `init{ext}`; a resumed
+    subsession starting at chunk N persists as `init.{N}{ext}` (#124).
+    """
+    return f"init{ext}" if index is None else f"init.{index}{ext}"
+
+
 def persist_init_segment(
     chunk_path: pathlib.Path, chunk_dir: pathlib.Path,
+    index: int = None,
 ) -> None:
-    """Extract the init segment from a chunk-0 file on disk and persist it
-    at `chunk_dir/init{ext}.enc` (or `init{ext}` if encryption is disabled),
-    where `ext` matches the chunk's file extension (`.webm` or `.mp4`).
+    """Extract the init segment from an init-bearing chunk on disk and
+    persist it at `chunk_dir/init{ext}.enc` (chunk 0) or
+    `chunk_dir/init.{index}{ext}.enc` (a resumed subsession's first chunk,
+    #124) — without `.enc` when encryption is disabled. `ext` matches the
+    chunk's file extension (`.webm` or `.mp4`).
 
     Dispatches on the chunk's suffix: WebM goes through the EBML walker,
     MP4 through the ISOBMFF box walker. Both raise ValueError on malformed
@@ -141,7 +174,7 @@ def persist_init_segment(
     else:
         raise ValueError(f"Unsupported chunk extension: {ext}")
 
-    init_path = chunk_dir / ("init" + ext)
+    init_path = chunk_dir / init_segment_name(ext, index)
     with open(init_path, 'wb') as f:
         f.write(init_bytes)
     try:

--- a/docs/triage/ISSUE-TRIAGE-PLAN.md
+++ b/docs/triage/ISSUE-TRIAGE-PLAN.md
@@ -26,7 +26,7 @@
 - #98 landing scroll line (PR #167) — final design: content-sized hero, line ~40px below CTA on all viewports; narrative fade gated on `useHasScrolled()` (tall desktop fits the first section in-viewport, so a geometry threshold alone fired it pre-scroll).
 - #66 stale TTS on edit (PR #166) — confirm dialog (Keep / Regenerate). Took several layers: `regenerate_tts` flag-gating; `has_tts` on BOTH node serializers (focal + `serialize_node_recursive`); `onTtsGenerated` callback fired from the SSE completion path so same-session edits see fresh `has_tts`; `SpeakerIcon` cache reset on `content` change; and **cache-busting the media URL** (`?v=<chunk id>`) because nginx serves `/media` with a 24h `Cache-Control` and the path is reused every regen.
 - #28 mobile audio player (PR #168) — pops out of the NavBar into a bottom floating card < 640px; toasts offset above it via `--floating-player-offset`.
-- Also filed during Wave 1: **#161** (Stop button should reset playback to 0, not hide the player) — not yet done.
+- Also filed during Wave 1: **#161** (Stop button should reset playback to 0, not hide the player) — ~~not yet done~~ **RESOLVED (confirmed fixed, 2026-06-10)**.
 
 **Key lessons that bit us in Wave 1 (see memory + Section 8):**
 - **Test like a human, end-to-end, in the real state.** Screenshots are primary evidence for layout; reproduce the user's *exact* repro (e.g. "generate TTS then edit in the *same session*", logged-out for the landing page). "200 OK"/"string is in the bundle"/passing unit tests are NOT proof a UI feature works.
@@ -56,7 +56,7 @@
 - **Import dedupe:** #136 (re-import / snapshot overlap) — now unblocked since #137/#135 shipped; model column + dedupe key, no manual migration. *Best next pick.*
 - **Profile/UX:** #131 (app-wide toast on profile-generation completion), #101 (transparent favicon — needs brand sign-off).
 - **Security:** #91 (reserved usernames — security-critical, final single-item staging pass) + #160 (mic-denied path).
-- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. Also still open from Wave 1: **#161** (Stop button resets playback to 0).
+- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
 
 ---
 

--- a/docs/triage/ISSUE-TRIAGE-PLAN.md
+++ b/docs/triage/ISSUE-TRIAGE-PLAN.md
@@ -18,6 +18,8 @@
 
 ## 0. PROGRESS LOG (read this first)
 
+> **GitHub state snapshot (2026-06-10, reconciled against live issues):** closed-completed among triaged issues — #28, #62, #63, #66, #94, #98, #108, #128, #129, #130, #134, #135, #137, **#138**, #142, **#160**, #161, #191; closed-won't-implement — #93. In-flight PRs (NOT merged): #174 (#136), #175 (#91), #194–#201 (overnight+morning batch 2026-06-10: #85, Sentry/health, #158, #155, #187/#192, #189, Wave-6 #104/#110/#139/#179, #131). #105 and #149 dropped from the plan per maintainer (2026-06-10).
+
 **✅ Wave 1 — COMPLETE & merged to `main`/prod (2026-05-29).** All 7 issues shipped via separate PRs, each verified on staging:
 - #142 nginx Server header (PR #162) — required a manual `server_tokens off` + reload on the **VM edge nginx** (the deploy only updates the container config); done on the VM, confirmed `Server: nginx`.
 - #62 disabled-button tooltips (PR #163) — the working fix wraps the disabled button in a non-disabled `<span title=…>` (a `title` on a `disabled` element never shows).
@@ -55,8 +57,8 @@
 - ~~**Todo polish** (#94, #93)~~ — **RESOLVED 2026-05-29:** #94 fixed & closed completed; #93 closed won't-implement. Todo cluster fully closed out.
 - **Import dedupe:** #136 (re-import / snapshot overlap) — now unblocked since #137/#135 shipped; model column + dedupe key, no manual migration. *Best next pick.*
 - **Profile/UX:** #131 (app-wide toast on profile-generation completion), #101 (transparent favicon — needs brand sign-off).
-- **Security:** #91 (reserved usernames — security-critical, final single-item staging pass) + #160 (mic-denied path).
-- Then the keyword cluster (#139→#149, #105) and #138 (markdown rendering, isolated). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
+- **Security:** #91 (reserved usernames — PR #175 open). ~~#160 (mic-denied path)~~ — **#160 CLOSED completed** (shipped as `438406c`, 2026-06-04).
+- Then the keyword cluster (#139→#149, #105) and ~~#138 (markdown rendering, isolated)~~ — **#138 CLOSED completed** (2026-06-10). Decision-gated items (Section 9) remain parked. ~~Also still open from Wave 1: **#161**~~ — #161 confirmed fixed (2026-06-10). **Update 2026-06-10:** #139/#110/#104 implemented (PR in flight, stacked on the caching batch); #105 dropped — likely no longer reproduces per maintainer; #149 dropped from the current plan per maintainer.
 
 ---
 
@@ -286,7 +288,7 @@ Principle: front-load XS/S high-confidence wins, sequence shared-plumbing, isola
 **Final single-item pass:** before merging **#91** to `main`, do a dedicated single-item staging push + Chrome re-check (security-critical; a batch sibling must not mask a regression).
 **Merge:** green PRs → `main`.
 
-### Wave 7 (optional, isolated) — high-regression / decision-gated
+### Wave 7 (optional, isolated) — high-regression / decision-gated — ◐ #138 CLOSED completed (2026-06-10)
 **Issues:** #138 (markdown rendering — touches a component consumed by Feed/NodeDetail/Profile; isolate so a regression is easy to spot), and any unblocked profile-policy verification (#65 verify-and-close-or-fix-by-#32).
 **Why isolated:** #138 has broad consumer surface and theme interactions; give it its own staging cycle. Note: the todo list itself renders via `TodoItem`, not MarkdownBody, so #138's checkbox-construct changes do not affect TodoPage directly — but verify any shared markdown styling.
 **Chrome test cycle:** Seed a node exercising all markdown constructs → assert styled headings/blockquote/table/hr/lists/code in NodeDetail, Feed, Profile; toggle light/dark and re-verify; confirm checkbox-construct rendering still works where MarkdownBody is used.

--- a/docs/triage/ISSUE-TRIAGE-VERDICTS.md
+++ b/docs/triage/ISSUE-TRIAGE-VERDICTS.md
@@ -3,6 +3,7 @@
 > **Status (2026-05-29):** This file is the static triage analysis. For live progress see Section 0 of `ISSUE-TRIAGE-PLAN.md`.
 > **Shipped to prod so far:** Wave 1 — #142, #62, #63, #134, #98, #66, #28. Wave 2 (reprioritized batch) — #108, #128, #129, #130, #135, #137. (All closed as completed on GitHub.)
 > **Closed without us shipping:** #94 (toggle ~1s delay) — completed/fixed; **#93 (hit target too small) — closed WON'T-IMPLEMENT** (maintainer decision). The whole todo cluster is now resolved.
+> **State sync (2026-06-10):** also closed since: #108, #128, #129, #130, #134, #135, #137, #138, #142, #160, #161, #191. See the PLAN Section 0 snapshot for the authoritative list + in-flight PRs.
 > **Filed during the work:** #161 (Stop button reset), #172 (decide model attribution on assistant turns). Some inherited rationales below are now stale because the issue shipped or was closed won't-implement — trust the PLAN's progress log over this file where they disagree.
 > **Post-triage cluster (2026-06-04):** a tightly-interdependent prompt-caching / context-pinning family — **#191** (pin artifacts), **#187** (voice provider cache), **#188** (streaming), **#189** (OpenAI cache), **#190** (text-mode placeholder), **#192** (`backend-cache`) — filed outside this triage. See **Section 6b of `ISSUE-TRIAGE-PLAN.md`** for the dependency order + cost / latency / consistency categorization. Linchpin: **#191 first** (standalone consistency win + hard pre-condition for #187/#192).
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.57.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -3206,6 +3207,97 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
+      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
+      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
+      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
+      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
+      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry-internal/feedback": "10.57.0",
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry-internal/replay-canvas": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
+      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "proxy": "http://localhost:5010",
   "dependencies": {
+    "@sentry/react": "^10.57.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -26,6 +26,7 @@ import AccountPage from "./pages/AccountPage";
 import AiPreferencesPage from "./pages/AiPreferencesPage";
 import ArtifactsPage from "./pages/ArtifactsPage";
 import ProfileGenerationWatcher from "./components/ProfileGenerationWatcher";
+import OnboardingFlow from "./components/OnboardingFlow";
 import PromptsPage from "./pages/PromptsPage";
 import PromptDetailPage from "./pages/PromptDetailPage";
 import SearchModal from "./components/SearchModal";
@@ -98,6 +99,12 @@ function App() {
       )}
 
       {showSearch && <SearchModal onClose={() => setShowSearch(false)} />}
+
+      {/* First-login onboarding (#147) — after terms, before anything else */}
+      {user && user.approved && user.terms_up_to_date
+        && user.onboarding_completed === false && !showTerms && (
+        <OnboardingFlow />
+      )}
 
       {/* Render the Terms Modal if the user hasn't accepted the terms yet */}
       {showTerms && (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,6 +24,7 @@ import TodoPage from "./pages/TodoPage";
 import ImportPage from "./pages/ImportPage";
 import AccountPage from "./pages/AccountPage";
 import AiPreferencesPage from "./pages/AiPreferencesPage";
+import ArtifactsPage from "./pages/ArtifactsPage";
 import PromptsPage from "./pages/PromptsPage";
 import PromptDetailPage from "./pages/PromptDetailPage";
 import SearchModal from "./components/SearchModal";
@@ -141,6 +142,7 @@ function App() {
           <Route path="/prompts/:promptKey" element={<ProtectedRoute><PromptDetailPage /></ProtectedRoute>} />
           <Route path="/import" element={<ProtectedRoute><ImportPage /></ProtectedRoute>} />
           <Route path="/ai-preferences" element={<ProtectedRoute><AiPreferencesPage /></ProtectedRoute>} />
+          <Route path="/artifacts" element={<ProtectedRoute><ArtifactsPage /></ProtectedRoute>} />
           <Route path="/account" element={<ProtectedRoute><AccountPage /></ProtectedRoute>} />
           <Route path="/node/:id" element={<ProtectedRoute><NodeDetailWrapper /></ProtectedRoute>} />
           <Route path="/admin" element={<ProtectedRoute><AdminPanel /></ProtectedRoute>} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,6 +25,7 @@ import ImportPage from "./pages/ImportPage";
 import AccountPage from "./pages/AccountPage";
 import AiPreferencesPage from "./pages/AiPreferencesPage";
 import ArtifactsPage from "./pages/ArtifactsPage";
+import ProfileGenerationWatcher from "./components/ProfileGenerationWatcher";
 import PromptsPage from "./pages/PromptsPage";
 import PromptDetailPage from "./pages/PromptDetailPage";
 import SearchModal from "./components/SearchModal";
@@ -112,6 +113,7 @@ function App() {
         />
       )}
 
+        <ProfileGenerationWatcher />
         <Routes>
           <Route path="/" element={<RootRoute />} />
           <Route path="/landing" element={<LandingPage />} />

--- a/frontend/src/components/ExternalImport.js
+++ b/frontend/src/components/ExternalImport.js
@@ -1,0 +1,212 @@
+import React, { useEffect, useRef, useState } from 'react';
+import api from '../api';
+
+/**
+ * References import (#155 / Download substrate): Community Archive
+ * tweets + X bookmarks. Imported items become semantically searchable
+ * (Cmd+K → Semantic) alongside your own entries.
+ */
+
+const cardStyle = {
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: '10px',
+  padding: '20px 24px',
+  marginBottom: '16px',
+};
+
+const titleStyle = {
+  fontFamily: 'var(--serif)', fontWeight: 300, fontSize: '1.2rem',
+  color: 'var(--text-primary)', margin: '0 0 6px 0',
+};
+
+const helpStyle = {
+  fontFamily: 'var(--sans)', fontWeight: 300, fontSize: '0.8rem',
+  color: 'var(--text-muted)', margin: '0 0 14px 0', lineHeight: 1.6,
+};
+
+const inputStyle = {
+  background: 'var(--bg-input)', border: '1px solid var(--border)',
+  borderRadius: '6px', color: 'var(--text-primary)',
+  fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
+  padding: '8px 12px',
+};
+
+const buttonStyle = {
+  padding: '8px 18px', background: 'var(--accent)', border: 'none',
+  borderRadius: '6px', color: 'var(--bg-deep)',
+  fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 400,
+  cursor: 'pointer',
+};
+
+export default function ExternalImport() {
+  const [counts, setCounts] = useState({});
+  const [caUsername, setCaUsername] = useState('');
+  const [caStatus, setCaStatus] = useState(null);
+  const [xStatus, setXStatus] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const fileRef = useRef(null);
+  const pollRef = useRef(null);
+
+  const refresh = async () => {
+    try {
+      const [itemsRes, xRes] = await Promise.all([
+        api.get('/external/items', { params: { per_page: 1 } }),
+        api.get('/external/twitter/status'),
+      ]);
+      setCounts(itemsRes.data.counts || {});
+      setXStatus(xRes.data);
+    } catch (e) { /* page still works without counts */ }
+  };
+
+  useEffect(() => {
+    refresh();
+    return () => pollRef.current && clearInterval(pollRef.current);
+  }, []);
+
+  const pollCounts = () => {
+    // Fetch tasks run in the background — refresh counts a few times.
+    let ticks = 0;
+    pollRef.current && clearInterval(pollRef.current);
+    pollRef.current = setInterval(() => {
+      refresh();
+      if (++ticks >= 12) clearInterval(pollRef.current);
+    }, 5000);
+  };
+
+  const fetchCA = async () => {
+    if (!caUsername.trim()) return;
+    setBusy(true);
+    setCaStatus(null);
+    try {
+      await api.post('/external/community-archive/fetch', {
+        username: caUsername.trim(),
+      });
+      setCaStatus('Fetching in the background — counts update below.');
+      pollCounts();
+    } catch (e) {
+      setCaStatus(e.response?.data?.error || 'Fetch failed.');
+    }
+    setBusy(false);
+  };
+
+  const importBookmarksFile = async (file) => {
+    setBusy(true);
+    try {
+      const text = await file.text();
+      const res = await api.post('/external/bookmarks/import',
+        JSON.parse(text) instanceof Array
+          ? { bookmarks: JSON.parse(text) } : JSON.parse(text));
+      setCaStatus(null);
+      setXStatus((prev) => ({ ...prev }));
+      alert(`Imported ${res.data.created} bookmarks ` +
+            `(${res.data.skipped} already known).`);
+      refresh();
+    } catch (e) {
+      alert(e.response?.data?.error || 'Import failed — is it valid JSON?');
+    }
+    setBusy(false);
+  };
+
+  const syncX = async () => {
+    setBusy(true);
+    try {
+      await api.post('/external/twitter/sync');
+      pollCounts();
+    } catch (e) {
+      alert(e.response?.data?.error || 'Sync failed.');
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div style={{ marginTop: '32px' }}>
+      <h2 style={{
+        fontFamily: 'var(--serif)', fontWeight: 300, fontSize: '1.5rem',
+        color: 'var(--text-primary)', margin: '0 0 4px 0',
+      }}>
+        References
+      </h2>
+      <p style={helpStyle}>
+        Content you've saved elsewhere, made searchable next to your own
+        writing (Cmd+K → Semantic).
+        {(counts.community_archive || counts.twitter_bookmark) ? (
+          <> Imported so far:
+            {counts.community_archive ? ` ${counts.community_archive} archive tweets` : ''}
+            {counts.community_archive && counts.twitter_bookmark ? ' ·' : ''}
+            {counts.twitter_bookmark ? ` ${counts.twitter_bookmark} bookmarks` : ''}.
+          </>
+        ) : null}
+      </p>
+
+      <div style={cardStyle}>
+        <h3 style={titleStyle}>Community Archive</h3>
+        <p style={helpStyle}>
+          Fetch tweets from the open Community Archive — any account that
+          donated its archive. Try your own handle or someone you follow.
+        </p>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <input
+            value={caUsername}
+            onChange={(e) => setCaUsername(e.target.value)}
+            placeholder="@username"
+            style={{ ...inputStyle, flex: '1 1 180px' }}
+          />
+          <button onClick={fetchCA} disabled={busy} style={buttonStyle}>
+            Fetch tweets
+          </button>
+        </div>
+        {caStatus && <p style={{ ...helpStyle, margin: '10px 0 0 0' }}>{caStatus}</p>}
+      </div>
+
+      <div style={cardStyle}>
+        <h3 style={titleStyle}>X Bookmarks</h3>
+        {xStatus && xStatus.connected ? (
+          <>
+            <p style={helpStyle}>
+              Connected as @{xStatus.handle}
+              {xStatus.last_synced_at ? ` · last synced ${xStatus.last_synced_at.slice(0, 10)}` : ''}
+            </p>
+            <button onClick={syncX} disabled={busy} style={buttonStyle}>
+              Sync bookmarks
+            </button>
+          </>
+        ) : xStatus && xStatus.configured ? (
+          <>
+            <p style={helpStyle}>
+              Connect your X account to pull in your bookmarks
+              (the 800 most recent — X's cap).
+            </p>
+            <a href={`${process.env.REACT_APP_BACKEND_URL}/api/external/twitter/connect`}>
+              <button style={buttonStyle}>Connect X</button>
+            </a>
+          </>
+        ) : (
+          <p style={helpStyle}>
+            Direct sync isn't configured yet. You can still import a
+            bookmarks JSON export:
+          </p>
+        )}
+        <div style={{ marginTop: '10px' }}>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="application/json"
+            style={{ display: 'none' }}
+            onChange={(e) => e.target.files[0] && importBookmarksFile(e.target.files[0])}
+          />
+          <button
+            onClick={() => fileRef.current && fileRef.current.click()}
+            disabled={busy}
+            style={{
+              ...buttonStyle, background: 'none',
+              border: '1px solid var(--border)', color: 'var(--text-muted)',
+            }}
+          >
+            Import bookmarks JSON
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/GlobalAudioPlayer.js
+++ b/frontend/src/components/GlobalAudioPlayer.js
@@ -111,6 +111,36 @@ const GlobalAudioPlayer = () => {
         {currentAudio.title || 'Audio Player'}
       </div>
 
+      {/* Chapters (#145) — only for TTS audio with real sections */}
+      {currentAudio.chapters && currentAudio.chapters.length > 1 && (
+        <select
+          value=""
+          onChange={(e) => {
+            const ch = currentAudio.chapters[Number(e.target.value)];
+            if (ch) seekToCumulativeTime(ch.start_time);
+            e.target.value = '';
+          }}
+          title="Jump to chapter"
+          style={{
+            background: 'var(--bg-input)',
+            border: '1px solid var(--border)',
+            borderRadius: '4px',
+            color: 'var(--text-muted)',
+            fontSize: '11px',
+            fontFamily: 'var(--sans)',
+            padding: '2px 4px',
+            maxWidth: isMobile ? '90px' : '130px',
+            cursor: 'pointer',
+            flexShrink: 0,
+          }}
+        >
+          <option value="" disabled>Chapters</option>
+          {currentAudio.chapters.map((ch, i) => (
+            <option key={i} value={i}>{ch.title}</option>
+          ))}
+        </select>
+      )}
+
       {/* Controls */}
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
         {isPlaying ? (

--- a/frontend/src/components/OnboardingFlow.js
+++ b/frontend/src/components/OnboardingFlow.js
@@ -1,0 +1,185 @@
+import React, { useState } from 'react';
+import api from '../api';
+import { useUser } from '../contexts/UserContext';
+
+/**
+ * First-login onboarding walkthrough (#147).
+ *
+ * Shown once, right after terms acceptance, for users who haven't
+ * completed it (server-tracked via onboarding_completed_at). Both
+ * "Begin" and "Skip" mark completion — it never reappears.
+ *
+ * The step COPY below is v0 placeholder text for maintainer tuning;
+ * the engine (steps array, gating, persistence) is the deliverable.
+ */
+
+const STEPS = [
+  {
+    title: 'Welcome to Loore',
+    body: (
+      <>
+        <p>
+          Loore is where your words become your <em style={{ color: 'var(--accent)' }}>lore</em> —
+          a growing body of writing that an AI reads to genuinely understand you.
+        </p>
+        <p>
+          The more you put in — journal entries, voice notes, imported
+          conversations — the better it reflects you back.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: 'Two ways in',
+    body: (
+      <>
+        <p>
+          <strong style={{ color: 'var(--text-primary)' }}>Voice</strong> — just talk.
+          Rambling is fine; that's where the good stuff hides. Your words are
+          transcribed and the AI responds out loud.
+        </p>
+        <p>
+          <strong style={{ color: 'var(--text-primary)' }}>Text</strong> — type instead.
+          Same conversation, same understanding, formatted for reading.
+        </p>
+        <p>You can switch between them mid-conversation.</p>
+      </>
+    ),
+  },
+  {
+    title: 'Private by default',
+    body: (
+      <>
+        <p>
+          Every entry is <strong style={{ color: 'var(--text-primary)' }}>private</strong> unless
+          you decide otherwise, and you control whether the AI may read it at all.
+        </p>
+        <p>
+          Entries the AI can read are sent to AI providers (OpenAI, Anthropic)
+          to generate responses — never for training unless you explicitly opt in.
+          You can change any entry's settings at any time.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: 'It remembers',
+    body: (
+      <>
+        <p>
+          As you write, Loore builds artifacts about you: a{' '}
+          <strong style={{ color: 'var(--text-primary)' }}>profile</strong>, a{' '}
+          <strong style={{ color: 'var(--text-primary)' }}>memory</strong>, your{' '}
+          <strong style={{ color: 'var(--text-primary)' }}>todos</strong> and{' '}
+          <strong style={{ color: 'var(--text-primary)' }}>intentions</strong>.
+        </p>
+        <p>
+          They persist across sessions and you can read and edit all of them —
+          look under Profile, Todo, and Account → Artifacts.
+        </p>
+        <p>That's it. The rest you'll discover by writing.</p>
+      </>
+    ),
+  },
+];
+
+export default function OnboardingFlow() {
+  const [step, setStep] = useState(0);
+  const [closing, setClosing] = useState(false);
+  const { user, setUser } = useUser();
+
+  const finish = async () => {
+    setClosing(true);
+    try {
+      await api.post('/dashboard/onboarding/complete');
+    } catch (err) {
+      console.error('Failed to mark onboarding complete:', err);
+    }
+    setUser({ ...user, onboarding_completed: true });
+  };
+
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, zIndex: 1000,
+      background: 'rgba(10, 9, 8, 0.92)', backdropFilter: 'blur(4px)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      opacity: closing ? 0 : 1, transition: 'opacity 0.3s ease',
+      padding: '24px',
+    }}>
+      <div style={{
+        maxWidth: '480px', width: '100%',
+        background: 'var(--bg-card)', border: '1px solid var(--border)',
+        borderRadius: '12px', padding: '48px 40px',
+      }}>
+        {/* Progress dots */}
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '32px' }}>
+          {STEPS.map((_, i) => (
+            <span key={i} style={{
+              width: '8px', height: '8px', borderRadius: '50%',
+              background: i === step ? 'var(--accent)' : 'var(--border)',
+              transition: 'background 0.2s',
+            }} />
+          ))}
+        </div>
+
+        <h2 style={{
+          fontFamily: 'var(--serif)', fontWeight: 300, fontSize: '1.8rem',
+          color: 'var(--text-primary)', margin: '0 0 16px 0',
+        }}>
+          {STEPS[step].title}
+        </h2>
+
+        <div style={{
+          fontFamily: 'var(--sans)', fontWeight: 300, fontSize: '0.95rem',
+          color: 'var(--text-secondary)', lineHeight: 1.7,
+        }}>
+          {STEPS[step].body}
+        </div>
+
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '12px',
+          marginTop: '36px',
+        }}>
+          <button
+            onClick={() => (isLast ? finish() : setStep(step + 1))}
+            style={{
+              padding: '10px 28px', background: 'var(--accent)',
+              border: 'none', borderRadius: '6px', color: 'var(--bg-deep)',
+              fontFamily: 'var(--sans)', fontSize: '0.9rem', fontWeight: 400,
+              cursor: 'pointer',
+            }}
+          >
+            {isLast ? 'Begin' : 'Next'}
+          </button>
+          {step > 0 && (
+            <button
+              onClick={() => setStep(step - 1)}
+              style={{
+                padding: '10px 20px', background: 'none',
+                border: '1px solid var(--border)', borderRadius: '6px',
+                color: 'var(--text-muted)', fontFamily: 'var(--sans)',
+                fontSize: '0.9rem', cursor: 'pointer',
+              }}
+            >
+              Back
+            </button>
+          )}
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={finish}
+            style={{
+              background: 'none', border: 'none', cursor: 'pointer',
+              color: 'var(--text-muted)', fontFamily: 'var(--sans)',
+              fontSize: '0.8rem', fontWeight: 300, opacity: 0.8,
+              textDecoration: 'underline',
+            }}
+          >
+            Skip for now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProfileGenerationWatcher.js
+++ b/frontend/src/components/ProfileGenerationWatcher.js
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
+import { useToast } from '../contexts/ToastContext';
+import { useUser } from '../contexts/UserContext';
+
+/**
+ * App-wide watcher for profile generation (#131).
+ *
+ * The single poller for /export/profile-status — mounted in App so the
+ * user is notified wherever they are when generation finishes (before
+ * this, completion was only visible while ProfilePage was open).
+ * Broadcasts progress via the 'loore_profile_progress' CustomEvent
+ * (ProfilePage renders its inline indicator from it) and the existing
+ * 'loore_profile_done' event on terminal states. Renders nothing.
+ */
+export default function ProfileGenerationWatcher() {
+  const { addToast } = useToast();
+  const { user } = useUser();
+  const [taskId, setTaskId] = useState(
+    () => localStorage.getItem('loore_profile_task_id')
+  );
+
+  // Pick up task ID from backend if localStorage doesn't have it
+  // (cross-browser continuation).
+  useEffect(() => {
+    if (!taskId && user && user.profile_generation_task_id) {
+      localStorage.setItem(
+        'loore_profile_task_id', user.profile_generation_task_id);
+      setTaskId(user.profile_generation_task_id);
+    }
+  }, [user, taskId]);
+
+  // Generation started from NavBar or ProfilePage.
+  useEffect(() => {
+    const handler = (e) => {
+      const startedId = e.detail?.taskId
+        || localStorage.getItem('loore_profile_task_id');
+      if (startedId) setTaskId(startedId);
+    };
+    window.addEventListener('loore_profile_started', handler);
+    return () => window.removeEventListener('loore_profile_started', handler);
+  }, []);
+
+  const { status, progress, data } = useAsyncTaskPolling(
+    taskId ? `/export/profile-status/${taskId}` : null,
+    { interval: 3000, enabled: !!taskId }
+  );
+
+  // Broadcast progress so ProfilePage can render its inline indicator
+  // without running a second poller.
+  useEffect(() => {
+    if (!taskId || !status) return;
+    window.dispatchEvent(new CustomEvent('loore_profile_progress', {
+      detail: { status, progress, message: data?.message },
+    }));
+  }, [taskId, status, progress, data]);
+
+  useEffect(() => {
+    if (status === 'completed') {
+      localStorage.removeItem('loore_profile_task_id');
+      setTaskId(null);
+      window.dispatchEvent(new Event('loore_profile_done'));
+      addToast('Your profile has been updated ✓', 6000);
+    } else if (status === 'failed') {
+      localStorage.removeItem('loore_profile_task_id');
+      setTaskId(null);
+      window.dispatchEvent(new Event('loore_profile_done'));
+      addToast('Profile generation failed');
+    }
+  }, [status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return null;
+}

--- a/frontend/src/components/SearchModal.js
+++ b/frontend/src/components/SearchModal.js
@@ -315,8 +315,14 @@ function SearchModal({ onClose }) {
 
           {!loading && results.map((r) => (
             <div
-              key={r.id}
-              onClick={(e) => handleResultClick(r.id, e)}
+              key={`${r.kind || 'node'}-${r.id}`}
+              onClick={(e) => {
+                if (r.kind === 'external') {
+                  if (r.external_url) window.open(r.external_url, '_blank', 'noopener');
+                  return;
+                }
+                handleResultClick(r.id, e);
+              }}
               style={{
                 padding: '12px 20px',
                 cursor: 'pointer',
@@ -341,8 +347,15 @@ function SearchModal({ onClose }) {
                   textTransform: 'uppercase',
                   letterSpacing: '0.5px',
                 }}>
-                  {r.node_type}
+                  {r.kind === 'external'
+                    ? (r.source === 'twitter_bookmark' ? 'bookmark' : 'archive')
+                    : r.node_type}
                 </span>
+                {r.kind === 'external' && r.author_handle && (
+                  <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+                    @{r.author_handle}
+                  </span>
+                )}
                 <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
                   {formatDate(r.created_at)}
                 </span>

--- a/frontend/src/components/SearchModal.js
+++ b/frontend/src/components/SearchModal.js
@@ -5,6 +5,7 @@ import { formatDate } from '../utils/date';
 
 function SearchModal({ onClose }) {
   const [query, setQuery] = useState('');
+  const [mode, setMode] = useState('keyword'); // 'keyword' | 'semantic'
   const [showDateFilter, setShowDateFilter] = useState(false);
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
@@ -45,7 +46,8 @@ function SearchModal({ onClose }) {
       params.per_page = 20;
       params.page = 1;
 
-      const res = await api.get('/search', { params });
+      const endpoint = mode === 'semantic' ? '/search/semantic' : '/search';
+      const res = await api.get(endpoint, { params });
       setResults(res.data.results);
       setTotal(res.data.total);
     } catch (err) {
@@ -57,9 +59,10 @@ function SearchModal({ onClose }) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [mode]);
 
   const loadMore = useCallback(async () => {
+    if (mode === 'semantic') return; // semantic returns a single ranked set
     const nextPage = page + 1;
     setLoadingMore(true);
     try {
@@ -78,7 +81,7 @@ function SearchModal({ onClose }) {
     } finally {
       setLoadingMore(false);
     }
-  }, [page, query, dateFrom, dateTo]);
+  }, [page, query, dateFrom, dateTo, mode]);
 
   // Auto-load more when the button scrolls into view
   useEffect(() => {
@@ -181,6 +184,25 @@ function SearchModal({ onClose }) {
               fontFamily: 'var(--sans)',
             }}
           />
+          <button
+            onClick={() => setMode(mode === 'keyword' ? 'semantic' : 'keyword')}
+            title={mode === 'semantic'
+              ? 'Semantic: ranked by meaning. Click for exact keyword match.'
+              : 'Keyword: exact match. Click for semantic (by meaning).'}
+            style={{
+              background: mode === 'semantic' ? 'var(--accent-subtle)' : 'transparent',
+              border: '1px solid ' + (mode === 'semantic' ? 'var(--accent-dim)' : 'var(--border)'),
+              borderRadius: '6px',
+              padding: '4px 10px',
+              fontSize: '12px',
+              color: mode === 'semantic' ? 'var(--accent)' : 'var(--text-muted)',
+              cursor: 'pointer',
+              flexShrink: 0,
+              fontFamily: 'var(--sans)',
+            }}
+          >
+            {mode === 'semantic' ? 'Semantic' : 'Keyword'}
+          </button>
           <button
             onClick={() => setShowDateFilter(!showDateFilter)}
             style={{

--- a/frontend/src/components/SpeakerIcon.js
+++ b/frontend/src/components/SpeakerIcon.js
@@ -47,6 +47,19 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
   const baseTitle = isNode ? `Node ${id}` : `Profile ${id}`;
   const fullTitle = header ? `${baseTitle}: ${header}` : baseTitle;
 
+  // Chapter list for TTS playback (#145) — empty for unstructured text.
+  const fetchChapters = useCallback(async () => {
+    if (!isNode) return [];
+    try {
+      const res = await api.get(`/nodes/${id}/tts-chapters`, {
+        validateStatus: (s) => s === 200 || s === 404,
+      });
+      return res.status === 200 ? (res.data.chapters || []) : [];
+    } catch (e) {
+      return [];
+    }
+  }, [id, isNode]);
+
   // SSE streaming for TTS chunks
   const handleChunkReady = useCallback((data) => {
     const chunkUrl = data.audio_url.startsWith('http')
@@ -59,16 +72,16 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
     if (sseChunkCountRef.current === 1) {
       // First chunk: start playback immediately via loadAudioQueue
       setLoading(false);
-      loadAudioQueue(
+      fetchChapters().then((chapters) => loadAudioQueue(
         [chunkUrl],
-        { title: fullTitle, id, type: isNode ? 'node' : 'profile' },
+        { title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters },
         chunkDuration != null ? [chunkDuration] : null
-      );
+      ));
     } else {
       // Subsequent chunks: append to the active queue
       appendChunkToQueue(chunkUrl, chunkDuration);
     }
-  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue]);
+  }, [fullTitle, id, isNode, loadAudioQueue, appendChunkToQueue, fetchChapters]);
 
   const handleAllComplete = useCallback((data) => {
     setSseActive(false);
@@ -285,8 +298,10 @@ const SpeakerIcon = ({ nodeId, profileId, content, isPublic, aiUsage, onTtsGener
         : `${process.env.REACT_APP_BACKEND_URL}${urlPath}`;
       setAudioSrc(srcUrl);
 
-      // Load audio into global player
-      await loadAudio({ url: srcUrl, title: fullTitle, id, type: isNode ? 'node' : 'profile' });
+      // Load audio into global player (chapters only for TTS audio —
+      // recorded-original playback has no section structure, #145)
+      const chapters = (!original_url && tts_url) ? await fetchChapters() : [];
+      await loadAudio({ url: srcUrl, title: fullTitle, id, type: isNode ? 'node' : 'profile', chapters });
       setLoading(false);
     } catch (err) {
       console.error('Error playing audio:', err);

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStreamingTranscription } from '../hooks/useStreamingTranscription';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { useToast } from '../contexts/ToastContext';
 
 /**
  * StreamingMicButton - A microphone button that supports real-time streaming transcription.
@@ -47,6 +48,20 @@ export default function StreamingMicButton({
     onComplete,
     onError,
   });
+
+  // #127: warn before the ~60-minute mark so a long recording can be
+  // wrapped up deliberately instead of silently degrading.
+  const { addToast } = useToast();
+  const longRecordingWarnedRef = useRef(false);
+  useEffect(() => {
+    if (duration < 1) longRecordingWarnedRef.current = false;
+    if (duration >= 55 * 60 && !longRecordingWarnedRef.current) {
+      longRecordingWarnedRef.current = true;
+      addToast(
+        'You\u2019ve been recording for 55 minutes — consider stopping '
+        + 'soon and continuing in a new recording.', 10000);
+    }
+  }, [duration, addToast]);
 
   const isOnline = useOnlineStatus();
   const isIdleOffline = !isOnline && sessionState === 'idle';

--- a/frontend/src/hooks/useStreamingMediaRecorder.js
+++ b/frontend/src/hooks/useStreamingMediaRecorder.js
@@ -42,6 +42,7 @@ export function useStreamingMediaRecorder({
   const durationIntervalRef = useRef(null);
   const stopResolveRef = useRef(null); // Resolve fn for the stop promise
   const dataAvailableFiredRef = useRef(false); // Track if ondataavailable ran during stop
+  const lifecycleCleanupRef = useRef(null); // #88 visibility/pagehide listeners
   const pausedAtRef = useRef(null); // Timestamp when paused
   const totalPausedMsRef = useRef(0); // Accumulated paused duration
   const mimeTypeRef = useRef(null); // Active recorder's mimeType (so non-state callbacks like getPartialBlob can read it)
@@ -60,6 +61,10 @@ export function useStreamingMediaRecorder({
 
   const resetRecording = useCallback(() => {
     // Clean up previous recording
+    if (lifecycleCleanupRef.current) {
+      lifecycleCleanupRef.current();
+      lifecycleCleanupRef.current = null;
+    }
     if (mediaUrl) {
       URL.revokeObjectURL(mediaUrl);
     }
@@ -253,6 +258,10 @@ export function useStreamingMediaRecorder({
       };
 
       mediaRecorder.onstop = () => {
+        if (lifecycleCleanupRef.current) {
+          lifecycleCleanupRef.current();
+          lifecycleCleanupRef.current = null;
+        }
         console.log(`[StreamingRecorder] onstop fired: totalChunks=${chunksRef.current.length}, chunkIndex=${chunkIndexRef.current}`);
         // Combine all chunks into final blob
         const blob = new Blob(chunksRef.current, { type: mediaRecorder.mimeType });
@@ -296,6 +305,28 @@ export function useStreamingMediaRecorder({
       const durationOffsetMs = durationOffset * 1000;
 
       // Start recording with timeslice for chunked output
+      // #88: flush the in-flight timeslice when the page is about to be
+      // hidden or unloaded (phone call, lock screen, tab switch, kill).
+      // requestData() emits the buffered audio through the normal
+      // ondataavailable → upload path while the page can still run JS;
+      // the upload layer adds a sendBeacon fallback for dying pages.
+      const lifecycleFlush = () => {
+        if (recorderRef.current
+            && recorderRef.current.state === 'recording') {
+          console.log('[StreamingRecorder] Lifecycle flush (visibility/pagehide)');
+          try { recorderRef.current.requestData(); } catch (e) { /* no-op */ }
+        }
+      };
+      const onVisibility = () => {
+        if (document.visibilityState === 'hidden') lifecycleFlush();
+      };
+      window.addEventListener('pagehide', lifecycleFlush);
+      document.addEventListener('visibilitychange', onVisibility);
+      lifecycleCleanupRef.current = () => {
+        window.removeEventListener('pagehide', lifecycleFlush);
+        document.removeEventListener('visibilitychange', onVisibility);
+      };
+
       // The timeslice parameter makes ondataavailable fire at the specified interval
       mediaRecorder.start(chunkIntervalMs);
       setStatus('recording');

--- a/frontend/src/hooks/useStreamingTranscription.js
+++ b/frontend/src/hooks/useStreamingTranscription.js
@@ -114,6 +114,28 @@ export function useStreamingTranscription(options = {}) {
     const family = blobType.split(';')[0].trim().toLowerCase();
     const ext = family === 'audio/mp4' ? '.mp4' : '.webm';
 
+    // #88: if the page is hidden (phone call / lock screen / closing),
+    // a normal XHR may be killed mid-flight. sendBeacon survives page
+    // death; fire it first and still run the normal upload — the server
+    // dedupes by chunk_index, so a double-delivery is harmless.
+    if (typeof document !== 'undefined'
+        && document.visibilityState === 'hidden'
+        && navigator.sendBeacon) {
+      try {
+        const beaconForm = new FormData();
+        beaconForm.append('chunk', blob, `chunk_${chunkIndex}${ext}`);
+        beaconForm.append('chunk_index', chunkIndex.toString());
+        beaconForm.append('mime_type', blobType);
+        const sent = navigator.sendBeacon(
+          `${process.env.REACT_APP_BACKEND_URL}/api/drafts/streaming/${sessionId}/audio-chunk`,
+          beaconForm
+        );
+        console.log(`[StreamingTranscription] sendBeacon fallback for chunk ${chunkIndex}: ${sent ? 'queued' : 'rejected'}`);
+      } catch (e) {
+        console.warn('[StreamingTranscription] sendBeacon failed', e);
+      }
+    }
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const formData = new FormData();

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,11 +1,21 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import * as Sentry from "@sentry/react";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import { UserProvider } from "./contexts/UserContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
+
+// Error monitoring — no-op unless REACT_APP_SENTRY_DSN is set at build time.
+if (process.env.REACT_APP_SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.REACT_APP_SENTRY_DSN,
+    environment: process.env.REACT_APP_SENTRY_ENVIRONMENT || "production",
+    sendDefaultPii: false,
+  });
+}
 
 const container = document.getElementById("root");
 const root = createRoot(container);

--- a/frontend/src/pages/AccountPage.js
+++ b/frontend/src/pages/AccountPage.js
@@ -326,6 +326,31 @@ export default function AccountPage() {
           Tone, style, boundaries. Updated automatically during Voice sessions.
         </div>
       </div>
+
+      <div style={rowStyle}>
+        <div style={labelStyle}>Artifacts</div>
+        <button
+          onClick={() => navigate("/artifacts")}
+          style={{
+            ...inputStyle,
+            cursor: "pointer",
+            textAlign: "left",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <span style={{ color: "var(--text-muted)", fontWeight: 300 }}>
+            Memory, scratchpad &amp; custom documents
+          </span>
+          <span style={{ color: "var(--accent)", fontSize: "0.85rem" }}>
+            View
+          </span>
+        </button>
+        <div style={helperStyle}>
+          Persistent documents the AI maintains across sessions.
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/ArtifactsPage.js
+++ b/frontend/src/pages/ArtifactsPage.js
@@ -1,0 +1,278 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import MarkdownBody from '../components/MarkdownBody';
+import api from '../api';
+import VersionHistoryDrawer from '../components/VersionHistoryDrawer';
+import { formatDate } from '../utils/date';
+
+const KIND_BLURBS = {
+  memory: "Durable facts the AI remembers about you across sessions. It updates this on its own as you talk.",
+  scratchpad: "The AI's working notes for ongoing threads — where it left off, open questions.",
+};
+
+export default function ArtifactsPage() {
+  const [artifacts, setArtifacts] = useState([]);
+  const [activeKind, setActiveKind] = useState('memory');
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [editContent, setEditContent] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [creatingKind, setCreatingKind] = useState(false);
+  const [newKind, setNewKind] = useState('');
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [versions, setVersions] = useState([]);
+  const [selectedVersionId, setSelectedVersionId] = useState(null);
+  const [versionContent, setVersionContent] = useState(null);
+
+  const fetchArtifacts = useCallback(async () => {
+    try {
+      const res = await api.get('/artifacts');
+      setArtifacts(res.data.artifacts);
+      setLoading(false);
+    } catch (err) {
+      console.error('Failed to load artifacts:', err);
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchArtifacts();
+  }, [fetchArtifacts]);
+
+  const active = artifacts.find((a) => a.kind === activeKind) || null;
+
+  const handleSave = async (kind) => {
+    setSaving(true);
+    try {
+      await api.put(`/artifacts/${kind}`, {
+        content: editContent,
+        generated_by: 'user',
+      });
+      await fetchArtifacts();
+      setEditing(false);
+      setCreatingKind(false);
+      setActiveKind(kind);
+    } catch (err) {
+      console.error('Failed to save artifact:', err);
+    }
+    setSaving(false);
+  };
+
+  const handleOpenHistory = async () => {
+    setDrawerOpen(true);
+    try {
+      const res = await api.get(`/artifacts/${activeKind}/versions`);
+      setVersions(res.data.versions);
+    } catch (err) {
+      console.error('Failed to load versions:', err);
+    }
+  };
+
+  const handleSelectVersion = async (id) => {
+    setSelectedVersionId(id);
+    setVersionContent(null);
+    try {
+      const res = await api.get(`/artifacts/versions/${id}`);
+      setVersionContent(res.data.artifact.content);
+    } catch (err) {
+      console.error('Failed to load version:', err);
+    }
+  };
+
+  const generatedByLabel = (g) => {
+    if (!g) return null;
+    if (g === 'user' || g === 'manual') return 'edited manually';
+    if (g === 'agentic_session') return 'AI session';
+    return g;
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: '60px 24px', maxWidth: '800px', margin: '0 auto' }}>
+        <p style={{ color: 'var(--text-muted)' }}>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '60px 24px', maxWidth: '800px', margin: '0 auto' }}>
+      <h1 style={{
+        fontFamily: 'var(--serif)',
+        fontSize: '2rem',
+        fontWeight: 300,
+        color: 'var(--text-primary)',
+        margin: '0 0 16px 0',
+      }}>
+        Artifacts
+      </h1>
+
+      {/* Kind tabs */}
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '20px' }}>
+        {artifacts.map((a) => (
+          <button
+            key={a.kind}
+            onClick={() => { setActiveKind(a.kind); setEditing(false); }}
+            style={{
+              padding: '6px 14px',
+              background: a.kind === activeKind ? 'var(--bg-card)' : 'none',
+              border: '1px solid',
+              borderColor: a.kind === activeKind ? 'var(--accent)' : 'var(--border)',
+              borderRadius: '16px',
+              color: a.kind === activeKind ? 'var(--text-primary)' : 'var(--text-muted)',
+              fontFamily: 'var(--sans)',
+              fontSize: '0.8rem',
+              fontWeight: 300,
+              cursor: 'pointer',
+            }}
+          >
+            {a.title}
+          </button>
+        ))}
+        <button
+          onClick={() => { setCreatingKind(true); setNewKind(''); setEditContent(''); setEditing(true); }}
+          title="Create a new artifact"
+          style={{
+            padding: '6px 14px',
+            background: 'none',
+            border: '1px dashed var(--border)',
+            borderRadius: '16px',
+            color: 'var(--text-muted)',
+            fontFamily: 'var(--sans)',
+            fontSize: '0.8rem',
+            cursor: 'pointer',
+          }}
+        >
+          +
+        </button>
+      </div>
+
+      {/* Meta line */}
+      {active && !creatingKind && (
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px', marginBottom: '16px', flexWrap: 'wrap' }}>
+          <p style={{
+            fontFamily: 'var(--sans)', fontSize: '0.75rem', fontWeight: 300,
+            color: 'var(--text-muted)', margin: 0, opacity: 0.7,
+          }}>
+            {KIND_BLURBS[active.kind] || 'A persistent document shared between you and the AI.'}
+            {active.created_at && (
+              <> &middot; last updated by {generatedByLabel(active.generated_by)} &middot; {formatDate(active.created_at)}</>
+            )}
+          </p>
+          {active.created_at && (
+            <button
+              onClick={handleOpenHistory}
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                fontFamily: 'var(--sans)', fontSize: '0.75rem', fontWeight: 300,
+                color: 'var(--text-muted)', opacity: 0.7, textDecoration: 'underline',
+              }}
+            >
+              history
+            </button>
+          )}
+          {!editing && (
+            <button
+              onClick={() => { setEditing(true); setEditContent(active.content || ''); }}
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                fontFamily: 'var(--sans)', fontSize: '0.75rem', fontWeight: 300,
+                color: 'var(--accent)', textDecoration: 'underline',
+              }}
+            >
+              edit
+            </button>
+          )}
+        </div>
+      )}
+
+      <div style={{ height: '1px', background: 'var(--accent-dim)', opacity: 0.3, marginBottom: '24px' }} />
+
+      {/* New-kind name input */}
+      {creatingKind && editing && (
+        <input
+          value={newKind}
+          onChange={(e) => setNewKind(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, '-'))}
+          placeholder="artifact-name (lowercase, dashes)"
+          style={{
+            width: '100%', marginBottom: '12px',
+            background: 'var(--bg-input)', border: '1px solid var(--border)',
+            borderRadius: '8px', color: 'var(--text-primary)',
+            fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
+            padding: '10px 16px',
+          }}
+        />
+      )}
+
+      {/* Editing mode */}
+      {editing && (
+        <div>
+          <textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            placeholder={activeKind === 'memory' && !creatingKind
+              ? 'Facts the AI should remember about you...'
+              : 'Artifact content (markdown)...'}
+            style={{
+              width: '100%', minHeight: '300px',
+              background: 'var(--bg-input)', border: '1px solid var(--border)',
+              borderRadius: '8px', color: 'var(--text-primary)',
+              fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 300,
+              padding: '16px', lineHeight: 1.6, resize: 'vertical',
+            }}
+          />
+          <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+            <button
+              onClick={() => handleSave(creatingKind ? newKind : activeKind)}
+              disabled={saving || (creatingKind && !newKind)}
+              style={{
+                padding: '8px 20px', background: 'var(--accent)', border: 'none',
+                borderRadius: '6px', color: 'var(--bg-deep)',
+                fontFamily: 'var(--sans)', fontSize: '0.85rem', fontWeight: 400,
+                cursor: saving ? 'not-allowed' : 'pointer', opacity: saving ? 0.6 : 1,
+              }}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+            <button
+              onClick={() => { setEditing(false); setCreatingKind(false); }}
+              style={{
+                padding: '8px 20px', background: 'none',
+                border: '1px solid var(--border)', borderRadius: '6px',
+                color: 'var(--text-muted)', fontFamily: 'var(--sans)',
+                fontSize: '0.85rem', cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Rendered content */}
+      {active && !editing && (
+        active.content ? (
+          <div className="loore-profile" style={{
+            fontFamily: 'var(--sans)', fontSize: '0.92rem', fontWeight: 300,
+            color: 'var(--text-secondary)', lineHeight: 1.7,
+          }}>
+            <MarkdownBody>{active.content}</MarkdownBody>
+          </div>
+        ) : (
+          <p style={{ color: 'var(--text-muted)', fontFamily: 'var(--sans)', fontSize: '0.9rem' }}>
+            Nothing here yet. The AI fills this in during Voice and Text sessions — or click edit to start it yourself.
+          </p>
+        )
+      )}
+
+      <VersionHistoryDrawer
+        isOpen={drawerOpen}
+        onClose={() => { setDrawerOpen(false); setSelectedVersionId(null); setVersionContent(null); }}
+        title={`${active ? active.title : ''} History`}
+        versions={versions}
+        selectedVersionId={selectedVersionId}
+        onSelectVersion={handleSelectVersion}
+        versionContent={versionContent}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/ArtifactsPage.js
+++ b/frontend/src/pages/ArtifactsPage.js
@@ -7,6 +7,7 @@ import { formatDate } from '../utils/date';
 const KIND_BLURBS = {
   memory: "Durable facts the AI remembers about you across sessions. It updates this on its own as you talk.",
   scratchpad: "The AI's working notes for ongoing threads — where it left off, open questions.",
+  intentions: "Your longer-running aspirations — noticed, clarified, and tracked together with the AI. Fulfilled or consciously released, both count.",
 };
 
 export default function ArtifactsPage() {

--- a/frontend/src/pages/ImportPage.js
+++ b/frontend/src/pages/ImportPage.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ImportData from "../components/ImportData";
+import ExternalImport from "../components/ExternalImport";
 
 export default function ImportPage() {
   return (
@@ -18,6 +19,7 @@ export default function ImportPage() {
         Import Data
       </h2>
       <ImportData inline />
+      <ExternalImport />
     </div>
   );
 }

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -4,7 +4,6 @@ import api from '../api';
 import VersionHistoryDrawer from '../components/VersionHistoryDrawer';
 import SpeakerIcon from '../components/SpeakerIcon';
 import RegenerateTtsDialog from '../components/RegenerateTtsDialog';
-import { useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
 import { useUser } from '../contexts/UserContext';
 import useSubmitShortcut from '../hooks/useSubmitShortcut';
 import { formatDate } from '../utils/date';
@@ -53,29 +52,10 @@ export default function ProfilePage() {
     return () => window.removeEventListener('loore_profile_started', handler);
   }, []);
 
-  const pollingEndpoint = generationTaskId
-    ? `/export/profile-status/${generationTaskId}` : null;
-
-  const { status: genStatus, progress: genProgress, data: genData } = useAsyncTaskPolling(
-    pollingEndpoint,
-    { interval: 3000, enabled: !!generationTaskId }
-  );
-
-  // React to polling status changes
-  useEffect(() => {
-    if (genStatus === 'completed') {
-      localStorage.removeItem('loore_profile_task_id');
-      setGenerationTaskId(null);
-      window.dispatchEvent(new Event('loore_profile_done'));
-      fetchProfile();
-    } else if (genStatus === 'failed') {
-      localStorage.removeItem('loore_profile_task_id');
-      setGenerationTaskId(null);
-      window.dispatchEvent(new Event('loore_profile_done'));
-      setFailMessage('Generation failed');
-      setTimeout(() => setFailMessage(''), 5000);
-    }
-  }, [genStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Progress + completion arrive from the app-wide
+  // ProfileGenerationWatcher (#131) — this page no longer polls.
+  const [genProgress, setGenProgress] = useState(0);
+  const [genData, setGenData] = useState(null);
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -91,6 +71,29 @@ export default function ProfilePage() {
       setLoading(false);
     }
   }, []);
+
+  useEffect(() => {
+    const onProgress = (e) => {
+      setGenProgress(e.detail?.progress || 0);
+      setGenData(e.detail?.message ? { message: e.detail.message } : null);
+      if (e.detail?.status === 'failed') {
+        setFailMessage('Generation failed');
+        setTimeout(() => setFailMessage(''), 5000);
+      }
+    };
+    const onDone = () => {
+      setGenerationTaskId(null);
+      setGenProgress(0);
+      setGenData(null);
+      fetchProfile();
+    };
+    window.addEventListener('loore_profile_progress', onProgress);
+    window.addEventListener('loore_profile_done', onDone);
+    return () => {
+      window.removeEventListener('loore_profile_progress', onProgress);
+      window.removeEventListener('loore_profile_done', onDone);
+    };
+  }, [fetchProfile]);
 
   useEffect(() => {
     fetchProfile();


### PR DESCRIPTION
## ⚠️ Stacked PR — merge AFTER #209

## Summary
Closes #183, implementing the issue's recommended design verbatim (Idea A + Idea B):
- **Chunked regen**: the hand-written profile (`generated_by == 'user'`, latest) is injected into the **first chunk whose data window reaches its creation date** — earlier chunks rebuild uninfluenced, so old data is never read through a future self-description. Edge case (profile newer than all data): one extra **reconciliation pass** at the end instead of dropping it.
- **Single-pass regen**: the profile rides along as a dated "don't overindex; don't apply retroactively" block and the model weighs it.
- Restores consistency with the incremental path (which already honored user-written profiles via `USER_WRITTEN_PROFILE_NOTE`).

## Verification
3 new tests (chronological injection chunk selection, the newer-than-all-data reconciliation pass incl. saved head profile, single-pass dated block). Suite: 483 green.
Behavioral quality of the merge prompt is LLM-dependent — the dated-note wording is tunable prompt text in `_dated_user_profile_block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)