### PR TITLE
Profile chunking: iterative renderer, engaged scope, stable token unit, tail-aware stop

### DIFF
--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -86,162 +86,45 @@ def _export_visible_filter(model, user_id):
     )
 
 
-def _render_tombstoned_node(
-    node, index_path, processed_nodes, filter_ai_usage,
-    user_id, created_before, embedded_quotes, included_ids,
-    ai_blocked_ids,
-):
-    """Emit a deletion placeholder for a soft-deleted node and recurse
-    into its children. Children may be alive other-user replies that
-    should still surface in the export tree.
-
-    Caller is responsible for the pre-deletion-access check — this
-    helper assumes the viewer is allowed to see the tombstone shell.
-    """
+def _node_header_line(node, index_path):
+    """Markdown header line shared by all node renderings."""
     depth = len(index_path.split('.'))
     header = "#" * min(depth + 1, 6)
     ts = node.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-    result = (
-        f"{header} [{index_path}] {_node_author_label(node)}"
-        f" - {ts}\n"
-        f"[Node deleted by author]\n\n"
-    )
+    return f"{header} [{index_path}] {_node_author_label(node)} - {ts}\n"
 
-    processed_nodes.add(node.id)
+
+def _filtered_children(node, filter_ai_usage, created_before, included_ids,
+                       keep_tombstones):
+    """Children of *node* that should render, sorted chronologically.
+
+    keep_tombstones: when a budget pre-selection (included_ids) is
+    active, tombstones pass through even if not pre-selected — they take
+    no real budget tokens and dropping them creates discontinuities
+    (§5a). The inaccessible-placeholder branch does not extend this
+    courtesy, matching the historical behavior.
+    """
     children = node.children
     if filter_ai_usage:
         children = [c for c in children if c.ai_usage in AI_ALLOWED]
     if created_before:
         children = [c for c in children if c.created_at < created_before]
     if included_ids is not None:
-        # Tombstones below us still need to surface even if they aren't
-        # in the SQL pre-selection set — see _export_visible_filter
-        # rationale.
-        children = [
-            c for c in children
-            if c.id in included_ids or c.deleted_at is not None
-        ]
-    children = sorted(children, key=lambda c: c.created_at)
-
-    for j, gc in enumerate(children):
-        gc_index = f"{index_path}.{j+1}"
-        result += format_node_tree(
-            gc, index_path=gc_index,
-            processed_nodes=processed_nodes,
-            filter_ai_usage=filter_ai_usage,
-            user_id=user_id,
-            created_before=created_before,
-            embedded_quotes=embedded_quotes,
-            included_ids=included_ids,
-            ai_blocked_ids=ai_blocked_ids,
-        )
-    return result
+        if keep_tombstones:
+            children = [
+                c for c in children
+                if c.id in included_ids or c.deleted_at is not None
+            ]
+        else:
+            children = [c for c in children if c.id in included_ids]
+    return sorted(children, key=lambda c: c.created_at)
 
 
-def _render_inaccessible_node(
-    node, index_path, processed_nodes, filter_ai_usage,
-    user_id, created_before, embedded_quotes, included_ids,
-    ai_blocked_ids,
-):
-    """Emit a privacy placeholder for an inaccessible node and recurse
-    into its children (which may themselves be accessible)."""
-    depth = len(index_path.split('.'))
-    header = "#" * min(depth + 1, 6)
-    ts = node.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-    result = (
-        f"{header} [{index_path}] {_node_author_label(node)}"
-        f" - {ts}\n"
-        f"[Content not accessible — private node by another user]\n\n"
-    )
-
-    processed_nodes.add(node.id)
-    children = node.children
-    if filter_ai_usage:
-        children = [c for c in children if c.ai_usage in AI_ALLOWED]
-    if created_before:
-        children = [c for c in children if c.created_at < created_before]
-    if included_ids is not None:
-        children = [c for c in children if c.id in included_ids]
-    children = sorted(children, key=lambda c: c.created_at)
-
-    for j, gc in enumerate(children):
-        gc_index = f"{index_path}.{j+1}"
-        result += format_node_tree(
-            gc, index_path=gc_index,
-            processed_nodes=processed_nodes,
-            filter_ai_usage=filter_ai_usage,
-            user_id=user_id,
-            created_before=created_before,
-            embedded_quotes=embedded_quotes,
-            included_ids=included_ids,
-            ai_blocked_ids=ai_blocked_ids,
-        )
-    return result
-
-
-def format_node_tree(
-    node,
-    index_path="1",
-    processed_nodes=None,
-    filter_ai_usage=False,
-    user_id=None,
-    created_before=None,
-    embedded_quotes=None,
-    included_ids=None,
-    ai_blocked_ids=None
-):
-    """
-    Recursively format a node and its descendants into a human-readable tree structure
-    using Markdown headers. Uses depth-first traversal for maximum readability.
-
-    Args:
-        node: The Node object to format
-        index_path: The hierarchical index (e.g., "1.1.2")
-        processed_nodes: Set of node IDs already processed (to avoid infinite loops)
-        filter_ai_usage: If True, only include child nodes where ai_usage is 'chat' or 'train'
-        user_id: User ID for resolving {quote:ID} placeholders (for access checks)
-        created_before: Optional datetime. If provided, only include child nodes created before
-                       this timestamp.
-        embedded_quotes: Optional dict from ExportQuoteResolver mapping
-                        node_id -> {quoted_id -> content}. When provided, uses smart
-                        quote resolution that embeds only when needed.
-        included_ids: Optional set of node IDs included in the export. Used with
-                     embedded_quotes for reference-based resolution.
-
-    Returns:
-        str: Formatted text representation of the node tree
-    """
-    if processed_nodes is None:
-        processed_nodes = set()
-
-    # Avoid infinite loops from circular references
-    if node.id in processed_nodes:
-        return ""
-
-    # Soft-deleted: render the tombstone shell (no content) and recurse.
-    # The caller is responsible for the pre-deletion-access check before
-    # routing here; format_node_tree's children loop below applies it
-    # via can_user_view_tombstone.
-    if node.deleted_at is not None:
-        return _render_tombstoned_node(
-            node, index_path, processed_nodes, filter_ai_usage,
-            user_id, created_before, embedded_quotes, included_ids,
-            ai_blocked_ids,
-        )
-
-    processed_nodes.add(node.id)
-
-    # Calculate depth from index_path (e.g., "1.2.3" -> depth 3)
-    depth = len(index_path.split('.'))
-
-    # Format the node header using Markdown headers (max 6 levels, then stay at 6)
-    header_level = min(depth + 1, 6)  # +1 because thread title uses #
-    header_prefix = "#" * header_level
-
-    timestamp = node.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
-
-    # Build the node text - no content indentation for token efficiency
-    result = f"{header_prefix} [{index_path}] {_node_author_label(node)} - {timestamp}\n"
+def _format_node_text(node, index_path, user_id, embedded_quotes,
+                      ai_blocked_ids):
+    """The node's own text block: header plus artifact refs (system-prompt
+    nodes) or quote-resolved content."""
+    result = _node_header_line(node, index_path)
 
     # System prompt nodes: emit reference instead of full content
     # Check new artifact system first, then legacy FK
@@ -280,59 +163,6 @@ def format_node_tree(
             result += f"[AI Preferences v{ai_prefs_ver} (ref #{ai_prefs.id})]\n"
 
         result += "\n"
-
-        # Process children
-        children = node.children
-        if filter_ai_usage:
-            children = [c for c in children if c.ai_usage in AI_ALLOWED]
-        if created_before:
-            children = [c for c in children if c.created_at < created_before]
-        if included_ids is not None:
-            # Pass tombstones through even if they aren't in the SQL
-            # pre-selection set — they don't take real budget tokens
-            # and dropping them creates discontinuities.
-            children = [
-                c for c in children
-                if c.id in included_ids or c.deleted_at is not None
-            ]
-        children = sorted(children, key=lambda c: c.created_at)
-
-        for i, child in enumerate(children):
-            child_index = f"{index_path}.{i+1}"
-            if len(children) > 1 and i > 0:
-                result += "---\n**BRANCH**\n---\n\n"
-
-            if child.deleted_at is not None:
-                # Tombstone: render only if viewer had pre-deletion
-                # access. Otherwise skip silently — the structural fact
-                # "something is here" would itself leak username/timestamp.
-                from backend.utils.privacy import can_user_view_tombstone
-                if user_id is None or can_user_view_tombstone(child, user_id):
-                    result += _render_tombstoned_node(
-                        child, child_index, processed_nodes,
-                        filter_ai_usage, user_id, created_before,
-                        embedded_quotes, included_ids, ai_blocked_ids,
-                    )
-                continue
-
-            if user_id and not can_user_access_node(child, user_id):
-                result += _render_inaccessible_node(
-                    child, child_index, processed_nodes,
-                    filter_ai_usage, user_id, created_before,
-                    embedded_quotes, included_ids, ai_blocked_ids,
-                )
-                continue
-
-            result += format_node_tree(
-                child, index_path=child_index,
-                processed_nodes=processed_nodes,
-                filter_ai_usage=filter_ai_usage,
-                user_id=user_id,
-                created_before=created_before,
-                embedded_quotes=embedded_quotes,
-                included_ids=included_ids,
-                ai_blocked_ids=ai_blocked_ids
-            )
         return result
 
     # Resolve {quote:ID} placeholders in content
@@ -350,68 +180,132 @@ def format_node_tree(
 
     result += content
     result += "\n\n"
-
-    # Process children (depth-first traversal)
-    # Filter children by AI usage if requested (for AI profile generation)
-    # Also filter by created_before if specified
-    children = node.children
-    if filter_ai_usage:
-        children = [c for c in children if c.ai_usage in AI_ALLOWED]
-    if created_before:
-        children = [c for c in children if c.created_at < created_before]
-
-    # If we have included_ids, filter to only include nodes in the
-    # export. Tombstones pass through even if not in included_ids —
-    # they don't take real budget tokens and dropping them creates
-    # discontinuities (per §5a).
-    if included_ids is not None:
-        children = [
-            c for c in children
-            if c.id in included_ids or c.deleted_at is not None
-        ]
-
-    children = sorted(children, key=lambda c: c.created_at)
-
-    for i, child in enumerate(children):
-        child_index = f"{index_path}.{i+1}"
-
-        # Mark branches (when there are multiple children)
-        if len(children) > 1 and i > 0:
-            result += "---\n**BRANCH**\n---\n\n"
-
-        if child.deleted_at is not None:
-            # Tombstone: render only with pre-deletion access; otherwise
-            # skip (don't leak structural "something is here").
-            from backend.utils.privacy import can_user_view_tombstone
-            if user_id is None or can_user_view_tombstone(child, user_id):
-                result += _render_tombstoned_node(
-                    child, child_index, processed_nodes,
-                    filter_ai_usage, user_id, created_before,
-                    embedded_quotes, included_ids, ai_blocked_ids,
-                )
-            continue
-
-        if user_id and not can_user_access_node(child, user_id):
-            result += _render_inaccessible_node(
-                child, child_index, processed_nodes,
-                filter_ai_usage, user_id, created_before,
-                embedded_quotes, included_ids, ai_blocked_ids,
-            )
-            continue
-
-        result += format_node_tree(
-            child,
-            index_path=child_index,
-            processed_nodes=processed_nodes,
-            filter_ai_usage=filter_ai_usage,
-            user_id=user_id,
-            created_before=created_before,
-            embedded_quotes=embedded_quotes,
-            included_ids=included_ids,
-            ai_blocked_ids=ai_blocked_ids
-        )
-
     return result
+
+
+def format_node_tree(
+    node,
+    index_path="1",
+    processed_nodes=None,
+    filter_ai_usage=False,
+    user_id=None,
+    created_before=None,
+    embedded_quotes=None,
+    included_ids=None,
+    ai_blocked_ids=None
+):
+    """
+    Format a node and its descendants into a human-readable tree structure
+    using Markdown headers. Depth-first traversal for maximum readability.
+
+    Iterative (explicit work stack) rather than recursive: the renderer
+    used one Python frame per reply-depth (plus the frames SQLAlchemy
+    burns lazy-loading children each level), so deep reply chains
+    overflowed the call stack — the same failure
+    `_collect_all_nodes_in_tree` had before c556e4d, one stage later in
+    the pipeline. Stack frames are (kind, node, index_path), where kind
+    mirrors the old mutual recursion: "node" (cycle-checked; routes
+    soft-deleted nodes to the tombstone shell), "tombstone", and
+    "inaccessible". Branch separators are pushed as ("text", str)
+    frames, so the concatenated output is identical to the recursive
+    version's.
+
+    Args:
+        node: The Node object to format
+        index_path: The hierarchical index (e.g., "1.1.2")
+        processed_nodes: Set of node IDs already processed (to avoid infinite loops)
+        filter_ai_usage: If True, only include child nodes where ai_usage is 'chat' or 'train'
+        user_id: User ID for resolving {quote:ID} placeholders (for access checks)
+        created_before: Optional datetime. If provided, only include child nodes created before
+                       this timestamp.
+        embedded_quotes: Optional dict from ExportQuoteResolver mapping
+                        node_id -> {quoted_id -> content}. When provided, uses smart
+                        quote resolution that embeds only when needed.
+        included_ids: Optional set of node IDs included in the export. Used with
+                     embedded_quotes for reference-based resolution.
+
+    Returns:
+        str: Formatted text representation of the node tree
+    """
+    from backend.utils.privacy import can_user_view_tombstone
+
+    if processed_nodes is None:
+        processed_nodes = set()
+
+    parts = []
+    stack = [("node", node, index_path)]
+    while stack:
+        frame = stack.pop()
+        if frame[0] == "text":
+            parts.append(frame[1])
+            continue
+        kind, current, path = frame
+
+        if kind == "node":
+            # Avoid infinite loops from circular references
+            if current.id in processed_nodes:
+                continue
+            # Soft-deleted: render the tombstone shell (no content). The
+            # caller is responsible for the pre-deletion-access check on
+            # the entry node; child tombstones are checked at push time
+            # below via can_user_view_tombstone.
+            if current.deleted_at is not None:
+                kind = "tombstone"
+
+        if kind == "node":
+            processed_nodes.add(current.id)
+            parts.append(_format_node_text(
+                current, path, user_id, embedded_quotes, ai_blocked_ids))
+            children = _filtered_children(
+                current, filter_ai_usage, created_before, included_ids,
+                keep_tombstones=True)
+            child_frames = []
+            for i, child in enumerate(children):
+                child_index = f"{path}.{i+1}"
+                # Mark branches (when there are multiple children)
+                if len(children) > 1 and i > 0:
+                    child_frames.append(("text", "---\n**BRANCH**\n---\n\n"))
+                if child.deleted_at is not None:
+                    # Tombstone: render only with pre-deletion access;
+                    # otherwise skip (don't leak structural "something
+                    # is here").
+                    if user_id is None or can_user_view_tombstone(
+                            child, user_id):
+                        child_frames.append(
+                            ("tombstone", child, child_index))
+                    continue
+                if user_id and not can_user_access_node(child, user_id):
+                    child_frames.append(
+                        ("inaccessible", child, child_index))
+                    continue
+                child_frames.append(("node", child, child_index))
+            # LIFO: push reversed so children pop left-to-right,
+            # preserving the recursive version's pre-order output.
+            stack.extend(reversed(child_frames))
+            continue
+
+        # Placeholder shells (tombstone / inaccessible). Children still
+        # render — they may be alive, accessible replies. All children
+        # route through the "node" kind (cycle check + deleted routing)
+        # with no BRANCH markers, matching the old recursive helpers.
+        if kind == "tombstone":
+            placeholder = "[Node deleted by author]\n\n"
+            keep_tombstones = True
+        else:
+            placeholder = ("[Content not accessible — private node by "
+                           "another user]\n\n")
+            keep_tombstones = False
+        parts.append(_node_header_line(current, path) + placeholder)
+        processed_nodes.add(current.id)
+        children = _filtered_children(
+            current, filter_ai_usage, created_before, included_ids,
+            keep_tombstones=keep_tombstones)
+        stack.extend(reversed([
+            ("node", gc, f"{path}.{j+1}")
+            for j, gc in enumerate(children)
+        ]))
+
+    return "".join(parts)
 
 
 def _collect_all_nodes_in_tree(node, filter_ai_usage=False, created_before=None,
@@ -849,11 +743,15 @@ def _build_user_export_incremental(
             children_by_parent.setdefault(r.parent_id, []).append(r)
 
     def _subtree_has_alive(row):
-        if row.deleted_at is None:
-            return True
-        for child in children_by_parent.get(row.id, []):
-            if _subtree_has_alive(child):
+        # Iterative: recursion depth would equal thread depth, which
+        # overflows on very deep reply chains (same class of bug as the
+        # old recursive format_node_tree).
+        pending = [row]
+        while pending:
+            r = pending.pop()
+            if r.deleted_at is None:
                 return True
+            pending.extend(children_by_parent.get(r.id, []))
         return False
 
     # Entry points. Iterate CTE rows so quoted-pre-cutoff embeds added
@@ -1084,7 +982,7 @@ def build_user_export_content(
     # doesn't show a chain of `[Node deleted by author]` placeholders
     # for content the user explicitly removed. Mixed threads (some
     # alive, some deleted) still show through with tombstones rendered
-    # by `_render_tombstoned_node`.
+    # by format_node_tree's tombstone shell.
     all_top_level_nodes = [
         n for n in all_top_level_nodes if _thread_has_alive_node(n.id)
     ]

--- a/backend/scripts/backfill_llm_token_counts.py
+++ b/backend/scripts/backfill_llm_token_counts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Backfill Node.token_count for LLM-reply nodes to the chars/4 estimate.
+
+Historically `generate_llm_response` stored the provider-reported
+output_tokens into Node.token_count, while every other node-creation
+path (user text, voice transcripts, imports — both roles) stored
+approximate_token_count (chars/4). Provider tokenizer counts run ~1.5x
+chars/4 and drift upward across model generations, so windows mixing
+LLM replies with user text were skewed: profile chunk budgets filled
+"faster" on chat-heavy data, breaking the approx-equal-chunk promise
+and (combined with the rendered chars/4 re-measure) starving the
+chunked regen's stopping criterion.
+
+Going forward llm_completion stores chars/4; this script converges the
+historical rows. Real token usage remains in APICostLog.
+
+Usage (on prod, from repo root):
+    python backend/scripts/backfill_llm_token_counts.py            # dry run
+    python backend/scripts/backfill_llm_token_counts.py --execute
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from backend.app import create_app
+from backend.extensions import db
+from backend.models import Node
+from backend.utils.tokens import approximate_token_count
+
+BATCH_SIZE = 500
+
+
+def main(execute):
+    app = create_app()
+    with app.app_context():
+        ids = [r[0] for r in (db.session.query(Node.id)
+                              .filter(Node.node_type == "llm")
+                              .order_by(Node.id).all())]
+        print(f"{len(ids)} llm nodes to examine")
+        changed = 0
+        old_sum = 0
+        new_sum = 0
+        decrypt_failures = 0
+        for start in range(0, len(ids), BATCH_SIZE):
+            batch = (Node.query
+                     .filter(Node.id.in_(ids[start:start + BATCH_SIZE]))
+                     .all())
+            for node in batch:
+                try:
+                    text = node.get_content() or ""
+                except Exception:
+                    decrypt_failures += 1
+                    continue
+                new_count = approximate_token_count(text)
+                if new_count == node.token_count:
+                    continue
+                old_sum += node.token_count or 0
+                new_sum += new_count
+                changed += 1
+                if execute:
+                    node.token_count = new_count
+            if execute:
+                db.session.commit()
+            done = min(start + BATCH_SIZE, len(ids))
+            print(f"  {done}/{len(ids)} examined, {changed} to change",
+                  end="\r")
+        print()
+        print(f"{'updated' if execute else 'would update'}: {changed} nodes")
+        print(f"token_count sum over changed nodes: {old_sum} -> {new_sum} "
+              f"({new_sum - old_sum:+d})")
+        if decrypt_failures:
+            print(f"WARNING: {decrypt_failures} nodes failed to decrypt "
+                  f"(skipped)")
+        if not execute:
+            print("\nDry run — re-run with --execute to apply.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Backfill llm-node token_count to chars/4")
+    parser.add_argument("--execute", action="store_true",
+                        help="apply changes (default: dry run)")
+    args = parser.parse_args()
+    main(args.execute)

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -76,6 +76,25 @@ def build_user_export_content(user, max_tokens=None, filter_ai_usage=False,
     return _build(user, max_tokens, filter_ai_usage, **kwargs)
 
 
+def _has_more_source_after(user, ts):
+    """Any AI-readable source data newer than *ts*, in the anchor scope
+    the profile pipeline reads (own + addressed nodes)?
+
+    Used to tell a genuine corpus tail (defer to the next update cycle)
+    from a mid-corpus chunk that merely *renders* compactly — the
+    rendered chars/4 estimate and the stored token_count are different
+    measures, so a budget-full window can re-measure below
+    MIN_CHUNK_TOKENS while plenty of data remains beyond it.
+    """
+    from sqlalchemy import or_
+    from backend.models import Node
+    return Node.query.filter(
+        or_(Node.user_id == user.id, Node.human_owner_id == user.id),
+        Node.created_at > ts,
+        Node.ai_usage.in_(['chat', 'train']),
+    ).first() is not None
+
+
 class ProfileGenerationTask(Task):
     """Custom task class with error handling."""
 
@@ -576,10 +595,15 @@ def _do_initial_generation(self, user, model_id, context_window,
         5000
     )
 
-    # First pass: get metadata to decide if iterative is needed
+    # First pass: get metadata to decide if iterative is needed.
+    # engaged_threads: profiles read the user's full conversational
+    # scope — their own threads AND their replies in other users'
+    # threads (anchor-based selection, same scope incremental updates
+    # already use). The legacy authored_threads scope missed the latter
+    # entirely (#110).
     total_export = build_user_export_content(
         user, max_tokens=None, filter_ai_usage=True,
-        return_metadata=True
+        return_metadata=True, include_strategy="engaged_threads"
     )
 
     if not total_export or not total_export.get("content"):
@@ -865,7 +889,7 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         chunk = build_user_export_content(
             user, max_tokens=chunk_budget, filter_ai_usage=True,
             created_after=current_cutoff, chronological_order=True,
-            return_metadata=True
+            return_metadata=True, include_strategy="engaged_threads"
         )
 
         if not chunk or not chunk.get("content"):
@@ -874,19 +898,30 @@ def _chunked_profile_loop(self, user, model_id, update_template,
         chunk_tokens_est = chunk["token_count"]
         latest_ts = chunk["latest_node_created_at"]
 
-        # Skip undersized chunks. When first_chunk_prompt_fn is set,
-        # the first chunk is always processed (initial generation
-        # must produce something even with little data).
+        # Skip undersized chunks — but only when they are the genuine
+        # corpus tail. A chunk can re-measure below the threshold while
+        # being a full budget window (the rendered chars/4 estimate vs
+        # stored token_count unit mismatch); deferring those starves the
+        # rebuild mid-corpus. When first_chunk_prompt_fn is set, the
+        # first chunk is always processed (initial generation must
+        # produce something even with little data).
         is_first_with_gen = (
             first_chunk_prompt_fn and current_profile_content is None
         )
         if not is_first_with_gen and chunk_tokens_est < MIN_CHUNK_TOKENS:
+            if not _has_more_source_after(user, latest_ts):
+                logger.info(
+                    f"User {user.id}: stopping chunked loop — "
+                    f"tail chunk {chunk_num} has {chunk_tokens_est} "
+                    f"formatted tokens < {MIN_CHUNK_TOKENS} min threshold "
+                    f"and no data remains after {latest_ts}"
+                )
+                break
             logger.info(
-                f"User {user.id}: stopping chunked loop — "
-                f"chunk {chunk_num} has {chunk_tokens_est} formatted "
-                f"tokens < {MIN_CHUNK_TOKENS} min threshold"
+                f"User {user.id}: chunk {chunk_num} renders to "
+                f"{chunk_tokens_est} formatted tokens (< {MIN_CHUNK_TOKENS}) "
+                f"but more data remains after {latest_ts} — processing"
             )
-            break
 
         if is_first_with_gen:
             prompt = first_chunk_prompt_fn(chunk)
@@ -940,14 +975,9 @@ def _chunked_profile_loop(self, user, model_id, update_template,
             f"cumulative={cumulative_source_tokens}"
         )
 
-        # Check if there's more data after this cutoff
-        from backend.models import Node
-        has_more = Node.query.filter(
-            Node.user_id == user.id,
-            Node.created_at > current_cutoff,
-            Node.ai_usage.in_(['chat', 'train'])
-        ).first() is not None
-        if not has_more:
+        # Check if there's more data after this cutoff (anchor scope:
+        # own + addressed nodes, matching what the export reads)
+        if not _has_more_source_after(user, current_cutoff):
             break
 
     return current_profile_id, chunk_num, cumulative_source_tokens

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -1167,7 +1167,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
                 }
 
             llm_node.set_content(llm_text)
-            llm_node.token_count = output_tokens or approximate_token_count(llm_text)
+            # chars/4, NOT the provider's output_tokens: Node.token_count
+            # is the platform's stable information-content measure (gates,
+            # chunk windowing, balance decisions all sum it). Provider
+            # tokenizer counts drift upward across model generations
+            # (~1.5x chars/4 already), which skewed every window that
+            # mixed LLM replies with chars/4-counted user text. Real
+            # token usage lives in APICostLog.
+            llm_node.token_count = approximate_token_count(llm_text)
 
             # Step 5b: Execute tool calls if any
             tool_meta = None

--- a/backend/tasks/profile_batch.py
+++ b/backend/tasks/profile_batch.py
@@ -36,7 +36,7 @@ from backend.tasks.exports import (
     CHUNK_BUDGET, MIN_CHUNK_TOKENS,
     build_user_export_content, build_update_template, build_chunk_prompt,
     build_integration_messages, _save_profile, _load_prompt,
-    _collect_iterative_chain,
+    _collect_iterative_chain, _has_more_source_after,
 )
 
 logger = get_task_logger(__name__)
@@ -141,14 +141,27 @@ def _build_next_profile_request(user):
     cutoff = prev.source_data_cutoff if prev else None
     cumulative = (prev.source_tokens_used or 0) if prev else 0
 
+    # engaged_threads: profiles read the user's full conversational
+    # scope — own threads AND replies in other users' threads (#110).
+    # This also routes from-scratch builds (cutoff=None) through the
+    # incremental machinery, which renders budget windows correctly via
+    # entry-point preambles; the legacy authored_threads path silently
+    # returned None whenever no thread *root* fit the budget window.
     chunk = build_user_export_content(
         user, max_tokens=CHUNK_BUDGET, filter_ai_usage=True,
-        created_after=cutoff, chronological_order=True, return_metadata=True)
+        created_after=cutoff, chronological_order=True, return_metadata=True,
+        include_strategy="engaged_threads")
 
     have_chunk = bool(chunk and chunk.get("content"))
     is_first_initial = prev is None
+    # Tail-aware threshold: defer only a genuine corpus tail. A chunk
+    # can re-measure below MIN_CHUNK_TOKENS while being a full budget
+    # window (rendered chars/4 vs stored token_count unit mismatch);
+    # if data remains beyond it, process it anyway.
     big_enough = have_chunk and (
-        is_first_initial or chunk["token_count"] >= MIN_CHUNK_TOKENS)
+        is_first_initial
+        or chunk["token_count"] >= MIN_CHUNK_TOKENS
+        or _has_more_source_after(user, chunk["latest_node_created_at"]))
 
     if big_enough:
         if is_first_initial:

--- a/backend/tests/test_exports_incremental.py
+++ b/backend/tests/test_exports_incremental.py
@@ -1077,3 +1077,100 @@ class TestCollectAllNodesDeepChain:
         # root before A before A1; A's subtree (incl. A1) before sibling B
         assert order.index(root.id) < order.index(a.id) < order.index(a1.id)
         assert order.index(a1.id) < order.index(b.id)
+
+
+# ── 17. format_node_tree: deep chain (renderer recursion regression) ─────
+
+class TestFormatNodeTreeDeepChain:
+    def _deep_chain(self, alice, depth):
+        parent_id = None
+        for i in range(depth):
+            n = _make_node(
+                alice, parent_id=parent_id, content=f"link {i}",
+                ai_usage="chat", token_count=1,
+                created_at=DEC_15 + timedelta(seconds=i),
+            )
+            parent_id = n.id
+        _db.session.commit()
+
+    def test_deep_chain_renders_without_overflow(self, app):
+        """The renderer had the same one-frame-per-depth recursion the
+        collector had before c556e4d, one stage later in the pipeline —
+        it crashed unbudgeted exports (and thus from-scratch profile
+        regens) on the deepest-thread users."""
+        from backend.routes.export_data import format_node_tree
+
+        alice = _make_user("alice")
+        _db.session.commit()
+        depth = 1500  # comfortably past the default recursion limit (1000)
+        self._deep_chain(alice, depth)
+
+        root = Node.query.filter_by(
+            user_id=alice.id, parent_id=None
+        ).first()
+        text = format_node_tree(root, filter_ai_usage=True,
+                                user_id=alice.id)
+        assert "link 0" in text
+        assert f"link {depth - 1}" in text
+        assert text.count("link ") == depth
+
+    def test_deep_chain_full_export_paths(self, app):
+        """End-to-end: both the unbudgeted legacy export and the
+        incremental export survive a deep chain (renderer +
+        _subtree_has_alive)."""
+        alice = _make_user("alice")
+        _db.session.commit()
+        depth = 1500
+        self._deep_chain(alice, depth)
+
+        legacy = _build(alice, filter_ai_usage=True, return_metadata=True)
+        assert legacy["node_count"] == depth
+
+        incremental = _build(
+            alice, filter_ai_usage=True, return_metadata=True,
+            created_after=DEC_15 - timedelta(days=1),
+        )
+        assert incremental["node_count"] == depth
+
+    def test_structure_matches_recursive_output(self, app):
+        """Branch markers, chronological sibling order, tombstone shells,
+        and subtree-before-next-sibling ordering are preserved exactly."""
+        from backend.routes.export_data import format_node_tree
+
+        alice = _make_user("alice")
+        _db.session.commit()
+
+        root = _make_node(alice, content="ROOT", ai_usage="chat",
+                          token_count=1, created_at=DEC_15)
+        a = _make_node(alice, parent_id=root.id, content="CHILD-A",
+                       ai_usage="chat", token_count=1,
+                       created_at=DEC_15 + timedelta(hours=1))
+        b = _make_node(alice, parent_id=root.id, content="CHILD-B",
+                       ai_usage="chat", token_count=1,
+                       created_at=DEC_15 + timedelta(hours=2))
+        a1 = _make_node(alice, parent_id=a.id, content="GRANDCHILD-A1",
+                        ai_usage="chat", token_count=1,
+                        created_at=DEC_15 + timedelta(hours=3))
+        b.deleted_at = DEC_15 + timedelta(days=1)
+        b1 = _make_node(alice, parent_id=b.id, content="UNDER-TOMBSTONE",
+                        ai_usage="chat", token_count=1,
+                        created_at=DEC_15 + timedelta(hours=4))
+        _db.session.commit()
+
+        text = format_node_tree(root, filter_ai_usage=True,
+                                user_id=alice.id)
+
+        # A's subtree before sibling B; B is a tombstone shell whose
+        # child still renders; exactly one BRANCH (two siblings).
+        i_root = text.index("ROOT")
+        i_a = text.index("CHILD-A")
+        i_a1 = text.index("GRANDCHILD-A1")
+        i_tomb = text.index("[Node deleted by author]")
+        i_b1 = text.index("UNDER-TOMBSTONE")
+        assert i_root < i_a < i_a1 < i_tomb < i_b1
+        assert "CHILD-B" not in text  # deleted content never renders
+        assert text.count("---\n**BRANCH**\n---") == 1
+        # index paths: A=1.1, A1=1.1.1, B(tombstone)=1.2, B1=1.2.1
+        assert "[1.1] " in text and "[1.1.1] " in text
+        assert "[1.2] " in text and "[1.2.1] " in text
+        assert b1.id is not None  # silence unused warnings

--- a/backend/tests/test_profile_batch.py
+++ b/backend/tests/test_profile_batch.py
@@ -133,6 +133,67 @@ def test_build_next_request_chunk(app, monkeypatch):
     assert CUSTOM_ID_RE.match(req["request"]["custom_id"])
 
 
+def test_build_next_request_uses_engaged_scope(app, monkeypatch):
+    """Profile chunks read the anchor scope (own + addressed nodes, #110),
+    not the legacy authored_threads scope that missed the user's replies
+    in other users' threads and silently returned None whenever no
+    thread root fit the budget window."""
+    u = _user()
+    _prev_profile(u, datetime(2026, 5, 1))
+    db.session.commit()
+    export = MagicMock(
+        return_value={"content": "DATA", "token_count": 90000,
+                      "latest_node_created_at": datetime(2026, 6, 1)})
+    monkeypatch.setattr(pb, "build_user_export_content", export)
+    monkeypatch.setattr(pb, "build_update_template", lambda uid: (
+        "T {existing_profile}|{new_data}|{source_tokens_past}"
+        "|{source_tokens_new}|{ratio_percent}"))
+
+    pb._build_next_profile_request(u)
+
+    assert export.call_args.kwargs["include_strategy"] == "engaged_threads"
+
+
+def test_build_next_request_small_chunk_mid_corpus_still_chunks(
+        app, monkeypatch):
+    """A chunk that re-measures below MIN_CHUNK_TOKENS but has data
+    remaining beyond it is a full budget window, not a tail — it must
+    be processed, not deferred (the unit-mismatch starvation that froze
+    a regen at a months-old cutoff with ~320k stored tokens left)."""
+    u = _user()
+    _prev_profile(u, datetime(2026, 5, 1))
+    db.session.commit()
+    monkeypatch.setattr(pb, "build_user_export_content", MagicMock(
+        return_value={"content": "SMALL RENDER", "token_count": 50000,
+                      "latest_node_created_at": datetime(2026, 6, 1)}))
+    monkeypatch.setattr(pb, "build_update_template", lambda uid: (
+        "T {existing_profile}|{new_data}|{source_tokens_past}"
+        "|{source_tokens_new}|{ratio_percent}"))
+    monkeypatch.setattr(pb, "_has_more_source_after", lambda u, ts: True)
+
+    req = pb._build_next_profile_request(u)
+
+    assert req is not None and req["meta"]["kind"] == "chunk"
+
+
+def test_build_next_request_small_tail_defers(app, monkeypatch):
+    """A genuinely small tail (nothing beyond it) is deferred to the
+    next update cycle — the threshold's original purpose."""
+    u = _user()
+    _prev_profile(u, datetime(2026, 5, 1))
+    db.session.commit()
+    monkeypatch.setattr(pb, "build_user_export_content", MagicMock(
+        return_value={"content": "TINY TAIL", "token_count": 5000,
+                      "latest_node_created_at": datetime(2026, 6, 1)}))
+    monkeypatch.setattr(pb, "_has_more_source_after", lambda u, ts: False)
+    monkeypatch.setattr(pb, "build_integration_messages",
+                        lambda uid, pid: (None, None))
+
+    req = pb._build_next_profile_request(u)
+
+    assert req is None  # not a chunk; single-version chain → no integration
+
+
 def test_build_next_request_none_when_no_data(app, monkeypatch):
     u = _user()
     _prev_profile(u, datetime(2026, 5, 1))   # single version → no integration


### PR DESCRIPTION
Addresses #110 (profile-input side).

Four related fixes to the profile-generation pipeline, found while investigating two prod incidents: a user's full regen freezing at a 7-week-old cutoff with ~320k tokens unread, and another user's regen never producing a chunk at all.

## 1. Iterative `format_node_tree` (deep-thread RecursionError)

The renderer kept one Python frame per reply-depth (plus SQLAlchemy lazy-load frames per level) and crashed with `RecursionError` at ~970 depth in prod — the same failure `_collect_all_nodes_in_tree` had before `c556e4d` (PR #181 era), one pipeline stage later. Rewritten with an explicit work stack whose frames mirror the old mutual recursion (`node` / `tombstone` / `inaccessible`, literal separators as text frames), so output is byte-identical: branch markers, tombstone shells, chronological sibling order, subtree-before-next-sibling. `_subtree_has_alive` (also depth-recursive) made iterative too.

## 2. Profile generation reads the engaged/anchor scope (#110)

Profile chunk builds now pass `include_strategy="engaged_threads"` (own + addressed nodes, climb up to context / down to descendants) instead of the legacy `authored_threads` scope:

- Fixes #110 for profile inputs: the user's replies in **other users' threads** now reach their profile.
- Aligns from-scratch chunk 1 with the scope chunks 2+ (incremental updates) already used — chains are no longer mixed-scope.
- Kills a silent failure: the legacy *budgeted* path renders only threads whose **root** fit the budget window and returns `None` otherwise — which made the batch seeder skip one prod user every hour with no log line.

The legacy `authored_threads` path remains for the user-facing `/export/threads` dump (intentional — that's "my threads"). Its budgeted root-dropping quirk still exists for any future budgeted caller; noted here rather than fixed, since profile generation no longer touches it.

## 3. Stable token unit: chars/4 everywhere (`Node.token_count`)

Every node-creation path stored `approximate_token_count` (chars/4) — except native LLM replies, which stored the provider's `output_tokens`. Provider tokenizer counts run ~1.5× chars/4 (measured: a chunk chars/4 called 99,038 was 147,251 tokens to Anthropic) and drift upward across model generations. That mixed a depreciating currency into the column every balance decision sums: chunk budget windows filled "faster" on chat-heavy data, breaking the approx-equal-chunk promise that integration fairness depends on.

`Node.token_count` is now uniformly chars/4 — a stable information-content measure decoupled from tokenizer evolution. Real token usage stays in `APICostLog`. `backend/scripts/backfill_llm_token_counts.py` (dry-run by default) converges historical rows.

## 4. Tail-aware `MIN_CHUNK_TOKENS`

The threshold exists to defer small corpus *tails* to the next update cycle, but it compared the rendered chars/4 re-measure of a window selected by stored token_count — two different units. An LLM-reply-heavy 90k-stored window rendered to ~54k, fell under the 80k threshold, and terminated the regen mid-corpus (the 7-week-frozen-cutoff incident). Now a sub-threshold chunk is deferred **only when nothing remains beyond it** (`_has_more_source_after`, same cheap existence query as the loop's `has_more`); a mid-corpus window is processed regardless of how compactly it renders. Applied in both the sync loop and the batch builder.

## Tests

- Renderer: 1500-deep chain renders (direct + end-to-end via both export paths); structure regression test (branch markers, tombstone shell, ordering, index paths).
- Batch builder: engaged-scope kwarg; small-mid-corpus chunk still processed; genuine tail deferred.
- Full backend suite: 435 passed.

## Deploy follow-ups (prod)

1. Run `python backend/scripts/backfill_llm_token_counts.py --execute` (dry-run first).
2. Re-set `profile_needs_full_regen` for user 44 (the deep-thread user) — the seeder will now actually build his chunk 1.
3. User 27's frozen tail folds in automatically on the next update cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
