### PR TITLE
Per-node 100k-char cap with serial-chain splitting (backfill + UI consent dialog)

### DIFF
--- a/backend/routes/import_data.py
+++ b/backend/routes/import_data.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from backend.models import Node, User, UserProfile
 from backend.extensions import db
 from backend.utils.privacy import AI_ALLOWED
-from datetime import datetime
+from datetime import datetime, timedelta
 import hashlib
 import zipfile
 import io
@@ -94,6 +94,44 @@ def _chatgpt_msg_key(msg):
         msg.get('role', 'user'), msg.get('created_at', ''),
         msg.get('text', ''),
     )
+
+
+def _add_imported_message_nodes(user_id, human_owner_id, parent_id,
+                                node_type, llm_model, node_content,
+                                privacy_level, ai_usage, source_key,
+                                msg_created_at):
+    """Create the node(s) for one imported message, splitting content
+    above NODE_CHAR_CAP into a serial parent→child chain.
+
+    source_key lands on the chain TIP (last part): both the dedup index
+    and the next message's parent resolve via source_key, so keeping it
+    on the tip means re-imports skip the whole message and follow-ups
+    chain after the full content — identical to a fresh import.
+
+    Returns (tip_node, nodes_created_count).
+    """
+    from backend.utils.node_split import split_text_at_cap
+    segments = split_text_at_cap(node_content)
+    tip = None
+    for j, seg in enumerate(segments):
+        n = Node(
+            user_id=user_id,
+            human_owner_id=human_owner_id,
+            parent_id=parent_id if tip is None else tip.id,
+            node_type=node_type,
+            llm_model=llm_model,
+            content=seg,
+            token_count=approximate_token_count(seg),
+            privacy_level=privacy_level,
+            ai_usage=ai_usage,
+            source_key=source_key if j == len(segments) - 1 else None,
+        )
+        if msg_created_at:
+            n.created_at = msg_created_at + timedelta(milliseconds=j)
+        db.session.add(n)
+        db.session.flush()
+        tip = n
+    return tip, len(segments)
 
 
 def _deleted_match_response(keys, deleted_keys, on_deleted):
@@ -393,33 +431,30 @@ def confirm_import():
                     except (ValueError, TypeError):
                         pass
 
-                # Create node
-                node = Node(
+                # Create node(s) — files above the per-node cap split
+                # into a serial chain
+                tip, created_count = _add_imported_message_nodes(
                     user_id=current_user.id,
                     human_owner_id=current_user.id,
                     parent_id=parent_id,
                     node_type="user",
-                    content=node_content,
-                    token_count=approximate_token_count(node_content),
+                    llm_model=None,
+                    node_content=node_content,
                     privacy_level=privacy_level,
                     ai_usage=ai_usage,
                     source_key=source_key,
+                    msg_created_at=node_created_at,
                 )
 
-                if node_created_at:
-                    node.created_at = node_created_at
-
-                db.session.add(node)
-                db.session.flush()  # Get the node ID
-
-                key_index[source_key] = node.id
-                parent_id = node.id
-                nodes_created += 1
+                key_index[source_key] = tip.id
+                parent_id = tip.id
+                nodes_created += created_count
 
             thread_count = 1
 
         else:  # separate_nodes
             # Create separate top-level threads for each file
+            threads_created = 0
             for file_data in files_sorted:
                 filename = file_data.get('filename_without_ext', 'Untitled')
                 content = file_data.get('content', '')
@@ -454,26 +489,25 @@ def confirm_import():
                     except (ValueError, TypeError):
                         pass
 
-                # Create top-level node (parent_id=None)
-                node = Node(
+                # Create top-level node (parent_id=None); files above the
+                # per-node cap split into a serial chain under the root
+                _, created_count = _add_imported_message_nodes(
                     user_id=current_user.id,
                     human_owner_id=current_user.id,
                     parent_id=None,
                     node_type="user",
-                    content=node_content,
-                    token_count=approximate_token_count(node_content),
+                    llm_model=None,
+                    node_content=node_content,
                     privacy_level=privacy_level,
                     ai_usage=ai_usage,
                     source_key=source_key,
+                    msg_created_at=node_created_at,
                 )
 
-                if node_created_at:
-                    node.created_at = node_created_at
+                nodes_created += created_count
+                threads_created += 1
 
-                db.session.add(node)
-                nodes_created += 1
-
-            thread_count = nodes_created
+            thread_count = threads_created
 
         nodes_updated = _apply_settings_to_skipped(
             skipped_alive_ids, privacy_level, ai_usage
@@ -953,33 +987,29 @@ def confirm_claude_import():
                     except (ValueError, TypeError):
                         pass
 
-                node = Node(
-                    user_id=llm_user.id if is_assistant else current_user.id,
-                    human_owner_id=current_user.id,
-                    parent_id=parent_id,
-                    node_type="llm" if is_assistant else "user",
-                    llm_model="claude-web" if is_assistant else None,
-                    content=node_content,
-                    token_count=approximate_token_count(node_content),
-                    privacy_level=privacy_level,
-                    ai_usage=ai_usage,
-                    source_key=source_key,
-                )
-
-                if msg_created_at:
-                    node.created_at = msg_created_at
-
                 # A node created without a parent starts a new thread;
                 # nodes chained onto an existing copy extend an old one.
                 if parent_id is None:
                     conv_started_new_thread = True
 
-                db.session.add(node)
-                db.session.flush()
+                tip, created_count = _add_imported_message_nodes(
+                    user_id=(
+                        llm_user.id if is_assistant else current_user.id
+                    ),
+                    human_owner_id=current_user.id,
+                    parent_id=parent_id,
+                    node_type="llm" if is_assistant else "user",
+                    llm_model="claude-web" if is_assistant else None,
+                    node_content=node_content,
+                    privacy_level=privacy_level,
+                    ai_usage=ai_usage,
+                    source_key=source_key,
+                    msg_created_at=msg_created_at,
+                )
 
-                key_index[source_key] = node.id
-                parent_id = node.id
-                nodes_created += 1
+                key_index[source_key] = tip.id
+                parent_id = tip.id
+                nodes_created += created_count
 
             if conv_started_new_thread:
                 thread_count += 1
@@ -1678,7 +1708,12 @@ def confirm_chatgpt_import():
                 # Get model slug for assistant messages
                 model_slug = msg.get('model', '') if is_assistant else None
 
-                node = Node(
+                # A node created without a parent starts a new thread;
+                # nodes chained onto an existing copy extend an old one.
+                if parent_id is None:
+                    conv_started_new_thread = True
+
+                tip, created_count = _add_imported_message_nodes(
                     user_id=(
                         llm_user.id if is_assistant else current_user.id
                     ),
@@ -1688,27 +1723,16 @@ def confirm_chatgpt_import():
                     llm_model=model_slug or (
                         "chatgpt" if is_assistant else None
                     ),
-                    content=node_content,
-                    token_count=approximate_token_count(node_content),
+                    node_content=node_content,
                     privacy_level=privacy_level,
                     ai_usage=ai_usage,
                     source_key=source_key,
+                    msg_created_at=msg_created_at,
                 )
 
-                if msg_created_at:
-                    node.created_at = msg_created_at
-
-                # A node created without a parent starts a new thread;
-                # nodes chained onto an existing copy extend an old one.
-                if parent_id is None:
-                    conv_started_new_thread = True
-
-                db.session.add(node)
-                db.session.flush()
-
-                key_index[source_key] = node.id
-                parent_id = node.id
-                nodes_created += 1
+                key_index[source_key] = tip.id
+                parent_id = tip.id
+                nodes_created += created_count
 
             if conv_started_new_thread:
                 thread_count += 1

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -649,9 +649,16 @@ def create_node():
     if err is not None:
         return err
 
+    # Content above the per-node cap is auto-split into a serial chain
+    # of nodes (first segment keeps this node's id). A single oversized
+    # node stalls chunked profile generation — see utils/node_split.py.
+    from backend.utils.node_split import split_text_at_cap, split_node_into_chain
+    segments = split_text_at_cap(content)
+    first_content = segments[0]
+
     # Calculate token count before encryption
     from backend.utils.tokens import approximate_token_count as _atc
-    token_count = _atc(content)
+    token_count = _atc(first_content)
 
     node = Node(
         user_id=current_user.id,
@@ -663,13 +670,17 @@ def create_node():
         privacy_level=privacy_level,
         ai_usage=ai_usage
     )
-    node.set_content(content)
+    node.set_content(first_content)
     db.session.add(node)
     db.session.flush()
 
+    parts = split_node_into_chain(node, segments=segments)
+
     # Attach context artifacts for any placeholders in the content
     from backend.utils.context_artifacts import sync_context_artifacts
-    sync_context_artifacts(node.id, current_user.id, content)
+    sync_context_artifacts(node.id, current_user.id, first_content)
+    for part in parts:
+        sync_context_artifacts(part.id, current_user.id, part.get_content())
 
     try:
         db.session.commit()
@@ -686,7 +697,9 @@ def create_node():
         "created_at": iso_utc(node.created_at),
         "username": current_user.username,
         "privacy_level": node.privacy_level,
-        "ai_usage": node.ai_usage
+        "ai_usage": node.ai_usage,
+        "split_into": 1 + len(parts),
+        "tip_id": parts[-1].id if parts else node.id
     }), 201
 
 # Update (edit) a node. (The node's prior content is saved in NodeVersion.)
@@ -702,6 +715,19 @@ def update_node(node_id):
     new_content = data.get("content")
     if new_content is None:
         return jsonify({"error": "Content required for update"}), 400
+
+    # Edits don't auto-split (re-parenting children mid-edit would be
+    # surprising); above-cap content is rejected and the UI guides the
+    # user to split into separate entries instead.
+    from backend.utils.node_split import NODE_CHAR_CAP
+    if len(new_content) > NODE_CHAR_CAP:
+        return jsonify({
+            "error": (
+                f"Content exceeds the {NODE_CHAR_CAP:,}-character "
+                f"per-entry limit. Please split it into multiple entries."
+            ),
+            "char_cap": NODE_CHAR_CAP,
+        }), 422
 
     # Handle privacy settings updates (optional)
     if "privacy_level" in data:

--- a/backend/routes/textmode.py
+++ b/backend/routes/textmode.py
@@ -65,6 +65,18 @@ def start_conversation():
     if not content or not content.strip():
         return jsonify({"error": "Content is required"}), 400
 
+    # Agentic conversations don't auto-split; the UI routes oversized
+    # content through the plain entry path (which splits server-side).
+    from backend.utils.node_split import NODE_CHAR_CAP
+    if len(content) > NODE_CHAR_CAP:
+        return jsonify({
+            "error": (
+                f"Content exceeds the {NODE_CHAR_CAP:,}-character "
+                f"per-entry limit."
+            ),
+            "char_cap": NODE_CHAR_CAP,
+        }), 422
+
     if privacy_level not in VALID_PRIVACY_LEVELS:
         return jsonify({"error": f"Invalid privacy_level: {privacy_level}"}), 400
 
@@ -156,6 +168,15 @@ def add_message(conversation_id):
     parent_id = data.get("parent_id")
     if not content or not content.strip():
         return jsonify({"error": "Content is required"}), 400
+    from backend.utils.node_split import NODE_CHAR_CAP
+    if len(content) > NODE_CHAR_CAP:
+        return jsonify({
+            "error": (
+                f"Content exceeds the {NODE_CHAR_CAP:,}-character "
+                f"per-entry limit."
+            ),
+            "char_cap": NODE_CHAR_CAP,
+        }), 422
     if not parent_id:
         return jsonify({"error": "parent_id is required"}), 400
 

--- a/backend/scripts/split_oversized_nodes.py
+++ b/backend/scripts/split_oversized_nodes.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Split existing nodes above NODE_CHAR_CAP into serial chains.
+
+Companion backfill for the per-node content cap (utils/node_split.py):
+the cap is enforced at creation going forward; this converges the
+historical oversized nodes (e.g. the ~900KB single-node paste that
+stalled a user's chunked profile regen for five weeks).
+
+Per node: the original keeps its id and the first segment (preserving
+quotes, source_key, audio linkage, artifacts); the remainder becomes
+new child nodes chained in series with +1ms created_at steps; existing
+children re-parent onto the last part. The original full content is
+preserved as a NodeVersion for recoverability.
+
+Usage (on prod, from repo root):
+    python backend/scripts/split_oversized_nodes.py            # dry run
+    python backend/scripts/split_oversized_nodes.py --execute
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from sqlalchemy import func
+
+from backend.app import create_app
+from backend.extensions import db
+from backend.models import Node, NodeVersion
+from backend.utils.node_split import (
+    NODE_CHAR_CAP, split_text_at_cap, split_node_into_chain,
+)
+
+
+def main(execute):
+    app = create_app()
+    with app.app_context():
+        # Prefilter on stored (possibly encrypted) length — ciphertext
+        # length is >= plaintext length, so this over-selects and never
+        # misses; the decrypted check below decides.
+        candidate_ids = [r[0] for r in (
+            db.session.query(Node.id)
+            .filter(func.length(Node.content) > NODE_CHAR_CAP,
+                    Node.deleted_at.is_(None))
+            .order_by(Node.id).all())]
+        print(f"{len(candidate_ids)} candidate node(s) by stored length")
+        split_count = 0
+        parts_total = 0
+        for nid in candidate_ids:
+            node = db.session.get(Node, nid)
+            try:
+                text = node.get_content() or ""
+            except Exception:
+                print(f"  node {nid}: decrypt failed — skipped")
+                continue
+            segments = split_text_at_cap(text)
+            if len(segments) <= 1:
+                continue
+            print(f"  node {nid}: user={node.user_id} type={node.node_type} "
+                  f"{len(text)} chars -> {len(segments)} parts")
+            if not execute:
+                split_count += 1
+                parts_total += len(segments)
+                continue
+            version = NodeVersion(node_id=node.id)
+            version.set_content(text)
+            db.session.add(version)
+            parts = split_node_into_chain(node, segments=segments)
+            db.session.commit()
+            split_count += 1
+            parts_total += 1 + len(parts)
+        print(f"\n{'split' if execute else 'would split'}: "
+              f"{split_count} node(s) into {parts_total} part(s) total")
+        if not execute:
+            print("Dry run — re-run with --execute to apply.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Split oversized nodes into serial chains")
+    parser.add_argument("--execute", action="store_true",
+                        help="apply changes (default: dry run)")
+    args = parser.parse_args()
+    main(args.execute)

--- a/backend/tests/test_node_split.py
+++ b/backend/tests/test_node_split.py
@@ -1,0 +1,232 @@
+"""Tests for the per-node content cap and serial-chain splitting.
+
+A single node above the chunk budget stalls chunked profile generation
+(the budget window admits it alone, the resolver can't fit it, the
+export returns None and the resume cursor never advances). The cap +
+split keep every node below the budget while preserving content
+losslessly across a serial parent→child chain.
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db  # noqa: E402
+from backend.models import User, Node  # noqa: E402
+from backend.utils.node_split import (  # noqa: E402
+    NODE_CHAR_CAP, split_text_at_cap, split_node_into_chain,
+)
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+# ── split_text_at_cap ───────────────────────────────────────────────────
+
+def test_short_text_untouched():
+    assert split_text_at_cap("hello\nworld", cap=100) == ["hello\nworld"]
+
+
+def test_exact_cap_untouched():
+    text = "x" * 100
+    assert split_text_at_cap(text, cap=100) == [text]
+
+
+def test_lossless_newline_split():
+    lines = [f"line {i} " + "x" * 30 for i in range(100)]
+    text = "\n".join(lines)
+    segments = split_text_at_cap(text, cap=500)
+    assert len(segments) > 1
+    assert "".join(segments) == text
+    for seg in segments:
+        assert len(seg) <= 500
+    # No segment starts mid-line: every boundary fell on a newline,
+    # so each earlier segment ends with one.
+    for seg in segments[:-1]:
+        assert seg.endswith("\n")
+
+
+def test_single_long_line_hard_cut():
+    text = "x" * 1200  # no newlines at all
+    segments = split_text_at_cap(text, cap=500)
+    assert segments == ["x" * 500, "x" * 500, "x" * 200]
+    assert "".join(segments) == text
+
+
+def test_mixed_long_line_and_newlines():
+    text = "short\n" + "y" * 800 + "\ntail"
+    segments = split_text_at_cap(text, cap=500)
+    assert "".join(segments) == text
+    for seg in segments:
+        assert len(seg) <= 500
+
+
+def test_default_cap_value():
+    assert NODE_CHAR_CAP == 100_000
+
+
+# ── split_node_into_chain ───────────────────────────────────────────────
+
+def _user(username="alice"):
+    u = User(username=username, approved=True, plan="alpha")
+    db.session.add(u)
+    db.session.flush()
+    return u
+
+
+def _node(user, content, parent_id=None, **kw):
+    n = Node(user_id=user.id, human_owner_id=user.id, parent_id=parent_id,
+             node_type=kw.pop("node_type", "user"),
+             privacy_level="private", ai_usage="chat",
+             token_count=len(content) // 4, **kw)
+    n.set_content(content)
+    n.created_at = kw.get("created_at", datetime(2026, 6, 1, 12, 0, 0))
+    db.session.add(n)
+    db.session.flush()
+    return n
+
+
+def test_chain_split_preserves_content_and_order(app):
+    user = _user()
+    lines = "\n".join(f"row {i} " + "z" * 40 for i in range(60))
+    node = _node(user, lines)
+    reply = _node(user, "a reply", parent_id=node.id)
+    db.session.commit()
+
+    parts = split_node_into_chain(
+        node, segments=split_text_at_cap(lines, cap=600))
+    db.session.commit()
+
+    assert len(parts) >= 1
+    # Lossless reassembly across the chain
+    chain_text = node.get_content() + "".join(
+        p.get_content() for p in parts)
+    assert chain_text == lines
+    # Serial chain: each part is the child of the previous
+    prev = node
+    for p in parts:
+        assert p.parent_id == prev.id
+        assert p.created_at > prev.created_at
+        assert p.node_type == node.node_type
+        assert p.ai_usage == node.ai_usage
+        assert p.privacy_level == node.privacy_level
+        prev = p
+    # Pre-existing reply re-parented onto the chain tip
+    assert reply.parent_id == parts[-1].id
+    # Original keeps its id and the first segment only
+    assert node.token_count == len(node.get_content()) // 4
+
+
+def test_chain_split_noop_below_cap(app):
+    user = _user()
+    node = _node(user, "small content")
+    db.session.commit()
+    assert split_node_into_chain(node) == []
+    assert node.get_content() == "small content"
+
+
+# ── API: create auto-splits, edit rejects ───────────────────────────────
+
+@pytest.fixture
+def client(app, monkeypatch):
+    from flask_login import LoginManager
+    import backend.routes.nodes as nodes_module
+
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return db.session.get(User, int(user_id))
+
+    app.register_blueprint(nodes_module.nodes_bp, url_prefix="/api/nodes")
+    with app.app_context():
+        user = _user("poster")
+        db.session.commit()
+        uid = user.id
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(uid)
+        sess["_fresh"] = True
+    return client
+
+
+def test_create_node_auto_splits(app, client, monkeypatch):
+    monkeypatch.setattr(
+        "backend.utils.context_artifacts.sync_context_artifacts",
+        lambda *a, **k: None)
+    big = "\n".join(f"line {i} " + "q" * 90 for i in range(1500))
+    assert len(big) > NODE_CHAR_CAP
+    res = client.post("/api/nodes/", json={
+        "content": big, "ai_usage": "chat", "privacy_level": "private"})
+    assert res.status_code == 201
+    data = res.get_json()
+    assert data["split_into"] >= 2
+    with app.app_context():
+        first = db.session.get(Node, data["id"])
+        chain = [first]
+        cur = first
+        while True:
+            child = Node.query.filter_by(parent_id=cur.id).first()
+            if child is None:
+                break
+            chain.append(child)
+            cur = child
+        assert len(chain) == data["split_into"]
+        assert "".join(n.get_content() for n in chain) == big
+        for n in chain:
+            assert len(n.get_content()) <= NODE_CHAR_CAP
+        assert chain[-1].id == data["tip_id"]
+
+
+def test_create_small_node_not_split(app, client, monkeypatch):
+    monkeypatch.setattr(
+        "backend.utils.context_artifacts.sync_context_artifacts",
+        lambda *a, **k: None)
+    res = client.post("/api/nodes/", json={
+        "content": "just a note", "ai_usage": "chat",
+        "privacy_level": "private"})
+    assert res.status_code == 201
+    data = res.get_json()
+    assert data["split_into"] == 1
+    assert data["tip_id"] == data["id"]
+
+
+def test_update_node_rejects_oversized(app, client, monkeypatch):
+    monkeypatch.setattr(
+        "backend.utils.context_artifacts.sync_context_artifacts",
+        lambda *a, **k: None)
+    res = client.post("/api/nodes/", json={
+        "content": "v1", "ai_usage": "chat", "privacy_level": "private"})
+    nid = res.get_json()["id"]
+    res = client.put(f"/api/nodes/{nid}", json={
+        "content": "x" * (NODE_CHAR_CAP + 1)})
+    assert res.status_code == 422
+    assert res.get_json()["char_cap"] == NODE_CHAR_CAP

--- a/backend/utils/node_split.py
+++ b/backend/utils/node_split.py
@@ -1,0 +1,97 @@
+"""Per-node content size cap and serial-chain splitting.
+
+A single node larger than the profile chunk budget stalls chunked
+profile generation: the chronological budget window admits it alone,
+the quote resolver cannot fit it, and the export returns None — so the
+resume cursor never advances past it (observed in prod: a ~900KB
+financial-statements paste pinned a user's profile chain at one cutoff
+for five weeks). The cap keeps every node comfortably below the
+90k-token chunk budget (100k chars ≈ 25k tokens ≈ 1/3 of a chunk).
+
+Splitting is lossless — segments concatenate back to the original
+text — and boundaries fall on newlines unless a single line exceeds
+the cap by itself. Split parts are chained in series (each part the
+parent of the next) with strictly increasing created_at, so context
+assembly reads them as one continuous text and chunked exports can
+window between them.
+"""
+
+from datetime import timedelta
+
+NODE_CHAR_CAP = 100_000
+
+
+def split_text_at_cap(text, cap=NODE_CHAR_CAP):
+    """Split *text* into segments of <= cap chars at newline boundaries.
+
+    Lossless: ``"".join(result) == text``. The boundary newline stays at
+    the end of the earlier segment. A single line longer than the cap is
+    hard-cut at the cap.
+    """
+    if text is None or len(text) <= cap:
+        return [text]
+    segments = []
+    rest = text
+    while len(rest) > cap:
+        cut = rest.rfind("\n", 0, cap)
+        cut_at = cut + 1 if cut != -1 else cap
+        segments.append(rest[:cut_at])
+        rest = rest[cut_at:]
+    if rest:
+        segments.append(rest)
+    return segments
+
+
+def split_node_into_chain(node, segments=None):
+    """Trim *node* to the first segment and chain the remainder as new
+    serial child nodes (each part the parent of the next).
+
+    The original node keeps its id — and therefore its quotes,
+    source_key, audio linkage, and artifacts. Pre-existing children of
+    *node* are re-parented onto the last part, so replies continue after
+    the full content. Each part's created_at is +1ms from the previous,
+    keeping chronological windowing and the profile resume cursor
+    strictly ordered.
+
+    Returns the list of newly created part nodes (empty when no split
+    is needed). The caller commits.
+    """
+    from backend.extensions import db
+    from backend.models import Node
+    from backend.utils.tokens import approximate_token_count
+
+    if segments is None:
+        segments = split_text_at_cap(node.get_content())
+    if len(segments) <= 1:
+        return []
+
+    original_children = Node.query.filter(
+        Node.parent_id == node.id).all()
+
+    node.set_content(segments[0])
+    node.token_count = approximate_token_count(segments[0])
+
+    parts = []
+    prev = node
+    for i, seg in enumerate(segments[1:], start=1):
+        part = Node(
+            user_id=node.user_id,
+            human_owner_id=node.human_owner_id,
+            parent_id=prev.id,
+            node_type=node.node_type,
+            llm_model=node.llm_model,
+            privacy_level=node.privacy_level,
+            ai_usage=node.ai_usage,
+            token_count=approximate_token_count(seg),
+        )
+        part.set_content(seg)
+        part.created_at = node.created_at + timedelta(milliseconds=i)
+        db.session.add(part)
+        db.session.flush()
+        parts.append(part)
+        prev = part
+
+    for child in original_children:
+        child.parent_id = prev.id
+
+    return parts

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -5,6 +5,7 @@ import { useUser } from "../contexts/UserContext";
 import StreamingMicButton from "./StreamingMicButton";
 import PrivacySelector from "./PrivacySelector";
 import RegenerateTtsDialog from "./RegenerateTtsDialog";
+import SplitContentDialog, { NODE_CHAR_CAP } from "./SplitContentDialog";
 import { useOnlineStatus } from "../hooks/useOnlineStatus";
 import api from "../api";
 import { uploadFileInChunks } from "../utils/chunkedUpload";
@@ -27,6 +28,14 @@ const NodeForm = forwardRef(
     // When editing an entry that has generated TTS, ask whether to keep or
     // regenerate the now-stale audio before saving (#66).
     const [showTtsDialog, setShowTtsDialog] = useState(false);
+
+    // Per-entry character cap: oversized new entries are split
+    // server-side into serially connected entries after explicit
+    // consent (paste or submit opens the dialog). pendingPaste holds
+    // paste text awaiting that consent.
+    const [showSplitDialog, setShowSplitDialog] = useState(false);
+    const [pendingPaste, setPendingPaste] = useState(null);
+    const [splitAcknowledged, setSplitAcknowledged] = useState(false);
 
     // Remember the user's last privacy / AI-usage choices for fresh
     // top-level entries (#63), so they don't have to re-pick every time.
@@ -285,7 +294,7 @@ const NodeForm = forwardRef(
       setContent("");
     };
 
-    const handleSubmit = async (event, regenerateTts) => {
+    const handleSubmit = async (event, regenerateTts, splitConfirmed) => {
       event && event.preventDefault();
       // Validate: require content or audio
       if (!editMode && uploadedFile) {
@@ -305,6 +314,25 @@ const NodeForm = forwardRef(
       ) {
         setShowTtsDialog(true);
         return;
+      }
+
+      // Per-entry character cap. New entries can split into serially
+      // connected entries (server-side, after consent via the dialog);
+      // edits and custom-submit conversations can't, so they get a
+      // plain error instead.
+      if (content.length > NODE_CHAR_CAP && !uploadedFile) {
+        if (editMode || onSubmitOverride) {
+          setError(
+            `This entry is ${content.length.toLocaleString()} characters — ` +
+            `above the ${NODE_CHAR_CAP.toLocaleString()}-character limit. ` +
+            `Please move part of it into separate entries.`
+          );
+          return;
+        }
+        if (!splitAcknowledged && !splitConfirmed) {
+          setShowSplitDialog(true);
+          return;
+        }
       }
 
       setLoading(true);
@@ -336,7 +364,8 @@ const NodeForm = forwardRef(
         // letting the user click LLM Response manually later after any
         // edits or follow-up nodes they want to add first.
         if (useAgenticPrompt && !editMode && !uploadedFile
-            && !streamingSessionId && !parentId && aiUsage !== 'none') {
+            && !streamingSessionId && !parentId && aiUsage !== 'none'
+            && content.length <= NODE_CHAR_CAP) {
           const res = await api.post('/textmode/start', {
             content,
             privacy_level: privacyLevel,
@@ -555,6 +584,29 @@ const NodeForm = forwardRef(
             if (!editMode && uploadedFile) {
               setUploadedFile(null);
             }
+          }}
+          onPaste={(e) => {
+            // Per-entry cap: intercept pastes that would exceed it and
+            // offer to split (new entries) or explain the limit
+            // (edits / custom-submit conversations).
+            const pasted = e.clipboardData
+              ? e.clipboardData.getData("text") : "";
+            if (!pasted) return;
+            const el = e.target;
+            const next = content.slice(0, el.selectionStart)
+              + pasted + content.slice(el.selectionEnd);
+            if (next.length <= NODE_CHAR_CAP) return;
+            e.preventDefault();
+            if (editMode || onSubmitOverride) {
+              setError(
+                `Pasting this would make the entry ` +
+                `${next.length.toLocaleString()} characters — above the ` +
+                `${NODE_CHAR_CAP.toLocaleString()}-character limit.`
+              );
+              return;
+            }
+            setPendingPaste(next);
+            setShowSplitDialog(true);
           }}
           rows={compact ? 3 : 6}
           style={{
@@ -912,6 +964,29 @@ const NodeForm = forwardRef(
           setShowTtsDialog(false);
           // Resume the save with the user's choice (no event object).
           handleSubmit(null, regenerate);
+        }}
+      />
+      <SplitContentDialog
+        open={showSplitDialog}
+        charCount={pendingPaste ? pendingPaste.length : content.length}
+        onClose={() => {
+          setShowSplitDialog(false);
+          setPendingPaste(null);
+        }}
+        onConfirm={() => {
+          setShowSplitDialog(false);
+          setSplitAcknowledged(true);
+          if (pendingPaste) {
+            // Paste path: insert the text; the split happens at save.
+            setContent(pendingPaste);
+            saveDraft(pendingPaste);
+            setHasDraft(true);
+            setPendingPaste(null);
+          } else {
+            // Submit path: resume the save (no event object); the
+            // server splits into connected entries.
+            handleSubmit(null, undefined, true);
+          }
         }}
       />
       </>

--- a/frontend/src/components/SplitContentDialog.js
+++ b/frontend/src/components/SplitContentDialog.js
@@ -1,0 +1,122 @@
+import React, { useEffect } from "react";
+
+export const NODE_CHAR_CAP = 100000;
+
+const overlayStyle = {
+  position: "fixed",
+  top: 0, left: 0, right: 0, bottom: 0,
+  backgroundColor: "rgba(0,0,0,0.7)",
+  backdropFilter: "blur(8px)",
+  WebkitBackdropFilter: "blur(8px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+};
+
+const cardStyle = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "12px",
+  padding: "2rem",
+  width: "440px",
+  maxWidth: "90vw",
+  maxHeight: "90vh",
+  overflowY: "auto",
+};
+
+const titleStyle = {
+  fontFamily: "var(--serif)",
+  fontSize: "1.4rem",
+  fontWeight: 400,
+  color: "var(--text-primary)",
+  margin: 0,
+  marginBottom: "1rem",
+};
+
+const bodyStyle = {
+  fontFamily: "var(--sans)",
+  fontSize: "0.92rem",
+  fontWeight: 300,
+  color: "var(--text-secondary)",
+  lineHeight: 1.6,
+  marginBottom: "1.5rem",
+};
+
+const buttonRowStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+};
+
+const buttonBaseStyle = {
+  fontFamily: "var(--sans)",
+  fontSize: "0.9rem",
+  fontWeight: 400,
+  padding: "10px 16px",
+  borderRadius: "6px",
+  cursor: "pointer",
+  textAlign: "left",
+  background: "var(--bg-deep)",
+  border: "1px solid var(--border)",
+  transition: "border-color 0.15s ease, background 0.15s ease",
+};
+
+/**
+ * Dialog shown when content exceeds the per-entry character cap
+ * (NODE_CHAR_CAP). Long entries are split server-side into a series of
+ * connected entries — one flowing text for the AI, separate entries in
+ * the thread. onConfirm proceeds with the split; onClose cancels.
+ */
+function SplitContentDialog({ open, charCount, onClose, onConfirm }) {
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const parts = Math.max(2, Math.ceil(charCount / NODE_CHAR_CAP));
+
+  return (
+    <div onClick={onClose} style={overlayStyle}>
+      <div onClick={(e) => e.stopPropagation()} style={cardStyle}>
+        <h2 style={titleStyle}>Long entry</h2>
+        <div style={bodyStyle}>
+          This text is {charCount.toLocaleString()} characters — above the{" "}
+          {NODE_CHAR_CAP.toLocaleString()}-character limit for a single
+          entry. It can be saved as ~{parts} connected entries: they read
+          as one continuous text and stay together in the thread.
+        </div>
+        <div style={buttonRowStyle}>
+          <button
+            onClick={onConfirm}
+            style={{ ...buttonBaseStyle, color: "var(--accent)" }}
+          >
+            <div style={{ fontWeight: 500 }}>
+              Split into ~{parts} connected entries
+            </div>
+            <div style={{
+              fontSize: "0.82rem", color: "var(--text-muted)",
+              fontWeight: 300, marginTop: "2px",
+            }}>
+              Split happens on line breaks — no line is cut in half.
+            </div>
+          </button>
+          <button
+            onClick={onClose}
+            style={{ ...buttonBaseStyle, color: "var(--text-secondary)" }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SplitContentDialog;


### PR DESCRIPTION
Follow-up to #211. Closes the remaining mechanism from the profile-chunking investigation: a single node larger than the chunk budget (prod case: a ~900KB financial-statements paste, node-level `token_count` 173k vs the 90k chunk budget) stalls chunked profile generation — the chronological budget window admits it alone, the quote resolver can't fit it, the export returns `None`, and the resume cursor never advances past it. That one node pinned a user's profile chain at a single cutoff for five weeks.

## Design

**Cap**: `NODE_CHAR_CAP = 100,000` chars (~25k tokens ≈ 1/3 of the 90k-token chunk budget, so chunk windows always fit several nodes and make progress). Voice transcripts (60min ≈ 50k chars) and LLM replies (≤ ~64k chars at max output) never split.

**Split semantics** (`backend/utils/node_split.py`):
- Lossless: segments concatenate back to the original text; boundaries fall on newlines (hard cut only if a single line exceeds the cap by itself).
- Serial chain: the original node keeps its id and the first segment — preserving `{quote:ID}` references, `source_key`, audio linkage, and artifacts — and the remainder becomes child nodes chained parent→child with +1ms `created_at` steps (chronological windowing and the profile resume cursor stay strictly ordered). Pre-existing children re-parent onto the chain tip, so replies continue after the full content.
- Functionally identical for LLM context assembly: the chain reads as one continuous text.

## Enforcement points

| Path | Behavior |
|---|---|
| `POST /nodes/` | auto-splits; response carries `split_into` + `tip_id` |
| `PUT /nodes/<id>` (edit) | rejects with 422 + `char_cap` (re-parenting children mid-edit would be surprising; the UI explains the limit) |
| Imports — files, Claude, ChatGPT | shared `_add_imported_message_nodes` helper splits; `source_key` lands on the chain **tip**, so re-import dedup skips the whole message and follow-ups chain after the full content, identical to a fresh import |
| Imports — Twitter | untouched (tweets can't exceed the cap) |
| `POST /textmode/start`, `/textmode/<id>/message` | reject with 422; the UI routes consented oversized entries through the plain entry path (which splits) |
| Streaming-draft save-as-node | untouched (transcripts are far below the cap) |

## UI (`NodeForm` + `SplitContentDialog`)

- **Paste** that would exceed the cap is intercepted: dialog offers "Split into ~N connected entries" (inserts the text; split happens server-side at save) or "Cancel" (paste dropped).
- **Submit** above the cap (e.g. typed/accumulated) opens the same dialog before sending.
- **Edit mode** shows an explanatory error instead — edits don't split.
- Oversized agentic entries fall back from `/textmode/start` to the plain entry path after consent.

## Backfill

`backend/scripts/split_oversized_nodes.py` (dry-run by default, `--execute` to apply): converges historical oversized nodes; preserves each original's full content as a `NodeVersion` for recoverability. Prefilters on stored ciphertext length (≥ plaintext, so it over-selects and never misses).

## Tests

11 new tests (`test_node_split.py`): lossless newline splitting, hard-cut of newline-less text, chain creation (serial parents, +1ms ordering, field propagation, re-parenting of existing replies), API auto-split end-to-end (chain reassembles to the original), small-content no-op, oversized-edit rejection. Full backend suite: 446 passed. Frontend builds clean.

## Deploy follow-up (prod)

1. `python backend/scripts/split_oversized_nodes.py` (dry run — expect node 21027 as the main hit), then `--execute`.
2. User 27's profile chain then advances past May 4 on the next heartbeat: ~3 windows of real remaining data (the 173k blob now split and windowable, plus May–June chat), then integration — fully caught up to the present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
