### PR TITLE
Enforce node char cap on voice transcription paths

### DIFF
--- a/backend/routes/drafts.py
+++ b/backend/routes/drafts.py
@@ -943,6 +943,11 @@ def save_streaming_as_node(session_id):
     node.set_content(content)
     node.token_count = approximate_token_count(content)
     db.session.add(node)
+    db.session.flush()
+    # Per-node cap: split very long transcripts into a serial chain
+    # (audio stays on this head node).
+    from backend.utils.node_split import split_node_into_chain
+    split_node_into_chain(node)
     db.session.commit()
 
     # Move audio files from drafts folder to nodes folder

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -775,6 +775,10 @@ def update_node(node_id):
         clear_tts_artifacts(node)
 
     node.set_content(new_content)
+    # Keep the stored information-content measure in sync with the
+    # edited text — chunk windowing and update gates sum this column.
+    from backend.utils.tokens import approximate_token_count as _atc_upd
+    node.token_count = _atc_upd(new_content)
     try:
         db.session.commit()
     except Exception as e:

--- a/backend/scripts/reconcile_token_counts.py
+++ b/backend/scripts/reconcile_token_counts.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Reconcile Node.token_count with chars/4 of each node's current content.
+
+Node.token_count is the platform's information-content measure (chunk
+windowing, profile-update gates, and balance decisions all sum it), but
+several historical paths let it drift from the content:
+
+- classic-upload voice transcription never updated it after writing the
+  transcript (nodes kept the ~9-token placeholder estimate, making long
+  recordings nearly invisible to chunk windowing and update gates);
+- node edits (PUT /nodes/<id>) never recomputed it, freezing the
+  creation-time count regardless of later changes;
+- native LLM replies stored provider output_tokens (converged earlier
+  by backfill_llm_token_counts.py — they no-op here).
+
+Both leaks are fixed at the source alongside this script; this
+converges the historical rows. Idempotent: re-running reports 0.
+
+Usage (on prod, from repo root):
+    python backend/scripts/reconcile_token_counts.py            # dry run
+    python backend/scripts/reconcile_token_counts.py --execute
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from backend.app import create_app
+from backend.extensions import db
+from backend.models import Node
+from backend.utils.tokens import approximate_token_count
+
+BATCH_SIZE = 500
+# Only report individual nodes with at least this much drift; tiny
+# diffs are still fixed but not worth a log line each.
+REPORT_THRESHOLD = 1000
+
+
+def main(execute):
+    app = create_app()
+    with app.app_context():
+        ids = [r[0] for r in (db.session.query(Node.id)
+                              .order_by(Node.id).all())]
+        print(f"{len(ids)} nodes to examine")
+        changed = 0
+        old_sum = 0
+        new_sum = 0
+        decrypt_failures = 0
+        for start in range(0, len(ids), BATCH_SIZE):
+            batch = (Node.query
+                     .filter(Node.id.in_(ids[start:start + BATCH_SIZE]))
+                     .all())
+            for node in batch:
+                try:
+                    text = node.get_content() or ""
+                except Exception:
+                    decrypt_failures += 1
+                    continue
+                new_count = approximate_token_count(text)
+                if new_count == (node.token_count or 0):
+                    continue
+                drift = new_count - (node.token_count or 0)
+                if abs(drift) >= REPORT_THRESHOLD:
+                    print(f"  node {node.id}: user={node.user_id} "
+                          f"type={node.node_type} "
+                          f"{node.token_count} -> {new_count} ({drift:+d})")
+                old_sum += node.token_count or 0
+                new_sum += new_count
+                changed += 1
+                if execute:
+                    node.token_count = new_count
+            if execute:
+                db.session.commit()
+            done = min(start + BATCH_SIZE, len(ids))
+            print(f"  {done}/{len(ids)} examined, {changed} to change",
+                  end="\r")
+        print()
+        print(f"{'updated' if execute else 'would update'}: {changed} nodes")
+        print(f"token_count sum over changed nodes: {old_sum} -> {new_sum} "
+              f"({new_sum - old_sum:+d})")
+        if decrypt_failures:
+            print(f"WARNING: {decrypt_failures} nodes failed to decrypt "
+                  f"(skipped)")
+        if not execute:
+            print("\nDry run — re-run with --execute to apply.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Reconcile Node.token_count with current content")
+    parser.add_argument("--execute", action="store_true",
+                        help="apply changes (default: dry run)")
+    args = parser.parse_args()
+    main(args.execute)

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -297,6 +297,10 @@ def finalize_streaming(self, node_id: int, session_id: str, total_chunks: int):
         from backend.utils.tokens import approximate_token_count
         node.set_content(final_content)
         node.token_count = approximate_token_count(final_content)
+        # Per-node cap: very long recordings (~2h+ of speech) can exceed
+        # it; split into a serial chain (audio stays on this head node).
+        from backend.utils.node_split import split_node_into_chain
+        split_node_into_chain(node)
         node.transcription_status = 'completed'
         node.transcription_completed_at = datetime.utcnow()
         node.transcription_progress = 100
@@ -1056,6 +1060,14 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
     db.session.add(user_node)
     db.session.flush()
 
+    # Per-node cap: split very long transcripts into a serial chain.
+    # Audio and transcript-chunk rows stay on this head node; the LLM
+    # reply chains after the tip so its context walk sees the full
+    # transcript above it.
+    from backend.utils.node_split import split_node_into_chain
+    _split_parts = split_node_into_chain(user_node)
+    tip_node = _split_parts[-1] if _split_parts else user_node
+
     # Move streaming audio to user node — inline version of
     # attach_streaming_audio_to_node that does NOT delete the draft
     # (we still need it for the SSE all_complete event).
@@ -1087,7 +1099,7 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
     from backend.utils.task_warnings import record_task_warning
     try:
         llm_node, _ = create_llm_placeholder(
-            user_node.id, model, user_id, enqueue=False,
+            tip_node.id, model, user_id, enqueue=False,
             ai_usage=ai_usage,
         )
     except (UserExportValidationError, ParentDeletedError) as e:
@@ -1119,7 +1131,7 @@ def _start_server_side_llm_chain(draft, session_id, transcript,
     # Chain: LLM generation → TTS generation
     celery_chain(
         generate_llm_response.si(
-            user_node.id, llm_node.id, model, user_id,
+            tip_node.id, llm_node.id, model, user_id,
             source_mode='voice',
         ),
         generate_tts_audio.si(

--- a/backend/tasks/transcription.py
+++ b/backend/tasks/transcription.py
@@ -241,7 +241,15 @@ def transcribe_audio(self, node_id: int, audio_file_path: str, filename: str = N
             else:
                 final_content = transcript
 
-            node.set_content(final_content or node.get_content())
+            final_content = final_content or node.get_content()
+            node.set_content(final_content)
+            from backend.utils.tokens import approximate_token_count
+            node.token_count = approximate_token_count(final_content)
+            # Per-node cap: very long recordings (~2h+ of speech) can
+            # exceed it; split into a serial chain. Audio stays on this
+            # head node; the transcript continues across the chain.
+            from backend.utils.node_split import split_node_into_chain
+            split_node_into_chain(node)
             node.transcription_status = 'completed'
             node.transcription_progress = 100
             node.transcription_completed_at = datetime.utcnow()

--- a/backend/tests/test_node_split.py
+++ b/backend/tests/test_node_split.py
@@ -145,6 +145,29 @@ def test_chain_split_preserves_content_and_order(app):
     assert node.token_count == len(node.get_content()) // 4
 
 
+def test_voice_node_split_keeps_audio_on_head(app):
+    """Splitting a transcribed voice node leaves the audio linkage on
+    the head node only — playback plays the full recording from the
+    chain head; parts carry transcript text, not audio."""
+    user = _user()
+    transcript = "\n".join(f"spoken sentence {i}" for i in range(200))
+    node = _node(user, transcript)
+    node.audio_original_url = "/media/nodes/1/original.webm"
+    db.session.commit()
+
+    parts = split_node_into_chain(
+        node, segments=split_text_at_cap(transcript, cap=800))
+    db.session.commit()
+
+    assert len(parts) >= 1
+    assert node.audio_original_url == "/media/nodes/1/original.webm"
+    for p in parts:
+        assert p.audio_original_url is None
+    chain_text = node.get_content() + "".join(
+        p.get_content() for p in parts)
+    assert chain_text == transcript
+
+
 def test_chain_split_noop_below_cap(app):
     user = _user()
     node = _node(user, "small content")

--- a/backend/tests/test_node_split.py
+++ b/backend/tests/test_node_split.py
@@ -242,6 +242,24 @@ def test_create_small_node_not_split(app, client, monkeypatch):
     assert data["tip_id"] == data["id"]
 
 
+def test_update_node_recomputes_token_count(app, client, monkeypatch):
+    """Edits must keep token_count in sync with the new content — it
+    was frozen at the creation-time count, drifting the measure that
+    chunk windowing and update gates sum."""
+    monkeypatch.setattr(
+        "backend.utils.context_artifacts.sync_context_artifacts",
+        lambda *a, **k: None)
+    res = client.post("/api/nodes/", json={
+        "content": "tiny", "ai_usage": "chat", "privacy_level": "private"})
+    nid = res.get_json()["id"]
+    longer = "much longer content " * 200
+    res = client.put(f"/api/nodes/{nid}", json={"content": longer})
+    assert res.status_code == 200
+    with app.app_context():
+        node = db.session.get(Node, nid)
+        assert node.token_count == len(longer) // 4
+
+
 def test_update_node_rejects_oversized(app, client, monkeypatch):
     monkeypatch.setattr(
         "backend.utils.context_artifacts.sync_context_artifacts",


### PR DESCRIPTION
Follow-up to #212, closing its one unguarded entrance — plus two `token_count` drift leaks found while in there.

## Voice transcription paths now enforce the cap

Voice nodes get their content written *after* creation by the transcription tasks, so the cap at `POST /nodes/` never saw them. A ~2-hour recording (~50k chars/hour of speech) crosses the 100k cap and would re-create the oversized-node chunk stall. Four sites now split through `split_node_into_chain` at content-write time:

- `tasks/transcription.py` — classic upload finalize
- `tasks/streaming_transcription.py` — streaming finalize
- `tasks/streaming_transcription.py` — voice-mode flow: the LLM placeholder and `generate_llm_response` now anchor on the split **tip**, so the reply's context walk sees the full transcript above it
- `routes/drafts.py` — streaming-draft save-as-node

Audio linkage and transcript-chunk rows stay on the head node (playback plays the full recording from the chain head); a test pins that.

## token_count drift fixes

`Node.token_count` is the measure chunk windowing and profile-update gates sum, and two paths let it drift from content:

- **Classic-upload voice transcription never updated it** — transcribed nodes kept the ~9-token placeholder estimate, making long recordings nearly invisible to windowing and gates. Fixed at finalize.
- **Node edits (`PUT /nodes/<id>`) never recomputed it** — the count stayed frozen at creation time. Fixed in `update_node`.

`backend/scripts/reconcile_token_counts.py` (dry-run default, idempotent) converges the historical rows: recomputes chars/4 for every node whose stored count differs from its current content. Already-converged LLM nodes no-op.

## Tests

448 backend tests pass (new: audio-stays-on-head split semantics, edit recomputes token_count).

## Deploy follow-up (prod)

`python backend/scripts/reconcile_token_counts.py` (dry run, eyeball the big-drift report lines), then `--execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
