### PR TITLE
feat: per-user monthly spend hard cap (all providers)

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -157,6 +157,22 @@ def create_app():
     from backend.routes.sse import sse_bp
     app.register_blueprint(sse_bp, url_prefix="/api/sse")
 
+    # Per-user spend cap: any HTTP path that tries to create an LLM
+    # placeholder for a blocked user raises SpendCapExceeded; surface it as
+    # the standard 402 payload so the frontend shows the spend-cap banner.
+    from backend.utils.spend import SpendCapExceeded
+
+    @app.errorhandler(SpendCapExceeded)
+    def _handle_spend_cap(_exc):
+        from flask import jsonify
+        return jsonify({
+            "error": "monthly_spend_limit_reached",
+            "message": (
+                "You've reached your monthly usage limit for the free "
+                "alpha. It resets at the start of next month."
+            ),
+        }), 402
+
     # Register CLI commands
     from backend.init_db import (
         init_db_command, backfill_human_owner_command,

--- a/backend/config.py
+++ b/backend/config.py
@@ -36,6 +36,15 @@ class Config:
     # Recipient for spend alerts (admin inbox also used for signup notices).
     SPEND_ALERT_EMAIL = os.environ.get("SPEND_ALERT_EMAIL", "signup@loore.org")
 
+    # Per-user monthly spend hard cap in USD, summed across ALL providers
+    # (issue #85 follow-up; free-alpha guardrail). 0 (default) disables the
+    # cap. When a user's month-to-date spend reaches this, they are
+    # hard-blocked from new cost-incurring actions until the month rolls
+    # over, and an alert goes to SPEND_ALERT_EMAIL. Ships dark; set in prod.
+    PER_USER_MONTHLY_LIMIT_USD = float(
+        os.environ.get("PER_USER_MONTHLY_LIMIT_USD", "0") or "0"
+    )
+
     # --- Profile-generation batch processing (issue #173, Part A) ---
     # A user takes the Batch API path if the global switch is on OR their id
     # is in the canary allowlist. Both default off → batch ships dark.

--- a/backend/models.py
+++ b/backend/models.py
@@ -47,6 +47,12 @@ class User(db.Model, UserMixin):
     # Subscription plan ("free", "alpha", "pro", etc.).
     plan = db.Column(db.String(16), nullable=False, default="alpha")
 
+    # Per-user monthly spend hard cap (issue: free-alpha guardrail). Stores the
+    # "YYYY-MM" (UTC) in which the user crossed PER_USER_MONTHLY_LIMIT_USD. While
+    # this equals the current month the user is blocked from cost-incurring
+    # actions; it auto-clears at month rollover (stored month no longer matches).
+    spend_blocked_month = db.Column(db.String(7), nullable=True)
+
     # Per-user defaults for new nodes (overridable per-node)
     default_privacy_level = db.Column(
         db.String(16), nullable=False, default="private",

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -215,6 +215,9 @@ def spend_status():
         "limit_fraction_used": (
             (anthropic / 1_000_000) / limit_usd if limit_usd > 0 else None
         ),
+        "per_user_limit_usd": config.get("PER_USER_MONTHLY_LIMIT_USD") or 0,
+        "users_blocked_this_month": User.query.filter_by(
+            spend_blocked_month=month).count(),
         "thresholds": parse_thresholds(config.get("SPEND_ALERT_THRESHOLDS")),
         "alerts_fired": [
             {

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -8,6 +8,7 @@ from backend.utils.privacy import (
 )
 from backend.routes.terms import CURRENT_TERMS_VERSION
 from backend.utils.reserved_usernames import validate_username
+from backend.utils.spend import user_is_capped
 
 dashboard_bp = Blueprint("dashboard_bp", __name__)
 
@@ -121,6 +122,9 @@ def get_dashboard():
             "default_privacy_level": current_user.default_privacy_level,
             "default_ai_usage": current_user.default_ai_usage,
             "timezone": current_user.timezone or "UTC",
+            # Lets the client block cost actions (e.g. starting a long voice
+            # recording) up front instead of after the fact (issue #85).
+            "spend_blocked": user_is_capped(current_user),
         },
         "pinned_nodes": pinned_list,
         "nodes": nodes_list,
@@ -242,6 +246,7 @@ def update_user():
                 "profile_generation_task_id": current_user.profile_generation_task_id,
                 "default_privacy_level": current_user.default_privacy_level,
                 "default_ai_usage": current_user.default_ai_usage,
+                "spend_blocked": user_is_capped(current_user),
             }
         }), 200
     except Exception as e:

--- a/backend/routes/export_data.py
+++ b/backend/routes/export_data.py
@@ -11,6 +11,7 @@ from backend.utils.quotes import (
     resolve_quotes, has_quotes, ExportQuoteResolver, resolve_quotes_for_export
 )
 from backend.utils.timefmt import iso_utc
+from backend.utils.spend import require_spend_headroom
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import subqueryload
 from datetime import datetime
@@ -1400,6 +1401,7 @@ def estimate_profile_tokens():
 
 @export_bp.route("/export/update_profile", methods=["POST"])
 @login_required
+@require_spend_headroom
 def update_profile():
     """
     Unified endpoint for initial profile generation and incremental updates.
@@ -1502,6 +1504,7 @@ def update_profile():
 
 @export_bp.route("/export/integrate_profile", methods=["POST"])
 @login_required
+@require_spend_headroom
 def integrate_profile():
     """
     Manually trigger profile integration: collect all iterative/update
@@ -1574,6 +1577,7 @@ def integrate_profile():
 
 @export_bp.route("/export/generate_profile", methods=["POST"])
 @login_required
+@require_spend_headroom
 def generate_profile():
     """
     Generate a comprehensive user profile using an LLM to analyze all of the user's writing.

--- a/backend/routes/nodes.py
+++ b/backend/routes/nodes.py
@@ -27,6 +27,7 @@ from backend.utils.privacy import (
 )
 from backend.utils.quotes import find_quote_ids, get_quote_data, has_quotes
 from backend.utils.api_keys import get_openai_chat_key
+from backend.utils.spend import require_spend_headroom
 from backend.utils.webm_utils import get_webm_duration
 from backend.utils.encryption import encrypt_file, decrypt_file_to_temp
 from backend.utils.audio_storage import list_streaming_audio_files
@@ -1075,6 +1076,7 @@ def get_suggested_model(node_id):
 # Request an LLM response based on the thread (the ancestors' texts are joined as a prompt).
 @nodes_bp.route("/<int:node_id>/llm", methods=["POST"])
 @login_required
+@require_spend_headroom
 def request_llm_response(node_id):
     from backend.llm_providers import LLMProvider
 
@@ -1433,6 +1435,7 @@ def download_audio(node_id):
 @nodes_bp.route("/<int:node_id>/tts", methods=["POST"])
 @login_required
 @voice_mode_required
+@require_spend_headroom
 def generate_tts(node_id):
     """Trigger (mock) TTS generation for the node.
 

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -14,6 +14,7 @@ from backend.utils.privacy import (
     PrivacyLevel,
 )
 from backend.utils.api_keys import get_openai_chat_key
+from backend.utils.spend import require_spend_headroom
 
 profile_bp = Blueprint("profile", __name__)
 
@@ -97,6 +98,7 @@ def get_audio(profile_id):
 
 @profile_bp.route("/<int:profile_id>/tts", methods=["POST"])
 @login_required
+@require_spend_headroom
 def generate_tts(profile_id):
     """Trigger TTS generation for the user profile."""
     profile = UserProfile.query.get_or_404(profile_id)

--- a/backend/routes/textmode.py
+++ b/backend/routes/textmode.py
@@ -131,6 +131,19 @@ def start_conversation():
     db.session.add(user_node)
     db.session.flush()
 
+    # Spend cap: keep the system + user nodes (the user's writing is never
+    # blocked), but skip the LLM placeholder and signal the frontend to show
+    # the cap banner. Handled inline (not via the chokepoint's 402) so the
+    # committed nodes aren't rolled back and the UI lands on the new thread.
+    from backend.utils.spend import user_is_capped
+    if auto_generate and user_is_capped(current_user):
+        db.session.commit()
+        return jsonify({
+            "conversation_id": system_node.id,
+            "user_node_id": user_node.id,
+            "spend_capped": True,
+        }), 202
+
     # 3. Placeholder LLM node and enqueue task — unless the caller
     # explicitly opted out (Agentic Reply ON + Auto-generate OFF).
     if auto_generate:

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -122,6 +122,12 @@ def generate_user_profile(self, user_id: int, model_id: str):
         if not user:
             raise ValueError(f"User {user_id} not found")
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user):
+            logger.warning(
+                "User %s is spend-capped; skipping profile generation", user_id)
+            return
+
         try:
             # Validate model is supported
             if model_id not in flask_app.config["SUPPORTED_MODELS"]:
@@ -427,6 +433,12 @@ def update_user_profile(self, user_id: int, model_id: str,
         user = User.query.get(user_id)
         if not user:
             raise ValueError(f"User {user_id} not found")
+
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user):
+            logger.warning(
+                "User %s is spend-capped; skipping profile update", user_id)
+            return
 
         # Set concurrency guard
         user.profile_generation_task_id = self.request.id
@@ -1099,6 +1111,12 @@ def integrate_user_profile(self, user_id: int, model_id: str,
         user = User.query.get(user_id)
         if not user:
             raise ValueError(f"User {user_id} not found")
+
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user):
+            logger.warning(
+                "User %s is spend-capped; skipping profile integration", user_id)
+            return
 
         user.profile_generation_task_id = self.request.id
         user.profile_generation_task_dispatched_at = datetime.utcnow()

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -671,6 +671,14 @@ def generate_llm_response(self, parent_node_id: int, llm_node_id: int, model_id:
         if not llm_node:
             raise ValueError(f"LLM node {llm_node_id} not found")
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping LLM completion", user_id)
+            llm_node.llm_task_status = 'failed'
+            db.session.commit()
+            return
+
         # Update status on the new llm_node
         llm_node.llm_task_status = 'processing'
         llm_node.llm_task_progress = 10

--- a/backend/tasks/recent_context.py
+++ b/backend/tasks/recent_context.py
@@ -209,6 +209,12 @@ def generate_recent_context(user_id, profile_id=None, data_cutoff_iso=None):
             logger.warning(f"User {user_id} not found")
             return
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user):
+            logger.info(
+                "User %s is spend-capped; skipping recent context", user_id)
+            return
+
         data_cutoff = (
             datetime.fromisoformat(data_cutoff_iso)
             if data_cutoff_iso else None

--- a/backend/tasks/spend_monitor.py
+++ b/backend/tasks/spend_monitor.py
@@ -6,7 +6,7 @@ Disabled unless ANTHROPIC_SPEND_LIMIT_USD is set to a positive value.
 from celery.utils.log import get_task_logger
 
 from backend.celery_app import celery, flask_app
-from backend.utils.spend import check_and_alert
+from backend.utils.spend import check_and_alert, enforce_user_spend_cap
 
 logger = get_task_logger(__name__)
 
@@ -19,4 +19,17 @@ def check_api_spend():
             logger.warning("Spend alert(s) fired: %s", result)
         else:
             logger.info("Spend check: %s", result)
+        return result
+
+
+@celery.task(name='backend.tasks.spend_monitor.enforce_user_cap')
+def enforce_user_cap(user_id):
+    """Per-user monthly hard-cap check, dispatched after each cost log
+    (issue #85 follow-up). No-op unless PER_USER_MONTHLY_LIMIT_USD is set."""
+    with flask_app.app_context():
+        result = enforce_user_spend_cap(user_id, flask_app.config)
+        if result.get("blocked"):
+            logger.warning("Per-user cap: %s", result)
+        else:
+            logger.info("Per-user cap check: %s", result)
         return result

--- a/backend/tasks/streaming_transcription.py
+++ b/backend/tasks/streaming_transcription.py
@@ -65,6 +65,14 @@ def transcribe_chunk(self, node_id: int, chunk_index: int, chunk_path: str):
     logger.info(f"Starting chunk transcription for node {node_id}, chunk {chunk_index}")
 
     with flask_app.app_context():
+        from backend.utils.spend import user_is_capped
+        _node = Node.query.get(node_id)
+        if _node and user_is_capped(_node.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping chunk transcription",
+                _node.user_id)
+            return
+
         # Get the transcript chunk record
         chunk_record = NodeTranscriptChunk.query.filter_by(
             node_id=node_id,
@@ -376,6 +384,14 @@ def transcribe_draft_chunk(self, session_id: str, chunk_index: int, chunk_path: 
     logger.info(f"Starting draft chunk transcription for session {session_id}, chunk {chunk_index}")
 
     with flask_app.app_context():
+        from backend.utils.spend import user_is_capped
+        _draft = Draft.query.filter_by(session_id=session_id).first()
+        if _draft and user_is_capped(_draft.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping draft chunk transcription",
+                _draft.user_id)
+            return
+
         # Get the transcript chunk record
         chunk_record = NodeTranscriptChunk.query.filter_by(
             session_id=session_id,
@@ -558,6 +574,13 @@ def transcribe_chunk_batch(self, session_id: str, chunk_indices: list):
         draft = Draft.query.filter_by(session_id=session_id).first()
         if not draft:
             raise ValueError(f"Draft not found for session {session_id}")
+
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(draft.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping batch transcription",
+                draft.user_id)
+            return
 
         # Family-only mime drives the on-disk extension. Defensive None
         # handling in case a row was inserted before the default backfill;

--- a/backend/tasks/transcription.py
+++ b/backend/tasks/transcription.py
@@ -60,6 +60,14 @@ def transcribe_audio(self, node_id: int, audio_file_path: str, filename: str = N
         if not node:
             raise ValueError(f"Node {node_id} not found")
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(node.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping transcription", node.user_id)
+            node.transcription_status = 'failed'
+            db.session.commit()
+            return
+
         # Update status to processing
         node.transcription_status = 'processing'
         node.transcription_started_at = datetime.utcnow()

--- a/backend/tasks/tts.py
+++ b/backend/tasks/tts.py
@@ -294,6 +294,15 @@ def generate_tts_audio(self, node_id: int, audio_storage_root: str,
         if not node:
             raise ValueError(f"Node {node_id} not found")
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(requesting_user_id or node.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping node TTS",
+                requesting_user_id or node.user_id)
+            node.tts_task_status = 'failed'
+            db.session.commit()
+            return
+
         node.tts_task_status = 'processing'
         node.tts_task_progress = 10
         db.session.commit()
@@ -401,6 +410,15 @@ def generate_tts_audio_for_profile(self, profile_id: int,
         profile = UserProfile.query.get(profile_id)
         if not profile:
             raise ValueError(f"UserProfile {profile_id} not found")
+
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(requesting_user_id or profile.user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping profile TTS",
+                requesting_user_id or profile.user_id)
+            profile.tts_task_status = 'failed'
+            db.session.commit()
+            return
 
         profile.tts_task_status = 'processing'
         profile.tts_task_progress = 10

--- a/backend/tasks/voice_todo_merge.py
+++ b/backend/tasks/voice_todo_merge.py
@@ -48,6 +48,16 @@ def apply_voice_todo(self, llm_node_id: int, model_id: str, user_id: int,
             logger.error(f"LLM node {llm_node_id} not found")
             return
 
+        from backend.utils.spend import user_is_capped
+        if user_is_capped(user_id):
+            logger.warning(
+                "User %s is spend-capped; skipping voice todo merge", user_id)
+            _update_apply_status(
+                llm_node, "failed", error="Monthly spend limit reached",
+                confirm_node_id=confirm_node_id)
+            db.session.commit()
+            return
+
         update_summary = llm_node.get_content()
         if not update_summary:
             logger.error(f"LLM node {llm_node_id} has no content")

--- a/backend/tests/test_user_spend_cap.py
+++ b/backend/tests/test_user_spend_cap.py
@@ -1,0 +1,172 @@
+"""Tests for the per-user monthly spend hard cap (issue #85 follow-up).
+
+Covers per-user month-to-date aggregation (all providers), the cheap
+flag-based gate with month-rollover auto-reset, the enforce/block/email
+path with within-month idempotency, the disabled-by-default behavior, and
+the route decorator's 402 response.
+
+Patterned after test_spend_monitor.py: sqlite in-memory, minimal Flask app,
+logic tested directly (no celery import).
+"""
+import os
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+# ── Environment ──────────────────────────────────────────────────────────
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import User, APICostLog  # noqa: E402
+from backend.utils.spend import (  # noqa: E402
+    current_month, enforce_user_spend_cap,
+    get_user_month_spend_microdollars, require_spend_headroom, user_is_capped,
+)
+
+NOW = datetime(2026, 6, 10, 3, 0, 0)
+PREV_MONTH = datetime(2026, 5, 20, 3, 0, 0)
+
+
+def _config(limit=50.0):
+    return {
+        "PER_USER_MONTHLY_LIMIT_USD": limit,
+        "SPEND_ALERT_EMAIL": "alerts@example.com",
+    }
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["TESTING"] = True
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        _db.session.add(User(username="tester"))
+        _db.session.add(User(username="other"))
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _log_cost(user_id, model_id, usd, created_at=NOW):
+    row = APICostLog(
+        user_id=user_id,
+        model_id=model_id,
+        request_type="llm",
+        cost_microdollars=int(usd * 1_000_000),
+    )
+    row.created_at = created_at
+    _db.session.add(row)
+    _db.session.commit()
+    return row
+
+
+def test_user_month_spend_all_providers_scoped(app):
+    u = User.query.filter_by(username="tester").first()
+    other = User.query.filter_by(username="other").first()
+    _log_cost(u.id, "claude-opus-4.6", 10.0)        # anthropic, this month
+    _log_cost(u.id, "gpt-5.5", 5.0)                  # openai, this month
+    _log_cost(u.id, "claude-opus-4.6", 99.0, PREV_MONTH)  # last month, excluded
+    _log_cost(other.id, "gpt-5.5", 42.0)             # other user, excluded
+    total = get_user_month_spend_microdollars(u.id, now=NOW)
+    assert total == int(15.0 * 1_000_000)            # 10 + 5, both providers
+
+
+def test_enforce_disabled_when_limit_zero(app):
+    u = User.query.filter_by(username="tester").first()
+    _log_cost(u.id, "claude-opus-4.6", 999.0)
+    send = MagicMock()
+    result = enforce_user_spend_cap(u.id, _config(limit=0), now=NOW,
+                                    send_email=send)
+    assert result["status"] == "disabled"
+    send.assert_not_called()
+    assert u.spend_blocked_month is None
+
+
+def test_enforce_under_cap_does_not_block(app):
+    u = User.query.filter_by(username="tester").first()
+    _log_cost(u.id, "claude-opus-4.6", 30.0)
+    send = MagicMock()
+    result = enforce_user_spend_cap(u.id, _config(limit=50), now=NOW,
+                                    send_email=send)
+    assert result["status"] == "ok"
+    assert result["blocked"] is False
+    send.assert_not_called()
+    assert u.spend_blocked_month is None
+
+
+def test_enforce_blocks_and_emails_once(app):
+    u = User.query.filter_by(username="tester").first()
+    _log_cost(u.id, "claude-opus-4.6", 40.0)
+    _log_cost(u.id, "gpt-5.5", 12.0)   # total $52 >= $50
+    send = MagicMock()
+    result = enforce_user_spend_cap(u.id, _config(limit=50), now=NOW,
+                                    send_email=send)
+    assert result["status"] == "blocked"
+    assert result["blocked"] is True
+    assert u.spend_blocked_month == current_month(NOW)
+    send.assert_called_once()
+    kwargs = send.call_args.kwargs
+    assert kwargs["to_email"] == "alerts@example.com"
+    assert kwargs["username"] == "tester"
+    assert kwargs["limit_usd"] == 50
+    assert round(kwargs["spend_usd"], 2) == 52.0
+
+    # Idempotent within the month: a second run does not re-email.
+    send2 = MagicMock()
+    again = enforce_user_spend_cap(u.id, _config(limit=50), now=NOW,
+                                   send_email=send2)
+    assert again["status"] == "already_blocked"
+    send2.assert_not_called()
+
+
+def test_user_is_capped_flag_and_month_rollover(app):
+    u = User.query.filter_by(username="tester").first()
+    assert user_is_capped(u, now=NOW) is False
+    u.spend_blocked_month = current_month(NOW)
+    _db.session.commit()
+    assert user_is_capped(u, now=NOW) is True
+    # Next month the same stored value no longer matches → auto-unblocked.
+    next_month = datetime(2026, 7, 1, 0, 0, 0)
+    assert user_is_capped(u, now=next_month) is False
+    # Accepts a bare id too.
+    assert user_is_capped(u.id, now=NOW) is True
+
+
+def test_require_spend_headroom_decorator(app, monkeypatch):
+    from backend.utils import spend as spendmod
+
+    @require_spend_headroom
+    def view():
+        return "ran"
+
+    fake_user = MagicMock(is_authenticated=True)
+    monkeypatch.setattr("flask_login.current_user", fake_user, raising=False)
+
+    monkeypatch.setattr(spendmod, "user_is_capped", lambda u, now=None: True)
+    with app.test_request_context():
+        body, status = view()
+        assert status == 402
+        assert body.json["error"] == "monthly_spend_limit_reached"
+
+    monkeypatch.setattr(spendmod, "user_is_capped", lambda u, now=None: False)
+    with app.test_request_context():
+        assert view() == "ran"

--- a/backend/tests/test_user_spend_cap.py
+++ b/backend/tests/test_user_spend_cap.py
@@ -151,6 +151,23 @@ def test_user_is_capped_flag_and_month_rollover(app):
     assert user_is_capped(u.id, now=NOW) is True
 
 
+def test_create_llm_placeholder_blocked_when_capped(app):
+    from backend.models import Node
+    from backend.utils.llm_nodes import create_llm_placeholder
+    from backend.utils.spend import SpendCapExceeded, current_month
+    u = User.query.filter_by(username="tester").first()
+    parent = Node(user_id=u.id, human_owner_id=u.id, node_type="user")
+    _db.session.add(parent)
+    _db.session.commit()
+    u.spend_blocked_month = current_month()
+    _db.session.commit()
+    before = Node.query.count()
+    with pytest.raises(SpendCapExceeded):
+        create_llm_placeholder(parent.id, "claude-opus-4.6", u.id, enqueue=False)
+    # No orphan placeholder node created.
+    assert Node.query.count() == before
+
+
 def test_require_spend_headroom_decorator(app, monkeypatch):
     from backend.utils import spend as spendmod
 

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -218,6 +218,76 @@ def send_spend_alert_email(to_email, provider, spend_usd, limit_usd, threshold):
         raise
 
 
+def send_user_spend_block_email(to_email, username, spend_usd, limit_usd):
+    """Alert the admin that a single user hit their monthly spend cap and has
+    been hard-blocked until month rollover (issue #85 follow-up)."""
+    config = current_app.config
+    sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"Loore: user {username} hit the ${limit_usd:,.0f} monthly cap"
+    msg["From"] = sender
+    msg["To"] = to_email
+
+    text_body = (
+        f"Per-user spend cap reached\n\n"
+        f"User: {username}\n"
+        f"Month-to-date spend: ${spend_usd:,.2f}\n"
+        f"Monthly cap: ${limit_usd:,.2f}\n\n"
+        f"This user is now hard-blocked from cost-incurring actions until the "
+        f"month rolls over.\n"
+        f"Review usage in the admin dashboard: https://loore.org/admin\n"
+    )
+
+    html_body = f"""\
+<html>
+<body style="font-family: 'Outfit', -apple-system, sans-serif; background: #0e0d0b; color: #ede8dd; padding: 40px 20px; margin: 0;">
+  <div style="max-width: 460px; margin: 0 auto; background: #181714; border-radius: 10px; border: 1px solid #302c27; padding: 48px 40px;">
+    <div style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-size: 14px; font-weight: 300; text-transform: uppercase; letter-spacing: 0.3em; color: #736b5f; margin-bottom: 32px;">
+      Loore
+    </div>
+    <h2 style="font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif; font-weight: 300; font-size: 28px; color: #ede8dd; margin: 0 0 12px 0;">
+      User hit monthly cap
+    </h2>
+    <p style="font-size: 15px; font-weight: 300; color: #a89f91; margin: 0 0 8px 0; line-height: 1.6;">
+      <strong style="color: #ede8dd;">{username}</strong> reached
+      <strong style="color: #c4956a;">${spend_usd:,.2f}</strong>
+      of the <strong style="color: #ede8dd;">${limit_usd:,.2f}</strong> monthly cap
+      and is now hard-blocked until the month rolls over.
+    </p>
+    <a href="https://loore.org/admin"
+       style="display: inline-block; margin-top: 20px; padding: 12px 32px; background: transparent; color: #c4956a;
+              text-decoration: none; border-radius: 6px; border: 1px solid #c4956a;
+              font-family: 'Outfit', -apple-system, sans-serif; font-size: 14px; font-weight: 400;
+              letter-spacing: 0.04em;">
+      Open admin dashboard
+    </a>
+  </div>
+</body>
+</html>"""
+
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    server = config.get("MAIL_SERVER", "localhost")
+    port = config.get("MAIL_PORT", 587)
+    use_tls = config.get("MAIL_USE_TLS", True)
+    username_smtp = config.get("MAIL_USERNAME")
+    password = config.get("MAIL_PASSWORD")
+
+    try:
+        with smtplib.SMTP(server, port) as smtp:
+            if use_tls:
+                smtp.starttls()
+            if username_smtp and password:
+                smtp.login(username_smtp, password)
+            smtp.sendmail(sender, to_email, msg.as_string())
+        logger.info(f"Spend block email sent to {to_email} (user {username})")
+    except Exception:
+        logger.exception(f"Failed to send spend block email to {to_email}")
+        raise
+
+
 def send_admin_signup_notification(username, user_email):
     config = current_app.config
     sender = config.get("MAIL_DEFAULT_SENDER", "login@loore.org")

--- a/backend/utils/llm_nodes.py
+++ b/backend/utils/llm_nodes.py
@@ -81,6 +81,15 @@ def create_llm_placeholder(parent_node_id, model_id, human_owner_id,
     Validation runs BEFORE any DB writes so a misconfigured placeholder
     never produces an orphan LLM node and never incurs LLM API spend.
     """
+    # Spend-cap guard: a blocked user must never get an LLM placeholder node
+    # (and never incur generation spend). Raised before any DB write so no
+    # orphan node is created; HTTP callers surface it as a 402 → banner via
+    # the SpendCapExceeded error handler. This is the single chokepoint for
+    # every placeholder-creating path (textmode, converse, voice, replies).
+    from backend.utils.spend import SpendCapExceeded, user_is_capped
+    if user_is_capped(human_owner_id):
+        raise SpendCapExceeded()
+
     # Race A guard: lock the parent row and reject if soft-deleted. The
     # locking is what closes the create-vs-soft-delete race under READ
     # COMMITTED — a plain SELECT-then-INSERT can't see the concurrent

--- a/backend/utils/spend.py
+++ b/backend/utils/spend.py
@@ -25,6 +25,13 @@ logger = logging.getLogger(__name__)
 ENFORCE_CAP_DELAY_SECONDS = 15
 
 
+class SpendCapExceeded(Exception):
+    """Raised when a spend-blocked user would incur a cost-bearing action.
+    Registered with a 402 error handler so any HTTP path that hits it
+    surfaces the standard monthly_spend_limit_reached payload (→ banner)."""
+    pass
+
+
 def month_start(now=None):
     now = now or datetime.utcnow()
     return datetime(now.year, now.month, 1)

--- a/backend/utils/spend.py
+++ b/backend/utils/spend.py
@@ -11,18 +11,28 @@ models that have since been removed from config still count correctly.
 """
 import logging
 from datetime import datetime
+from functools import wraps
 
-from sqlalchemy import func, or_
+from sqlalchemy import event, func, or_
 
 from backend.extensions import db
 from backend.models import APICostLog, SpendAlert
 
 logger = logging.getLogger(__name__)
 
+# Seconds to defer the per-user cap check after a cost row is inserted, so the
+# inserting transaction has committed before we aggregate committed spend.
+ENFORCE_CAP_DELAY_SECONDS = 15
+
 
 def month_start(now=None):
     now = now or datetime.utcnow()
     return datetime(now.year, now.month, 1)
+
+
+def current_month(now=None):
+    """Current calendar month as "YYYY-MM" (UTC)."""
+    return (now or datetime.utcnow()).strftime("%Y-%m")
 
 
 def _anthropic_filter(config):
@@ -122,3 +132,132 @@ def check_and_alert(config, now=None, send_email=None):
         "limit_usd": limit_usd,
         "fired": fired,
     }
+
+
+# --- Per-user monthly hard cap (issue #85 follow-up) -----------------------
+
+def get_user_month_spend_microdollars(user_id, now=None):
+    """Month-to-date spend in microdollars for one user, ALL providers."""
+    q = db.session.query(
+        func.coalesce(func.sum(APICostLog.cost_microdollars), 0)
+    ).filter(
+        APICostLog.user_id == user_id,
+        APICostLog.created_at >= month_start(now),
+    )
+    return int(q.scalar() or 0)
+
+
+def user_is_capped(user, now=None):
+    """Cheap, query-light check of whether a user is currently spend-blocked.
+
+    Pass a loaded User to avoid any query (the flag is already on the row);
+    a bare id triggers a single primary-key lookup. The block auto-expires at
+    month rollover because we compare the stored month to the current one.
+    """
+    from backend.models import User
+    if user is None:
+        return False
+    if not isinstance(user, User):
+        user = db.session.get(User, user)
+        if user is None:
+            return False
+    blocked = user.spend_blocked_month
+    return bool(blocked) and blocked == current_month(now)
+
+
+def enforce_user_spend_cap(user_id, config, now=None, send_email=None):
+    """Block a user whose month-to-date spend (all providers) has reached
+    PER_USER_MONTHLY_LIMIT_USD, and alert the admin once. Idempotent within a
+    month. Runs in its own transaction (safe to call out-of-band).
+
+    `send_email` is injectable for tests; defaults to the real sender.
+    """
+    from backend.models import User
+    limit_usd = config.get("PER_USER_MONTHLY_LIMIT_USD") or 0
+    if limit_usd <= 0:
+        return {"status": "disabled"}
+
+    now = now or datetime.utcnow()
+    month = current_month(now)
+    user = db.session.get(User, user_id)
+    if user is None:
+        return {"status": "no_user", "user_id": user_id}
+    if user.spend_blocked_month == month:
+        return {"status": "already_blocked", "user_id": user_id, "month": month}
+
+    spend_usd = get_user_month_spend_microdollars(user_id, now=now) / 1_000_000
+    if spend_usd < limit_usd:
+        return {
+            "status": "ok", "user_id": user_id,
+            "spend_usd": round(spend_usd, 4), "limit_usd": limit_usd,
+            "blocked": False,
+        }
+
+    # Over the cap. Persist the block first (the critical effect), then alert
+    # best-effort — a failed email must not leave the user un-blocked.
+    user.spend_blocked_month = month
+    db.session.commit()
+
+    if send_email is None:
+        from backend.utils.email import send_user_spend_block_email
+        send_email = send_user_spend_block_email
+    try:
+        send_email(
+            to_email=config.get("SPEND_ALERT_EMAIL") or "signup@loore.org",
+            username=user.username,
+            spend_usd=spend_usd,
+            limit_usd=limit_usd,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send per-user spend block email for user %s", user_id)
+
+    logger.warning(
+        "User %s hard-blocked: $%.2f >= $%.2f cap for %s",
+        user_id, spend_usd, limit_usd, month)
+    return {
+        "status": "blocked", "user_id": user_id, "month": month,
+        "spend_usd": round(spend_usd, 4), "limit_usd": limit_usd,
+        "blocked": True,
+    }
+
+
+def require_spend_headroom(fn):
+    """Route decorator: reject cost-incurring requests from a capped user with
+    402 + a clear message. Place below @login_required so current_user is set.
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        from flask import jsonify
+        from flask_login import current_user
+        if getattr(current_user, "is_authenticated", False) and \
+                user_is_capped(current_user):
+            return jsonify({
+                "error": "monthly_spend_limit_reached",
+                "message": (
+                    "You've reached your monthly usage limit for the free "
+                    "alpha. It resets at the start of next month."
+                ),
+            }), 402
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@event.listens_for(APICostLog, "after_insert")
+def _dispatch_user_cap_check(mapper, connection, target):
+    """After any cost row is written, schedule a (deferred, out-of-band)
+    per-user cap check. No-op unless the cap is enabled, so tests and the
+    default config incur zero broker traffic."""
+    try:
+        from flask import current_app, has_app_context
+        if not has_app_context():
+            return
+        if (current_app.config.get("PER_USER_MONTHLY_LIMIT_USD") or 0) <= 0:
+            return
+        if target.user_id is None:
+            return
+        from backend.tasks.spend_monitor import enforce_user_cap
+        enforce_user_cap.apply_async(
+            args=[target.user_id], countdown=ENFORCE_CAP_DELAY_SECONDS)
+    except Exception:
+        logger.exception("Failed to dispatch per-user spend cap check")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import Dashboard from "./components/Dashboard";
 import Feed from "./components/Feed";
 import NavBar from "./components/NavBar";
 import NodeFormModal from "./components/NodeFormModal";
+import SpendCapBanner from "./components/SpendCapBanner";
 import TermsModal from "./components/TermsModal";
 import AdminPanel from "./components/AdminPanel";
 import NodeDetailWrapper from "./components/NodeDetailWrapper";
@@ -74,6 +75,7 @@ function App() {
     <AudioProvider>
       <div>
         <NavBar onNewEntryClick={() => setShowNewEntry(true)} />
+        <SpendCapBanner />
         <div style={{ paddingTop: "60px" }}>
         {showNewEntry && (
           <NodeFormModal

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -25,4 +25,25 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Surface the per-user monthly spend cap (HTTP 402) as a global banner,
+// regardless of which cost action hit it. The call site's own error handling
+// still runs (we re-reject), so spinners stop as usual. SpendCapBanner listens.
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const data = error.response && error.response.data;
+    if (error.response && error.response.status === 402 &&
+        data && data.error === "monthly_spend_limit_reached") {
+      try {
+        window.dispatchEvent(new CustomEvent("loore:spend-capped", {
+          detail: { message: data.message },
+        }));
+      } catch (e) {
+        // Ignore — CustomEvent unavailable; the rejection below still flows.
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -485,8 +485,11 @@ function NodeDetail() {
       })
       .catch((err) => {
         console.error(err);
-        setError(err.response?.data?.error || `Error starting ${sessionType} session.`);
         setVoiceLoading(false);
+        // 402 = spend cap, surfaced globally by SpendCapBanner; don't echo
+        // the raw error code into the view.
+        if (err?.response?.status === 402) return;
+        setError(err.response?.data?.error || `Error starting ${sessionType} session.`);
       });
   };
 

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -361,29 +361,32 @@ function NodeDetail() {
     return newNodeId;
   };
 
+  // Shared handling for a failed LLM-request (the /nodes/:id/llm POST),
+  // used by the explicit button and the auto-generate-on-submit/edit paths.
+  // - 402 (monthly spend cap): surfaced globally by SpendCapBanner — return
+  //   silently so the thread stays exactly where the user was. setError()
+  //   here replaces the whole node view with the message, so echoing the
+  //   raw code would both blank the thread and look technical.
+  // - 400 (user-correctable, e.g. a bad {user_export} placeholder): toast,
+  //   keep the page intact.
+  // - otherwise: surface in the node view.
+  const handleLlmRequestError = (err) => {
+    console.error(err);
+    const status = err?.response?.status;
+    const apiErr = err?.response?.data?.error;
+    if (status === 402) return;
+    if (status === 400 && apiErr) {
+      addToast(apiErr, 8000);
+      return;
+    }
+    setError(apiErr || err.message || "Error requesting LLM response.");
+  };
+
   const handleLLMResponse = () => {
     setError("");
     requestLlmFor(id)
       .then((newNodeId) => setLlmTaskNodeId(newNodeId))
-      .catch((err) => {
-        console.error(err);
-        // 400 = user-correctable validation (e.g. misconfigured
-        // {user_export} placeholder). Surface as a toast so the page
-        // stays intact; setError() at this level replaces the whole
-        // node view with the message, which feels destructive for
-        // something the user just needs to fix and resend.
-        const status = err?.response?.status;
-        const apiErr = err?.response?.data?.error;
-        // 402 = monthly spend cap. It's surfaced globally by SpendCapBanner,
-        // so keep the node view exactly where the user was and don't echo
-        // the raw error code into the page.
-        if (status === 402) return;
-        if (status === 400 && apiErr) {
-          addToast(apiErr, 8000);
-          return;
-        }
-        setError(apiErr || err.message || "Error requesting LLM response.");
-      });
+      .catch(handleLlmRequestError);
   };
 
   // Gate + fire a child LLM generation under `parentNodeId`. Returns the
@@ -423,8 +426,7 @@ function NodeDetail() {
         navigate(`/node/${newNodeId}`);
       }
     } catch (err) {
-      console.error(err);
-      setError(err.response?.data?.error || err.message || "Error sending message.");
+      handleLlmRequestError(err);
     }
   };
 
@@ -461,14 +463,7 @@ function NodeDetail() {
       const llmNodeId = await tryAutoGenerateFor(updated.id, chain);
       if (llmNodeId) navigate(`/node/${llmNodeId}?awaitLlm=${llmNodeId}`);
     } catch (err) {
-      console.error(err);
-      const status = err?.response?.status;
-      const apiErr = err?.response?.data?.error;
-      if (status === 400 && apiErr) {
-        addToast(apiErr, 8000);
-        return;
-      }
-      setError(apiErr || err.message || "Error requesting LLM response.");
+      handleLlmRequestError(err);
     }
   };
 

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -426,6 +426,13 @@ function NodeDetail() {
         navigate(`/node/${newNodeId}`);
       }
     } catch (err) {
+      // Spend cap: the user's node WAS created; only the LLM reply was
+      // blocked. Land on the new node (same as the auto-generate-off path)
+      // so it shows and the input resets — the banner fires globally.
+      if (err?.response?.status === 402) {
+        navigate(`/node/${newNodeId}`);
+        return;
+      }
       handleLlmRequestError(err);
     }
   };

--- a/frontend/src/components/NodeDetail.js
+++ b/frontend/src/components/NodeDetail.js
@@ -374,6 +374,10 @@ function NodeDetail() {
         // something the user just needs to fix and resend.
         const status = err?.response?.status;
         const apiErr = err?.response?.data?.error;
+        // 402 = monthly spend cap. It's surfaced globally by SpendCapBanner,
+        // so keep the node view exactly where the user was and don't echo
+        // the raw error code into the page.
+        if (status === 402) return;
         if (status === 400 && apiErr) {
           addToast(apiErr, 8000);
           return;

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -351,6 +351,13 @@ const NodeForm = forwardRef(
           });
           deleteDraft();
           setHasDraft(false);
+          // Spend cap: backend kept the system + user nodes but skipped the
+          // LLM placeholder (e.g. /textmode/start). Surface the banner.
+          if (data && data.spend_capped) {
+            try {
+              window.dispatchEvent(new CustomEvent('loore:spend-capped', {}));
+            } catch (e) { /* no-op */ }
+          }
           onSuccess(data);
           setLoading(false);
           return;

--- a/frontend/src/components/NodeForm.js
+++ b/frontend/src/components/NodeForm.js
@@ -374,6 +374,14 @@ const NodeForm = forwardRef(
           });
           deleteDraft();
           setHasDraft(false);
+          // Spend cap: backend kept the system + user nodes but skipped the
+          // LLM placeholder. Surface the banner; the no-llm_node_id branch
+          // below lands the user on their new thread without a placeholder.
+          if (res.data.spend_capped) {
+            try {
+              window.dispatchEvent(new CustomEvent('loore:spend-capped', {}));
+            } catch (e) { /* no-op */ }
+          }
           if (res.data.llm_node_id) {
             onSuccess({
               id: res.data.llm_node_id,

--- a/frontend/src/components/SpendCapBanner.js
+++ b/frontend/src/components/SpendCapBanner.js
@@ -26,20 +26,23 @@ export default function SpendCapBanner() {
   return (
     <div style={{
       position: 'fixed',
-      top: 60,
-      left: 0,
-      right: 0,
-      zIndex: 1000,
-      display: 'flex',
-      justifyContent: 'center',
+      // Bottom-center, sitting above the mobile floating audio player when
+      // present (GlobalAudioPlayer publishes its height as
+      // --floating-player-offset; 0px when absent) — matches the toast
+      // placement so the player is never occluded. #28.
+      bottom: 'calc(24px + var(--floating-player-offset, 0px))',
+      left: '50%',
+      transform: 'translateX(-50%)',
+      zIndex: 9999,
+      width: '100%',
+      maxWidth: 680,
       padding: '0 16px',
+      boxSizing: 'border-box',
       pointerEvents: 'none',
     }}>
       <div style={{
         pointerEvents: 'auto',
-        maxWidth: 680,
         width: '100%',
-        marginTop: 12,
         background: 'var(--bg-card)',
         border: '1px solid var(--accent)',
         borderRadius: 8,
@@ -82,7 +85,7 @@ export default function SpendCapBanner() {
       </div>
       <style>{`
         @keyframes spendcap-in {
-          from { opacity: 0; transform: translateY(-8px); }
+          from { opacity: 0; transform: translateY(8px); }
           to { opacity: 1; transform: translateY(0); }
         }
       `}</style>

--- a/frontend/src/components/SpendCapBanner.js
+++ b/frontend/src/components/SpendCapBanner.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+
+const DEFAULT_MESSAGE =
+  "You've reached your monthly usage limit for the free alpha. " +
+  "It resets at the start of next month.";
+
+/**
+ * Fixed top banner shown when a cost-incurring action is refused because the
+ * user hit their monthly spend cap (HTTP 402, issue #85 follow-up). Driven by
+ * the global "loore:spend-capped" event dispatched from the api.js response
+ * interceptor, so every cost action (LLM, TTS, profile generation) surfaces it
+ * uniformly. Persists until dismissed — the cap holds for the rest of the month.
+ */
+export default function SpendCapBanner() {
+  const [message, setMessage] = useState(null);
+
+  useEffect(() => {
+    const onCapped = (e) =>
+      setMessage((e.detail && e.detail.message) || DEFAULT_MESSAGE);
+    window.addEventListener('loore:spend-capped', onCapped);
+    return () => window.removeEventListener('loore:spend-capped', onCapped);
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 60,
+      left: 0,
+      right: 0,
+      zIndex: 1000,
+      display: 'flex',
+      justifyContent: 'center',
+      padding: '0 16px',
+      pointerEvents: 'none',
+    }}>
+      <div style={{
+        pointerEvents: 'auto',
+        maxWidth: 680,
+        width: '100%',
+        marginTop: 12,
+        background: 'var(--bg-card)',
+        border: '1px solid var(--accent)',
+        borderRadius: 8,
+        boxShadow: '0 4px 20px rgba(0,0,0,0.25)',
+        padding: '12px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        animation: 'spendcap-in 0.25s ease-out',
+      }}>
+        <span style={{
+          fontFamily: 'var(--sans)',
+          fontSize: '0.7rem',
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: 'var(--accent)',
+          whiteSpace: 'nowrap',
+        }}>Limit reached</span>
+        <span style={{
+          flex: 1,
+          fontFamily: 'var(--sans)',
+          fontSize: '0.9rem',
+          fontWeight: 300,
+          lineHeight: 1.5,
+          color: 'var(--text-secondary)',
+        }}>{message}</span>
+        <button
+          onClick={() => setMessage(null)}
+          aria-label="Dismiss"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--text-muted)',
+            fontSize: '1.2rem',
+            lineHeight: 1,
+            cursor: 'pointer',
+            padding: '0 4px',
+          }}
+        >×</button>
+      </div>
+      <style>{`
+        @keyframes spendcap-in {
+          from { opacity: 0; transform: translateY(-8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/StreamingMicButton.js
+++ b/frontend/src/components/StreamingMicButton.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useStreamingTranscription } from '../hooks/useStreamingTranscription';
 import { useOnlineStatus } from '../hooks/useOnlineStatus';
+import { isSpendBlocked, notifySpendBlocked } from '../utils/spendCap';
 
 /**
  * StreamingMicButton - A microphone button that supports real-time streaming transcription.
@@ -98,6 +99,9 @@ export default function StreamingMicButton({
 
   const handleClick = useCallback(() => {
     if (sessionState === 'idle') {
+      // Block before any recording starts — a long recording stopped only at
+      // the end would be lost work (issue #85).
+      if (isSpendBlocked()) { notifySpendBlocked(); return; }
       // Call onRecordingStart before starting to capture pre-existing content
       if (onRecordingStart) {
         onRecordingStart();

--- a/frontend/src/contexts/UserContext.js
+++ b/frontend/src/contexts/UserContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from "react";
 import api from "../api";
+import { markSpendBlocked } from "../utils/spendCap";
 
 // Create a new context
 const UserContext = createContext(null);
@@ -18,6 +19,9 @@ export const UserProvider = ({ children }) => {
         const fetchedUser = response.data.user;
         setUser(fetchedUser);
         setLoading(false);
+        // Remember an already-capped user so cost actions (e.g. starting a
+        // voice recording) can be blocked up front this session (issue #85).
+        if (fetchedUser?.spend_blocked) markSpendBlocked();
 
         // Persist the browser timezone so the LLM context can render absolute
         // local-time stamps (#130). Only PATCH when it differs from what the

--- a/frontend/src/hooks/useStreamingTTS.js
+++ b/frontend/src/hooks/useStreamingTTS.js
@@ -158,8 +158,14 @@ export function useStreamingTTS(nodeId, options = {}) {
 
     } catch (err) {
       console.error('Failed to start TTS:', err);
-      setState('error');
       setIsGenerating(false);
+      // 402 = monthly spend cap, surfaced globally by SpendCapBanner. Reset
+      // cleanly instead of showing the raw error code in the TTS control.
+      if (err.response?.status === 402) {
+        setState('idle');
+        return;
+      }
+      setState('error');
       setErrorMessage(err.response?.data?.error || err.message);
       if (onError) {
         onError(err);

--- a/frontend/src/pages/VoicePage.js
+++ b/frontend/src/pages/VoicePage.js
@@ -8,6 +8,7 @@ import RecoveryBanner from '../components/RecoveryBanner';
 import OfflineBanner from '../components/OfflineBanner';
 import ProposalInline from '../components/ProposalInline';
 import { useToast } from '../contexts/ToastContext';
+import { isSpendBlocked, notifySpendBlocked } from '../utils/spendCap';
 import api from '../api';
 
 function formatDuration(seconds) {
@@ -334,6 +335,7 @@ export default function VoicePage() {
         <RecoveryBanner
           draft={interruptedDraft}
           onContinue={() => {
+            if (isSpendBlocked()) { notifySpendBlocked(); return; }
             const { session_id, id, chunk_count, parent_id, streaming_mime_type } = interruptedDraft;
             clearInterrupted();
             handleResumeSession({
@@ -405,7 +407,12 @@ export default function VoicePage() {
 
         {phase === 'ready' && (
           <button
-            onClick={handleStart}
+            onClick={() => {
+              // Block before any recording starts — a long recording stopped
+              // only at the end would be lost work (issue #85).
+              if (isSpendBlocked()) { notifySpendBlocked(); return; }
+              handleStart();
+            }}
             disabled={!isOnline}
             style={{
               width: '72px', height: '72px', borderRadius: '50%',
@@ -609,7 +616,10 @@ export default function VoicePage() {
 
       {/* Record button to continue */}
       <button
-        onClick={() => handleContinue(voiceReset)}
+        onClick={() => {
+          if (isSpendBlocked()) { notifySpendBlocked(); return; }
+          handleContinue(voiceReset);
+        }}
         disabled={!isOnline}
         title={isOnline ? 'Continue' : "You're offline"}
         style={{

--- a/frontend/src/utils/spendCap.js
+++ b/frontend/src/utils/spendCap.js
@@ -1,0 +1,35 @@
+// Client-side knowledge of the per-user monthly spend cap (issue #85), so
+// cost actions can be blocked BEFORE they start — most importantly, before a
+// voice recording begins, since a long recording stopped only at the end
+// would be lost work.
+//
+// The flag is set from two sources: the user object on load (UserContext calls
+// markSpendBlocked when user.spend_blocked is true) and any 402 surfaced this
+// session (the api.js interceptor dispatches 'loore:spend-capped'). It only
+// ever flips true within a session; a new month clears it on the next load
+// (user.spend_blocked comes back false).
+
+let _capped = false;
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('loore:spend-capped', () => { _capped = true; });
+}
+
+export function markSpendBlocked() {
+  _capped = true;
+}
+
+export function isSpendBlocked() {
+  return _capped;
+}
+
+// Re-surface the banner (and mark blocked) — call this when a capped user
+// attempts a cost action that we're refusing client-side.
+export function notifySpendBlocked() {
+  _capped = true;
+  try {
+    window.dispatchEvent(new CustomEvent('loore:spend-capped', {}));
+  } catch (e) {
+    // Ignore — CustomEvent unavailable.
+  }
+}


### PR DESCRIPTION
## What

A free-alpha guardrail (follow-up to #85's global monitor): when a single user's **month-to-date API spend across all providers** reaches `PER_USER_MONTHLY_LIMIT_USD`, they are **hard-blocked** from new cost-incurring actions until the month rolls over, and an alert email goes to `SPEND_ALERT_EMAIL` (defaults to signup@loore.org). Writing plain text, reading, and editing are never blocked — only actions that spend.

Ships **dark** — `PER_USER_MONTHLY_LIMIT_USD` defaults to `0` (disabled). Set it in prod (e.g. `50`) to activate, exactly like the #85 global cap.

## How it tracks & enforces

- **`User.spend_blocked_month`** (`"YYYY-MM"`) — set when the cap is crossed; the gate compares it to the current month, so the block **auto-clears at month rollover with no cron**.
- **After-insert listener on `APICostLog`** schedules a deferred, out-of-band per-user check once per cost log (countdown 15s so it reads committed state). The request path stays free — a flag read; the aggregate (one indexed `SUM`) runs only at log time. No-op unless the cap is enabled, so default config and tests incur zero broker traffic.
- **`enforce_user_spend_cap()`** sums month-to-date spend, persists the block first, then best-effort emails (block survives a mail failure). Idempotent within a month.

## Enforcement — never create a cost-bearing action when capped

- **Single chokepoint:** `create_llm_placeholder()` raises `SpendCapExceeded` **before any DB write**, so an LLM node is never created for a blocked user on any path (textmode, replies, voice chain, from-node). A Flask error handler maps it to the standard **402 `monthly_spend_limit_reached`** payload.
- **Route pre-flight** (`@require_spend_headroom` → 402) on the discrete user actions: LLM response, node TTS, profile TTS, profile generate/update/integrate.
- **Task-entry guards** on every cost-incurring task (LLM completion, audio + streaming transcription, node/profile TTS, recent-context, profile gen/update/integrate, voice todo merge) — catches voice-chain and auto-triggered spend even where no route fronts it.
- **`/textmode/start`** keeps the system + user nodes (writing isn't blocked) and returns `spend_capped: true` instead of creating a placeholder, so the UI lands on the new thread with no stuck "pending" node.
- **Recording blocked up front:** voice recordings can be ~1h, so a recording stopped only at the end would be lost work. The client learns the cap (`spend_blocked` on the user object, plus any 402 this session) and the **Voice record / continue / recovery-continue buttons and the Write-New-Entry mic** refuse to start recording and show the banner on click.

## Frontend — "limit reached" banner & UX

- **`api.js` interceptor** turns any 402 `monthly_spend_limit_reached` into a global `loore:spend-capped` event; call-site error handling still runs (re-rejected) so spinners stop.
- **`SpendCapBanner`** shows a dismissible, on-brand bottom-center banner (above the audio player, matching the toasts).
- **No raw error codes / no blank views:** NodeDetail's LLM-request catches (explicit button, auto-generate submit, edit, session-from-node) and `useStreamingTTS` swallow the 402 and keep the user where they are; a capped reply still creates and shows the user's node (only the LLM reply is skipped).
- **`utils/spendCap.js`** tracks the cap client-side (set on user load when already capped, and on any 402); `UserContext` marks it.

## Admin & config

- `GET /api/admin/spend` now also reports `per_user_limit_usd` and `users_blocked_this_month`.
- Env vars: `PER_USER_MONTHLY_LIMIT_USD` (`config.py`, default 0 = off), `SPEND_ALERT_EMAIL` (default signup@loore.org). One global ceiling applied per user — no per-user override or DB-stored limit.

## Tests

7 new backend tests in `test_user_spend_cap.py` (per-user aggregation across providers, disabled-by-default, under-cap, block+email, within-month idempotency, flag/rollover, the 402 decorator, and the `create_llm_placeholder` chokepoint creating no orphan node). Full backend suite: **532 pass**. Frontend builds clean. Model-only change → migration auto-generates on deploy.

## Verified on staging

Block email received; LLM reply, speaker/TTS, fresh textmode session, existing-thread reply (with auto-generate), and voice recording all blocked with the banner and no stuck placeholders; writing plain text still works. Activated in testing via the flask shell (`app.config["PER_USER_MONTHLY_LIMIT_USD"]`) since the env var ships dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
