### PR TITLE
feat: Alchemical Mode v1 — readiness gate, opt-in, Alchemy card, source-guided sessions (dark, ALCHEMY_V1)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -49,3 +49,4 @@ MAIL_USE_TLS=true
 MAIL_USERNAME=<email address>
 MAIL_PASSWORD=<password>
 MAIL_DEFAULT_SENDER=<email address>
+ALCHEMY_V1=true

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -180,6 +180,10 @@ def create_app():
     from backend.routes.feedback import feedback_bp
     app.register_blueprint(feedback_bp, url_prefix="/api/feedback")
 
+    # Alchemical Mode (dark behind ALCHEMY_V1; routes 404 while off).
+    from backend.routes.alchemy import alchemy_bp
+    app.register_blueprint(alchemy_bp, url_prefix="/api/alchemy")
+
     # AI preferences folded into the artifact model (#158 Slice 5): managed via
     # the generic /api/artifacts CRUD (kind="ai_preferences"); the dedicated
     # /api/ai-preferences blueprint was removed.

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -84,4 +84,5 @@ from backend.tasks import recent_context  # noqa: F401
 from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
 from backend.tasks import spend_monitor  # noqa: F401
+from backend.tasks import alchemy_readiness  # noqa: F401
 from backend.tasks import embeddings  # noqa: F401

--- a/backend/config.py
+++ b/backend/config.py
@@ -73,6 +73,15 @@ class Config:
     SEMANTIC_SEARCH_AGENTIC = os.environ.get(
         "SEMANTIC_SEARCH_AGENTIC", "false").lower() in ("1", "true", "yes")
 
+    # --- Alchemical Mode (docs/FOUR-FEATURE-ECOSYSTEM.md) ---
+    # Guided depth work behind a DOUBLE gate (LLM readiness pre-filter +
+    # explicit user opt-in with disclaimers). Ships DARK: off by default,
+    # on in staging. Off -> alchemy routes 404, the read_source tool is
+    # dropped from the tool list, and alchemy_status is absent from the
+    # user payload (frontend shows nothing).
+    ALCHEMY_V1 = os.environ.get(
+        "ALCHEMY_V1", "false").lower() in ("1", "true", "yes")
+
     # Safety factor for prompt-too-long retries (0.99 = aim for 99% of the limit)
     RETRY_SAFETY_FACTOR = 0.99
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -728,6 +728,86 @@ class UserFeedback(db.Model):
         return decrypt_content(self.content)
 
 
+class AlchemySource(db.Model):
+    """A body of source material for Alchemical Mode (docs/FOUR-FEATURE-
+    ECOSYSTEM.md "Alchemical Mode"). Public/licensed texts (not user data),
+    stored chunked + embedded so the alchemy guide can retrieve passages
+    relevant to where the user currently is."""
+    __tablename__ = "alchemy_source"
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(48), nullable=False, unique=True, index=True)
+    title = db.Column(db.String(128), nullable=False)
+    description = db.Column(db.String(255), nullable=True)
+    origin_url = db.Column(db.String(512), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    @property
+    def available(self):
+        return bool(self.chunks and len(self.chunks) > 0)
+
+
+class AlchemySourceChunk(db.Model):
+    """One passage of an AlchemySource, with its embedding (packed float32,
+    same convention as NodeEmbedding). Plaintext — this is published text,
+    not user content."""
+    __tablename__ = "alchemy_source_chunk"
+    id = db.Column(db.Integer, primary_key=True)
+    source_id = db.Column(
+        db.Integer,
+        db.ForeignKey("alchemy_source.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    idx = db.Column(db.Integer, nullable=False)
+    heading = db.Column(db.String(255), nullable=True)
+    content = db.Column(db.Text, nullable=False)
+    vector = db.Column(db.LargeBinary, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    source = db.relationship("AlchemySource", backref=db.backref(
+        "chunks", cascade="all, delete-orphan", order_by="AlchemySourceChunk.idx"))
+
+
+class AlchemyState(db.Model):
+    """Per-user Alchemical Mode state — the double gate, made structural.
+
+    readiness_status is OUR side (a separate LLM process checking the last
+    couple of months of the user's data against a safety/readiness
+    checklist); opted_in_at + disclaimer acceptance is the USER's side.
+    The mode does nothing for a user unless BOTH gates are open."""
+    __tablename__ = "alchemy_state"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, unique=True, index=True)
+    # not_checked | ready | not_ready
+    readiness_status = db.Column(db.String(16), nullable=False,
+                                 default="not_checked")
+    readiness_rationale = db.Column(db.Text, nullable=True)  # encrypted
+    checked_at = db.Column(db.DateTime, nullable=True)
+    checked_by = db.Column(db.String(64), nullable=True)
+    opted_in_at = db.Column(db.DateTime, nullable=True)
+    source_slug = db.Column(db.String(48), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref=db.backref(
+        "alchemy_state", uselist=False))
+
+    def set_rationale(self, plaintext):
+        self.readiness_rationale = encrypt_content(plaintext or "")
+
+    def get_rationale(self):
+        return decrypt_content(self.readiness_rationale) \
+            if self.readiness_rationale else ""
+
+    @property
+    def status_for_user(self):
+        """What the frontend sees: None (nothing), "offered", "active"."""
+        if self.opted_in_at is not None:
+            return "active"
+        if self.readiness_status == "ready":
+            return "offered"
+        return None
+
+
 class UserPrompt(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)

--- a/backend/prompts/alchemy.txt
+++ b/backend/prompts/alchemy.txt
@@ -1,0 +1,31 @@
+Loore is a personal AI platform where users build a growing body of text — their "lore" — through journaling, voice notes, and reflective conversation with you.
+
+This is an ALCHEMY session — a mode the user was invited into after a readiness check, and explicitly opted into, understanding it is experimental. Your role here is different from ordinary reflection: you are a guide through a serious body of transformative source material, chosen by the user. You know them through their profile, intentions, and recent writing; the source is available to you through the read_source tool.
+
+## What alchemy sessions are
+
+The user is not here to read the source — they are here to be met. The source informs YOU; the user receives it through you, translated into their own vocabulary, connected to what they are actually living through right now. Think of the source as a mountain and yourself as the local guide: you have walked it, you know where the paths are, and you take the user only as far as their current footing allows.
+
+## Method
+
+- Begin from where the user actually is — what they said, not where the material "should" start. The right entry point is whatever in the source speaks to their present state.
+- Use read_source to pull passages relevant to what the user is working with. Read before you guide: retrieve, digest, then speak in your own words woven with theirs. Quote the source sparingly and only when the original phrasing carries something a paraphrase would lose; name the source when you quote it.
+- Translate, don't teach. No jargon the user hasn't already used or you haven't grounded. If a term from the source is worth introducing, introduce it through something the user already said.
+- Pace by their sharing. One step per session is fine. If their material shows turbulence — destabilization, sleep loss, crisis language — set the source aside entirely and just be with what's there; suggest they return when things settle. Never push depth onto instability.
+- The user can stop at any time, and you should occasionally make that felt — lightly, without ceremony.
+
+## Boundaries
+
+- This is not therapy, and you are not a teacher granting attainments. No diagnosing, no promising outcomes, no "you are now ready for X" pronouncements.
+- If the user asks what this mode is, be plain about it: a guided, personalized path through the source they chose.
+- All the ordinary Loore behaviors (todos, proposals, artifacts) remain available but recede — use them only if the user clearly asks.
+
+{user_profile}
+
+<user_intentions>
+{user_intentions}
+</user_intentions>
+
+<user_recent>
+{user_recent}
+</user_recent>

--- a/backend/prompts/alchemy_readiness.txt
+++ b/backend/prompts/alchemy_readiness.txt
@@ -1,0 +1,24 @@
+You are performing a READINESS AND SAFETY CHECK for Loore's Alchemical Mode — a guided journey through serious contemplative/transformative source material. You will see roughly the last two months of one user's journal writing. Your job is to judge whether OFFERING this mode to them now is safe and appropriate. This is a gate that protects the user; when in doubt, the answer is no.
+
+IMPORTANT: This checklist is a v0 DRAFT written by the AI developer-collaborator. The safety criteria are ultimately the product owner's call and this file is expected to be reviewed and rewritten by him.
+
+Evaluate the writing against this checklist:
+
+1. **Stability** — Daily life appears functional: work, relationships, sleep, basic self-care show up as ordinary background, not as ongoing emergencies.
+2. **No acute crisis** — No indications of acute mental-health crisis, suicidal ideation, self-harm, psychosis-adjacent experiences, mania, or substance crisis in the recent window. ANY such indication means not ready, full stop.
+3. **Grounded self-reflection** — The user can observe their own states and name them without being swallowed by them; some capacity to hold difficult material at a distance.
+4. **Genuine pull toward depth** — Evidence of authentic interest in contemplative, philosophical, psychological, or spiritual depth work — arising from them, not something a recommendation would implant.
+5. **Resourced** — Signs of support: relationships, practices, routines, or professional support they can lean on if the material stirs things up.
+6. **No recent destabilization by depth work itself** — If previous intense practice/experiences appear (retreats, psychedelics, energetic phenomena, dark-night territory), they are integrated or being handled with support, not raw and unheld.
+
+Respond with ONLY a JSON object, no other text:
+
+{
+  "ready": true | false,
+  "rationale": "2-4 sentences explaining the judgment, written respectfully — the user may one day read this.",
+  "flags": ["short machine-readable tags for any concerns, e.g. sleep-disruption, crisis-language, thin-support, insufficient-data"]
+}
+
+Rules:
+- Fewer than ~10 substantive entries in the window, or mostly logistical content with no interior material → not ready, flag "insufficient-data".
+- Uncertainty resolves to "ready": false. There is no cost to waiting; there can be a cost to not waiting.

--- a/backend/routes/alchemy.py
+++ b/backend/routes/alchemy.py
@@ -1,0 +1,228 @@
+"""Alchemical Mode routes (dark behind ALCHEMY_V1).
+
+The double gate, enforced here:
+- /status and the Home card only ever OFFER the mode to users whose
+  AlchemyState says the readiness check passed (our side).
+- /opt-in requires the readiness gate to be open AND an explicit
+  accept_risks acknowledgment (user side).
+- /start requires both gates open, and attaches the hidden alchemy guide
+  prompt (never the user-editable textmode prompt).
+"""
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request, current_app
+from flask_login import login_required, current_user
+
+from backend.models import (
+    Node, AlchemySource, AlchemyState, User,
+)
+from backend.extensions import db
+from backend.utils.privacy import validate_ai_usage
+from backend.utils.llm_nodes import (
+    create_llm_placeholder, pick_model_for_generation,
+)
+from backend.utils.context_artifacts import attach_context_artifacts
+
+alchemy_bp = Blueprint("alchemy", __name__)
+
+PROMPT_KEY = "alchemy"
+
+
+def _enabled():
+    return bool(current_app.config.get("ALCHEMY_V1", False))
+
+
+def _state():
+    return AlchemyState.query.filter_by(user_id=current_user.id).first()
+
+
+@alchemy_bp.route("/status", methods=["GET"])
+@login_required
+def status():
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    state = _state()
+    return jsonify({
+        "status": state.status_for_user if state else None,
+        "source_slug": state.source_slug if state else None,
+    }), 200
+
+
+@alchemy_bp.route("/sources", methods=["GET"])
+@login_required
+def sources():
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    rows = AlchemySource.query.order_by(AlchemySource.id.asc()).all()
+    return jsonify({"sources": [{
+        "slug": s.slug,
+        "title": s.title,
+        "description": s.description,
+        "available": s.available,
+    } for s in rows]}), 200
+
+
+@alchemy_bp.route("/opt-in", methods=["POST"])
+@login_required
+def opt_in():
+    """The user-side gate. Requires the readiness gate already open and an
+    explicit acknowledgment of the risks."""
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    state = _state()
+    if state is None or state.readiness_status != "ready":
+        return jsonify({
+            "error": "Alchemical Mode is not available for this account."
+        }), 403
+    if state.opted_in_at is not None:
+        return jsonify({"error": "Already opted in."}), 409
+
+    data = request.get_json() or {}
+    if data.get("accept_risks") is not True:
+        return jsonify({
+            "error": "Explicit acknowledgment of the risks is required."
+        }), 400
+    source_slug = data.get("source_slug")
+    source = AlchemySource.query.filter_by(slug=source_slug).first()
+    if source is None or not source.available:
+        return jsonify({"error": "Unknown or unavailable source."}), 400
+
+    state.opted_in_at = datetime.utcnow()
+    state.source_slug = source.slug
+    db.session.commit()
+    return jsonify({
+        "status": "active",
+        "source_slug": source.slug,
+    }), 200
+
+
+@alchemy_bp.route("/opt-out", methods=["POST"])
+@login_required
+def opt_out():
+    """Stopping must always be at least as easy as starting."""
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    state = _state()
+    if state is None or state.opted_in_at is None:
+        return jsonify({"error": "Not opted in."}), 409
+    state.opted_in_at = None
+    state.source_slug = None
+    db.session.commit()
+    return jsonify({"status": "offered"}), 200
+
+
+@alchemy_bp.route("/check-readiness", methods=["POST"])
+@login_required
+def trigger_readiness():
+    """Admin-only manual trigger of the readiness check for a user.
+
+    Deliberately not self-serve and not scheduled — rollout policy (who
+    gets checked, when) is an open product decision."""
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    if not current_user.is_admin:
+        return jsonify({"error": "Unauthorized"}), 403
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    if not user_id or not User.query.get(user_id):
+        return jsonify({"error": "user_id is required"}), 400
+    from backend.tasks.alchemy_readiness import check_user_readiness
+    task = check_user_readiness.delay(user_id)
+    return jsonify({"task_id": task.id}), 202
+
+
+@alchemy_bp.route("/start", methods=["POST"])
+@login_required
+def start_session():
+    """Start an alchemy conversation — mirrors /textmode/start, but the
+    system node carries the HIDDEN alchemy guide prompt and both gates are
+    checked. Subsequent turns ride the ordinary thread flow."""
+    if not _enabled():
+        return jsonify({"error": "Not found"}), 404
+    state = _state()
+    if (state is None or state.readiness_status != "ready"
+            or state.opted_in_at is None):
+        return jsonify({
+            "error": "Alchemical Mode is not active for this account."
+        }), 403
+
+    data = request.get_json() or {}
+    content = data.get("content")
+    if not content or not content.strip():
+        return jsonify({"error": "Content is required"}), 400
+    from backend.utils.node_split import NODE_CHAR_CAP
+    if len(content) > NODE_CHAR_CAP:
+        return jsonify({
+            "error": (f"Content exceeds the {NODE_CHAR_CAP:,}-character "
+                      f"per-entry limit."),
+            "char_cap": NODE_CHAR_CAP,
+        }), 422
+
+    ai_usage = data.get("ai_usage") or current_user.default_ai_usage
+    if not validate_ai_usage(ai_usage) or ai_usage == "none":
+        return jsonify({
+            "error": "Alchemy requires ai_usage of 'chat' or 'train'",
+        }), 400
+    # Depth work stays private by default regardless of the user's default
+    # privacy setting — sharing an alchemy thread is a deliberate act later.
+    privacy_level = "private"
+
+    model_id = data.get("model")
+    if not model_id:
+        model_id = pick_model_for_generation(None, current_user)
+    if model_id not in current_app.config["SUPPORTED_MODELS"]:
+        return jsonify({"error": f"Unsupported model: {model_id}"}), 400
+
+    from backend.utils.prompts import get_user_prompt_record
+    prompt_record = get_user_prompt_record(current_user.id, PROMPT_KEY)
+
+    system_node = Node(
+        user_id=current_user.id,
+        human_owner_id=current_user.id,
+        parent_id=None,
+        node_type="user",
+        privacy_level=privacy_level,
+        ai_usage=ai_usage,
+    )
+    db.session.add(system_node)
+    db.session.flush()
+    attach_context_artifacts(
+        system_node.id, current_user.id, prompt_record=prompt_record,
+    )
+
+    from backend.utils.tokens import approximate_token_count
+    user_node = Node(
+        user_id=current_user.id,
+        human_owner_id=current_user.id,
+        parent_id=system_node.id,
+        node_type="user",
+        privacy_level=privacy_level,
+        ai_usage=ai_usage,
+        token_count=approximate_token_count(content),
+    )
+    user_node.set_content(content)
+    db.session.add(user_node)
+    db.session.flush()
+
+    from backend.utils.spend import user_is_capped
+    if user_is_capped(current_user):
+        db.session.commit()
+        return jsonify({
+            "conversation_id": system_node.id,
+            "user_node_id": user_node.id,
+            "spend_capped": True,
+        }), 202
+
+    llm_node, task_id = create_llm_placeholder(
+        user_node.id, model_id, current_user.id,
+        privacy_level=privacy_level,
+        ai_usage=ai_usage,
+        source_mode="textmode",
+    )
+    db.session.commit()
+    return jsonify({
+        "conversation_id": system_node.id,
+        "user_node_id": user_node.id,
+        "llm_node_id": llm_node.id,
+        "task_id": task_id,
+    }), 202

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -10,6 +10,24 @@ from backend.routes.terms import CURRENT_TERMS_VERSION
 from backend.utils.reserved_usernames import validate_username
 from backend.utils.spend import user_is_capped
 
+
+def _alchemy_status_for(user):
+    from flask import current_app
+    if not current_app.config.get("ALCHEMY_V1", False):
+        return None
+    from backend.models import AlchemyState
+    state = AlchemyState.query.filter_by(user_id=user.id).first()
+    return state.status_for_user if state else None
+
+
+def _alchemy_source_for(user):
+    from flask import current_app
+    if not current_app.config.get("ALCHEMY_V1", False):
+        return None
+    from backend.models import AlchemyState
+    state = AlchemyState.query.filter_by(user_id=user.id).first()
+    return state.source_slug if state and state.opted_in_at else None
+
 dashboard_bp = Blueprint("dashboard_bp", __name__)
 
 
@@ -125,6 +143,10 @@ def get_dashboard():
             # Lets the client block cost actions (e.g. starting a long voice
             # recording) up front instead of after the fact (issue #85).
             "spend_blocked": user_is_capped(current_user),
+            # Alchemical Mode (dark behind ALCHEMY_V1): null = show nothing,
+            # "offered" = show the invitation card, "active" = mode is on.
+            "alchemy_status": _alchemy_status_for(current_user),
+            "alchemy_source": _alchemy_source_for(current_user),
         },
         "pinned_nodes": pinned_list,
         "nodes": nodes_list,

--- a/backend/routes/prompts.py
+++ b/backend/routes/prompts.py
@@ -98,6 +98,11 @@ def get_prompt(prompt_key):
     """Get the active version of a specific prompt."""
     if prompt_key not in PROMPT_DEFAULTS:
         return jsonify({"error": "Unknown prompt key"}), 404
+    if PROMPT_DEFAULTS[prompt_key].get('hidden'):
+        # Hidden prompts (e.g. the Alchemy guide) are not user-readable or
+        # user-editable — the mode depends on the user meeting the material
+        # through the guide, and gates must not be self-editable.
+        return jsonify({"error": "Unknown prompt key"}), 404
 
     meta = PROMPT_DEFAULTS[prompt_key]
     latest = UserPrompt.query.filter_by(
@@ -129,6 +134,8 @@ def get_prompt(prompt_key):
 def update_prompt(prompt_key):
     """Save a new version of a prompt."""
     if prompt_key not in PROMPT_DEFAULTS:
+        return jsonify({"error": "Unknown prompt key"}), 404
+    if PROMPT_DEFAULTS[prompt_key].get('hidden'):
         return jsonify({"error": "Unknown prompt key"}), 404
 
     data = request.get_json() or {}

--- a/backend/scripts/import_alchemy_source.py
+++ b/backend/scripts/import_alchemy_source.py
@@ -1,0 +1,97 @@
+"""Import an Alchemy source from a URL or file into the database.
+
+Usage (from repo root, inside the app environment):
+    python backend/scripts/import_alchemy_source.py \
+        --slug meditationbook \
+        --title "Meditationbook (Mark Lippmann)" \
+        --url https://meditationbook.page/ \
+        --description "Mark Lippmann's (meditationstuff) book on meditation." \
+        --execute
+
+Without --execute it's a dry run: fetches, chunks, prints stats, writes
+nothing. Embedding requires OPENAI key config (chat key); cost is logged
+to the admin user (--cost-user-id, default 1).
+
+NOTE: run off the prod VM or in small batches per
+project_no_heavy_scripts_on_prod_vm — though this one is light (one page,
+one embedding sweep).
+"""
+import argparse
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend import create_app  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--slug", required=True)
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--url", help="Fetch source HTML from this URL")
+    ap.add_argument("--file", help="Read source text/HTML from a file")
+    ap.add_argument("--description", default=None)
+    ap.add_argument("--cost-user-id", type=int, default=1)
+    ap.add_argument("--execute", action="store_true",
+                    help="Actually write to the DB (default: dry run)")
+    ap.add_argument("--no-embed", action="store_true",
+                    help="Store chunks without embeddings (search inert)")
+    args = ap.parse_args()
+
+    if not args.url and not args.file:
+        ap.error("one of --url / --file is required")
+
+    app = create_app()
+    with app.app_context():
+        from backend.utils.alchemy_sources import (
+            html_to_text, chunk_text, import_source,
+        )
+        from backend.utils.api_keys import get_openai_chat_key
+
+        if args.url:
+            import requests
+            print(f"Fetching {args.url} …")
+            resp = requests.get(args.url, timeout=120, headers={
+                "User-Agent": "Loore-alchemy-import/1.0"})
+            resp.raise_for_status()
+            raw = resp.text
+        else:
+            with open(args.file, "r", encoding="utf-8") as f:
+                raw = f.read()
+
+        text = html_to_text(raw) if "<" in raw[:1000] else raw
+        chunks = chunk_text(text)
+        total_chars = sum(len(c) for _h, c in chunks)
+        headings = sum(1 for h, _c in chunks if h)
+        print(f"Text: {len(text):,} chars → {len(chunks)} chunks "
+              f"({total_chars:,} chars, {headings} with headings)")
+        if chunks:
+            h0, c0 = chunks[0]
+            print(f"First chunk [{h0}]: {c0[:200]!r}")
+
+        if not args.execute:
+            print("DRY RUN — nothing written. Re-run with --execute.")
+            return
+
+        api_key = None
+        if not args.no_embed:
+            api_key = get_openai_chat_key(app.config)
+            if not api_key:
+                print("No OpenAI key configured — aborting (use "
+                      "--no-embed to store without vectors).")
+                sys.exit(1)
+
+        source, count = import_source(
+            args.slug, args.title, text,
+            description=args.description, origin_url=args.url,
+            api_key=api_key, embed_user_id=args.cost_user_id,
+        )
+        print(f"Imported source '{source.slug}' (id={source.id}) "
+              f"with {count} chunks"
+              + (" (no embeddings)" if args.no_embed else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tasks/alchemy_readiness.py
+++ b/backend/tasks/alchemy_readiness.py
@@ -1,0 +1,181 @@
+"""Celery task: Alchemical Mode readiness/safety check.
+
+The OUR-side half of the double gate (docs/FOUR-FEATURE-ECOSYSTEM.md,
+"Alchemical Mode"): a separate LLM process reads roughly the last two
+months of a user's writing and judges it against the safety/readiness
+checklist in prompts/alchemy_readiness.txt. Only users judged ready are
+ever OFFERED the mode; opting in stays a separate, explicit user action.
+
+Dispatched manually (admin endpoint / flask shell) — deliberately not on
+a beat schedule until the checklist has been reviewed and the rollout
+policy decided.
+"""
+import json
+import os
+from datetime import datetime, timedelta
+
+from celery.utils.log import get_task_logger
+
+from backend.celery_app import celery, flask_app
+from backend.models import User, AlchemyState, APICostLog
+from backend.extensions import db
+from backend.llm_providers import LLMProvider, PromptTooLongError
+from backend.utils.tokens import reduce_export_tokens
+from backend.utils.api_keys import get_api_keys_for_usage
+from backend.utils.cost import calculate_llm_cost_microdollars
+
+logger = get_task_logger(__name__)
+
+READINESS_WINDOW_DAYS = 60
+
+
+def _load_readiness_prompt():
+    # Deliberately NOT user-overridable — a user editing their own safety
+    # gate would defeat it.
+    path = os.path.join(flask_app.root_path, "prompts",
+                        "alchemy_readiness.txt")
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _parse_verdict(text):
+    """Parse the model's JSON verdict, tolerating code fences. Any parse
+    failure resolves to not-ready (the gate fails closed)."""
+    raw = (text or "").strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        if raw.startswith("json"):
+            raw = raw[4:]
+    try:
+        start = raw.index("{")
+        end = raw.rindex("}") + 1
+        verdict = json.loads(raw[start:end])
+    except (ValueError, json.JSONDecodeError):
+        return {"ready": False,
+                "rationale": "Verdict unparseable — gate fails closed.",
+                "flags": ["unparseable-verdict"]}
+    return {
+        "ready": bool(verdict.get("ready", False)),
+        "rationale": str(verdict.get("rationale", "")),
+        "flags": list(verdict.get("flags", []) or []),
+    }
+
+
+@celery.task(name="backend.tasks.alchemy_readiness.check_user_readiness")
+def check_user_readiness(user_id):
+    """Run the readiness check for one user and persist the verdict."""
+    with flask_app.app_context():
+        if not flask_app.config.get("ALCHEMY_V1", False):
+            logger.info("ALCHEMY_V1 off — skipping readiness check")
+            return
+
+        user = User.query.get(user_id)
+        if user is None:
+            logger.warning(f"Alchemy readiness: no user {user_id}")
+            return
+
+        state = AlchemyState.query.filter_by(user_id=user_id).first()
+        if state is None:
+            state = AlchemyState(user_id=user_id)
+            db.session.add(state)
+            db.session.flush()
+
+        default_model = flask_app.config.get(
+            "DEFAULT_LLM_MODEL", "claude-opus-4.6")
+        model_id = default_model
+
+        cutoff = datetime.utcnow() - timedelta(days=READINESS_WINDOW_DAYS)
+        from backend.routes.export_data import (
+            build_user_export_content as _build_export,
+        )
+        export_result = _build_export(
+            user,
+            max_tokens=None,
+            filter_ai_usage=True,
+            created_after=cutoff,
+            chronological_order=True,
+            return_metadata=True,
+            collapse_artifacts=True,
+        )
+        if not export_result or not (export_result.get("content") or "").strip():
+            state.readiness_status = "not_ready"
+            state.set_rationale(
+                "Not enough recent writing to assess readiness.")
+            state.checked_at = datetime.utcnow()
+            state.checked_by = model_id
+            db.session.commit()
+            logger.info(f"Alchemy readiness user {user_id}: insufficient data")
+            return
+
+        prompt_template = _load_readiness_prompt()
+        api_keys = get_api_keys_for_usage(flask_app.config, "chat")
+
+        recent_data = export_result["content"]
+        MAX_RETRIES = 2
+        max_data_tokens = None
+        for attempt in range(MAX_RETRIES + 1):
+            if max_data_tokens is not None:
+                export_result = _build_export(
+                    user,
+                    max_tokens=max_data_tokens,
+                    filter_ai_usage=True,
+                    created_after=cutoff,
+                    chronological_order=True,
+                    return_metadata=True,
+                    collapse_artifacts=True,
+                )
+                if not export_result:
+                    logger.warning(
+                        f"Alchemy readiness user {user_id}: "
+                        "no data after truncation")
+                    return
+                recent_data = export_result["content"]
+            prompt_text = (
+                f"{prompt_template}\n\n"
+                f"--- USER'S RECENT WRITING (last "
+                f"{READINESS_WINDOW_DAYS} days) ---\n\n{recent_data}"
+            )
+            messages = [{
+                "role": "user",
+                "content": [{"type": "text", "text": prompt_text}],
+            }]
+            try:
+                response = LLMProvider.get_completion(
+                    model_id, messages, api_keys)
+                break
+            except PromptTooLongError as e:
+                if attempt == MAX_RETRIES:
+                    raise
+                max_data_tokens = reduce_export_tokens(
+                    max_data_tokens, e.actual_tokens, e.max_tokens,
+                    export_content=recent_data,
+                )
+                logger.warning(
+                    f"Alchemy readiness prompt too long "
+                    f"({e.actual_tokens} > {e.max_tokens}); retrying "
+                    f"with max_data_tokens={max_data_tokens}")
+
+        input_tokens = response.get("input_tokens", 0)
+        output_tokens = response.get("output_tokens", 0)
+        cost = calculate_llm_cost_microdollars(
+            model_id, input_tokens, output_tokens)
+        db.session.add(APICostLog(
+            user_id=user_id,
+            model_id=model_id,
+            request_type="alchemy_readiness",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_microdollars=cost,
+        ))
+
+        verdict = _parse_verdict(response["content"])
+        state.readiness_status = "ready" if verdict["ready"] else "not_ready"
+        rationale = verdict["rationale"]
+        if verdict["flags"]:
+            rationale += f" [flags: {', '.join(verdict['flags'])}]"
+        state.set_rationale(rationale)
+        state.checked_at = datetime.utcnow()
+        state.checked_by = model_id
+        db.session.commit()
+        logger.info(
+            f"Alchemy readiness user {user_id}: {state.readiness_status}")

--- a/backend/tasks/llm_completion.py
+++ b/backend/tasks/llm_completion.py
@@ -59,7 +59,8 @@ USER_ARTIFACTS_INDEX_PLACEHOLDER = "{user_artifacts_index}"
 # read_artifact pulls a UserArtifact by kind; read_todo pulls the user's todo
 # list (its own model, no longer shown inline — #158 Slice 3); semantic_search
 # pulls relevant snippets from the user's own archive by meaning (#155).
-RETRIEVAL_TOOLS = {"read_artifact", "read_todo", "semantic_search"}
+RETRIEVAL_TOOLS = {"read_artifact", "read_todo", "semantic_search",
+                   "read_source"}
 # Max number of interim retrieval round-trips before the model must answer.
 MAX_RETRIEVAL_ROUNDS = 5
 # Max new {quote:ID} pulls resolved per loop round (a 1h sharing can be huge;
@@ -275,6 +276,31 @@ VOICE_TOOLS = [
             "required": [],
         },
     },
+    {
+        "name": "read_source",
+        "description": (
+            "Alchemy sessions only. Retrieve passages from the user's "
+            "selected source material relevant to a query — where the "
+            "source speaks to what the user is currently working with. "
+            "Returns the most relevant passages within the same turn. "
+            "Tell the user you're consulting the source. Do not call "
+            "this outside an alchemy session — it will error."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "What to look for in the source — a theme, "
+                        "question, or the user's current state, in plain "
+                        "language."
+                    ),
+                },
+            },
+            "required": ["query"],
+        },
+    },
 ]
 
 
@@ -288,9 +314,14 @@ def gated_voice_tools(config):
     any divergence here silently busts the whole cache — the warm writes a
     tool set generation never reads (observed as read=0 with the warm
     keeping semantic_search while generation dropped it)."""
-    if config.get("SEMANTIC_SEARCH_AGENTIC", False):
+    dropped = set()
+    if not config.get("SEMANTIC_SEARCH_AGENTIC", False):
+        dropped.add("semantic_search")
+    if not config.get("ALCHEMY_V1", False):
+        dropped.add("read_source")
+    if not dropped:
         return VOICE_TOOLS
-    return [t for t in VOICE_TOOLS if t.get("name") != "semantic_search"]
+    return [t for t in VOICE_TOOLS if t.get("name") not in dropped]
 
 
 _ARTIFACT_KIND_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,47}$')
@@ -572,6 +603,25 @@ def _retrieval_injection_text(tr):
             f"\"{tr.get('query', '')}\" — previews only; to read one in full, "
             "reference it as {quote:<id>}. Use only if actually relevant:\n"
             + "\n".join(lines) + "]")
+    if name == "read_source":
+        from backend.models import AlchemySourceChunk
+        chunks = tr.get("chunks") or []
+        parts = []
+        for c in chunks:
+            chunk = AlchemySourceChunk.query.get(c.get("chunk_id"))
+            if chunk is None:
+                continue
+            text = (chunk.content or "").strip()
+            if not text:
+                continue
+            heading = f" — {chunk.heading}" if chunk.heading else ""
+            parts.append(f"--- passage {chunk.idx}{heading} ---\n{text}")
+        if not parts:
+            return None
+        return (
+            f"[Source passages for \"{tr.get('query', '')}\" "
+            f"(from {tr.get('source_slug', 'the selected source')}):\n\n"
+            + "\n\n".join(parts) + "]")
     return None
 
 
@@ -1019,6 +1069,59 @@ def _execute_tool_calls(tool_calls, llm_node, node_chain, user_id):
                             {"node_id": nid, "score": round(score, 4)}
                             for nid, _created, _snip, score in snippets
                         ]
+
+            elif name == "read_source":
+                # Alchemy: retrieve passages from the user's selected source
+                # (docs/FOUR-FEATURE-ECOSYSTEM.md, "Alchemical Mode"). Only
+                # chunk ids + scores are stored in meta; passage text is
+                # re-resolved at injection time like the other retrievals.
+                query = (inp.get("query") or "").strip()
+                from backend.models import AlchemyState, AlchemySource
+                alchemy_state = AlchemyState.query.filter_by(
+                    user_id=user_id).first()
+                if not query:
+                    result["status"] = "error"
+                    result["error"] = "read_source needs a query."
+                elif (alchemy_state is None
+                        or alchemy_state.opted_in_at is None
+                        or not alchemy_state.source_slug):
+                    result["status"] = "error"
+                    result["error"] = (
+                        "No alchemy source is active for this user — "
+                        "read_source only works in alchemy sessions.")
+                else:
+                    source = AlchemySource.query.filter_by(
+                        slug=alchemy_state.source_slug).first()
+                    if source is None or not source.available:
+                        result["status"] = "error"
+                        result["error"] = "The selected source is empty."
+                    else:
+                        from backend.utils.api_keys import (
+                            get_openai_chat_key,
+                        )
+                        from backend.utils.alchemy_sources import (
+                            search_source_chunks,
+                        )
+                        emb_key = get_openai_chat_key(flask_app.config)
+                        if not emb_key:
+                            result["status"] = "error"
+                            result["error"] = (
+                                "Source retrieval is unavailable right "
+                                "now.")
+                        else:
+                            matches = search_source_chunks(
+                                source.id, query[:4000], emb_key,
+                                user_id=user_id,
+                                k=flask_app.config.get(
+                                    "ALCHEMY_TOP_K", 3),
+                            )
+                            result["status"] = "success"
+                            result["query"] = query
+                            result["source_slug"] = source.slug
+                            result["chunks"] = [
+                                {"chunk_id": cid, "score": round(sc, 4)}
+                                for cid, sc in matches
+                            ]
 
             elif name == "apply_feedback":
                 # Send the feedback the AI proposed under a ### Feedback

--- a/backend/tests/test_alchemy.py
+++ b/backend/tests/test_alchemy.py
@@ -1,0 +1,389 @@
+"""Tests for Alchemical Mode (ALCHEMY_V1 dark flag).
+
+Covers: the double gate (readiness pre-filter + explicit opt-in), the
+hidden alchemy prompt (off the Prompts page, blocked from read/edit),
+source chunking, the read_source retrieval tool + injection, the
+readiness verdict parser (fails closed), and flag-off 404s.
+
+Mirrors test_textmode.py's app/mocking pattern: celery + the LLM task
+module are mocked so create_llm_placeholder never touches a real queue.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ["ENCRYPTION_DISABLED"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("TWITTER_API_KEY", "fake")
+os.environ.setdefault("TWITTER_API_SECRET", "fake")
+
+sys.modules.setdefault("celery", MagicMock())
+sys.modules.setdefault("celery.utils", MagicMock())
+sys.modules.setdefault("celery.utils.log", MagicMock())
+sys.modules.setdefault("celery.result", MagicMock())
+sys.modules.setdefault("ffmpeg", MagicMock())
+
+_mock_llm_task_module = MagicMock()
+_mock_task_result = MagicMock()
+_mock_task_result.id = "fake-task-id"
+_mock_llm_task_module.generate_llm_response.delay.return_value = (
+    _mock_task_result
+)
+sys.modules["backend.tasks.llm_completion"] = _mock_llm_task_module
+
+import pytest  # noqa: E402
+from flask import Flask  # noqa: E402
+
+for _mod in ["flask_login", "backend.models", "backend.extensions"]:
+    if _mod in sys.modules and isinstance(sys.modules[_mod], MagicMock):
+        del sys.modules[_mod]
+
+import flask_login as _real_flask_login          # noqa: E402
+from backend.extensions import db as _db         # noqa: E402
+from backend.models import (                     # noqa: E402
+    User, Node, NodeContextArtifact,
+    AlchemySource, AlchemySourceChunk, AlchemyState,
+)
+import backend.models as _real_backend_models    # noqa: E402
+from backend.utils.alchemy_sources import (      # noqa: E402
+    html_to_text, chunk_text,
+)
+from backend.utils.embeddings import pack_vector  # noqa: E402
+
+
+def _make_app(alchemy_v1=True):
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    app.config["ALCHEMY_V1"] = alchemy_v1
+    app.config["DEFAULT_LLM_MODEL"] = "gpt-5"
+    app.config["SUPPORTED_MODELS"] = {
+        "gpt-5": {"provider": "openai", "api_model": "gpt-5"},
+    }
+
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.alchemy import alchemy_bp
+    from backend.routes.prompts import prompts_bp
+    app.register_blueprint(alchemy_bp, url_prefix="/api/alchemy")
+    app.register_blueprint(prompts_bp, url_prefix="/api/prompts")
+    return app
+
+
+@pytest.fixture
+def app():
+    _affected = lambda k: (  # noqa: E731
+        k == "flask_login"
+        or k.startswith("backend.routes")
+        or k == "backend.models"
+    )
+    saved = {k: sys.modules[k] for k in list(sys.modules) if _affected(k)}
+
+    sys.modules["flask_login"] = _real_flask_login
+    sys.modules["backend.models"] = _real_backend_models
+    for _k in [k for k in list(sys.modules) if k.startswith("backend.routes")]:
+        del sys.modules[_k]
+
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+    for k in [k for k in list(sys.modules) if _affected(k)]:
+        del sys.modules[k]
+    sys.modules.update(saved)
+
+
+@pytest.fixture
+def client(app):
+    client = app.test_client()
+    user = User.query.first()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    return client
+
+
+def _mk_source(slug="meditationbook", with_chunks=True, vectors=True):
+    source = AlchemySource(slug=slug, title="Meditationbook",
+                           description="test source")
+    _db.session.add(source)
+    _db.session.flush()
+    if with_chunks:
+        for i, (heading, content, vec) in enumerate([
+            ("On sitting", "The practice begins with sitting down.",
+             [1.0, 0.0]),
+            ("On noting", "Noting is the act of gently labeling.",
+             [0.0, 1.0]),
+        ]):
+            _db.session.add(AlchemySourceChunk(
+                source_id=source.id, idx=i, heading=heading,
+                content=content,
+                vector=pack_vector(vec) if vectors else None,
+            ))
+    _db.session.commit()
+    return source
+
+
+def _mk_state(uid, readiness="ready", opted_in=False, source_slug=None):
+    from datetime import datetime
+    state = AlchemyState(user_id=uid, readiness_status=readiness)
+    if opted_in:
+        state.opted_in_at = datetime.utcnow()
+        state.source_slug = source_slug
+    _db.session.add(state)
+    _db.session.commit()
+    return state
+
+
+# ── Model ────────────────────────────────────────────────────────────────
+
+def test_status_for_user_transitions(app):
+    uid = User.query.first().id
+    state = _mk_state(uid, readiness="not_checked")
+    assert state.status_for_user is None
+    state.readiness_status = "not_ready"
+    assert state.status_for_user is None
+    state.readiness_status = "ready"
+    assert state.status_for_user == "offered"
+    from datetime import datetime
+    state.opted_in_at = datetime.utcnow()
+    assert state.status_for_user == "active"
+
+
+# ── Chunking ─────────────────────────────────────────────────────────────
+
+def test_html_to_text_keeps_headings():
+    html = ("<html><head><style>x{}</style></head><body>"
+            "<h2>First Section</h2><p>Alpha beta.</p>"
+            "<h2>Second</h2><p>Gamma &amp; delta.</p></body></html>")
+    text = html_to_text(html)
+    assert "## First Section" in text
+    assert "Gamma & delta." in text
+    assert "style" not in text
+
+
+def test_chunk_text_splits_on_headings_and_size():
+    big_para = "Long paragraph sentence. " * 30  # ~750 chars
+    text = ("## One\n" + "\n\n".join([big_para] * 5)
+            + "\n## Two\nShort body of the second section that is long "
+              "enough to stand alone as a chunk on its own merits, with "
+              "plenty of extra words to clear the merge threshold easily "
+              "and then some more padding to be safe about the minimum "
+              "chunk length constant used by the splitter.")
+    chunks = chunk_text(text)
+    assert all(len(c) <= 3200 for _h, c in chunks)
+    assert any(h == "One" for h, _c in chunks)
+    assert any(h == "Two" for h, _c in chunks)
+    # Section One was oversized → multiple chunks under the same heading.
+    assert sum(1 for h, _c in chunks if h == "One") >= 2
+
+
+# ── Routes: the double gate ──────────────────────────────────────────────
+
+def test_status_and_sources(app, client):
+    uid = User.query.first().id
+    _mk_source()
+    r = client.get("/api/alchemy/status")
+    assert r.status_code == 200
+    assert r.get_json()["status"] is None  # no state row yet
+
+    _mk_state(uid, readiness="ready")
+    assert client.get(
+        "/api/alchemy/status").get_json()["status"] == "offered"
+
+    srcs = client.get("/api/alchemy/sources").get_json()["sources"]
+    assert srcs[0]["slug"] == "meditationbook"
+    assert srcs[0]["available"] is True
+
+
+def test_opt_in_requires_readiness_gate(app, client):
+    _mk_source()
+    # No state row at all → 403.
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook",
+                          "accept_risks": True})
+    assert r.status_code == 403
+
+    uid = User.query.first().id
+    _mk_state(uid, readiness="not_ready")
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook",
+                          "accept_risks": True})
+    assert r.status_code == 403
+
+
+def test_opt_in_requires_explicit_risk_acknowledgment(app, client):
+    uid = User.query.first().id
+    _mk_source()
+    _mk_state(uid, readiness="ready")
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook"})
+    assert r.status_code == 400
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook",
+                          "accept_risks": "yes"})  # truthy is NOT enough
+    assert r.status_code == 400
+
+
+def test_opt_in_happy_path_then_conflict_then_opt_out(app, client):
+    uid = User.query.first().id
+    _mk_source()
+    _mk_state(uid, readiness="ready")
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook",
+                          "accept_risks": True})
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "active"
+
+    # Double opt-in conflicts.
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "meditationbook",
+                          "accept_risks": True})
+    assert r.status_code == 409
+
+    # Stopping is one call, no ceremony.
+    r = client.post("/api/alchemy/opt-out")
+    assert r.status_code == 200
+    state = AlchemyState.query.filter_by(user_id=uid).first()
+    assert state.opted_in_at is None
+    assert state.status_for_user == "offered"
+
+
+def test_opt_in_rejects_unavailable_source(app, client):
+    uid = User.query.first().id
+    _mk_source(slug="empty-source", with_chunks=False)
+    _mk_state(uid, readiness="ready")
+    r = client.post("/api/alchemy/opt-in",
+                    json={"source_slug": "empty-source",
+                          "accept_risks": True})
+    assert r.status_code == 400
+
+
+def test_start_requires_active_state(app, client):
+    uid = User.query.first().id
+    _mk_source()
+    _mk_state(uid, readiness="ready")  # offered, NOT opted in
+    r = client.post("/api/alchemy/start", json={"content": "hello"})
+    assert r.status_code == 403
+
+
+def test_start_creates_thread_with_hidden_prompt(app, client):
+    uid = User.query.first().id
+    _mk_source()
+    _mk_state(uid, readiness="ready", opted_in=True,
+              source_slug="meditationbook")
+    r = client.post("/api/alchemy/start",
+                    json={"content": "What's alive: restlessness."})
+    assert r.status_code == 202
+    body = r.get_json()
+    system = Node.query.get(body["conversation_id"])
+    assert system.privacy_level == "private"
+    pin = NodeContextArtifact.query.filter_by(
+        node_id=system.id, artifact_type="prompt").first()
+    assert pin is not None
+    from backend.models import UserPrompt
+    prompt_row = UserPrompt.query.get(pin.artifact_id)
+    assert prompt_row.prompt_key == "alchemy"
+    assert "ALCHEMY session" in prompt_row.get_content()
+
+
+def test_routes_404_when_flag_off():
+    _affected = lambda k: (  # noqa: E731
+        k == "flask_login" or k.startswith("backend.routes")
+        or k == "backend.models")
+    saved = {k: sys.modules[k] for k in list(sys.modules) if _affected(k)}
+    sys.modules["flask_login"] = _real_flask_login
+    sys.modules["backend.models"] = _real_backend_models
+    for _k in [k for k in list(sys.modules)
+               if k.startswith("backend.routes")]:
+        del sys.modules[_k]
+    app = _make_app(alchemy_v1=False)
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester")
+        _db.session.add(user)
+        _db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(user.id)
+            sess["_fresh"] = True
+        assert client.get("/api/alchemy/status").status_code == 404
+        assert client.get("/api/alchemy/sources").status_code == 404
+        assert client.post("/api/alchemy/start",
+                           json={"content": "x"}).status_code == 404
+        _db.session.remove()
+        _db.drop_all()
+    for k in [k for k in list(sys.modules) if _affected(k)]:
+        del sys.modules[k]
+    sys.modules.update(saved)
+
+
+# ── Hidden prompt ────────────────────────────────────────────────────────
+
+def test_alchemy_prompt_hidden_from_prompts_api(app, client):
+    listed = client.get("/api/prompts/").get_json()["prompts"]
+    assert all(p["prompt_key"] != "alchemy" for p in listed)
+    assert client.get("/api/prompts/alchemy").status_code == 404
+    assert client.put("/api/prompts/alchemy",
+                      json={"content": "edited gate"}).status_code == 404
+
+
+# ── Readiness verdict parsing (fails closed) ─────────────────────────────
+
+def test_parse_verdict_variants():
+    # Import against stub glue (the module imports backend.celery_app).
+    glue = ("backend.celery_app", "backend.llm_providers",
+            "backend.tasks.alchemy_readiness")
+    saved = {k: sys.modules.get(k) for k in glue}
+    sys.modules["backend.celery_app"] = MagicMock()
+    sys.modules["backend.llm_providers"] = MagicMock()
+    sys.modules.pop("backend.tasks.alchemy_readiness", None)
+    from backend.tasks.alchemy_readiness import _parse_verdict
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+    ok = _parse_verdict(
+        '{"ready": true, "rationale": "Stable.", "flags": []}')
+    assert ok["ready"] is True
+
+    fenced = _parse_verdict(
+        '```json\n{"ready": false, "rationale": "Thin.", '
+        '"flags": ["insufficient-data"]}\n```')
+    assert fenced["ready"] is False
+    assert "insufficient-data" in fenced["flags"]
+
+    garbage = _parse_verdict("I think the user seems fine, probably?")
+    assert garbage["ready"] is False  # the gate fails closed
+    assert "unparseable-verdict" in garbage["flags"]
+
+
+# ── read_source retrieval ────────────────────────────────────────────────
+
+def test_search_source_chunks_ranks(app, monkeypatch):
+    _mk_source()
+    from backend.utils import alchemy_sources as als
+    monkeypatch.setattr(als, "embed_texts",
+                        lambda texts, key, **kw: [[1.0, 0.0]])
+    source = AlchemySource.query.first()
+    matches = als.search_source_chunks(source.id, "sitting", "fake-key")
+    assert len(matches) == 2
+    top_chunk = AlchemySourceChunk.query.get(matches[0][0])
+    assert top_chunk.heading == "On sitting"

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -109,7 +109,10 @@ def test_gated_voice_tools_warm_matches_generation():
     on = gated_voice_tools({"SEMANTIC_SEARCH_AGENTIC": True})
     assert "semantic_search" not in names(off)        # dark (prod default)
     assert "semantic_search" in names(on)             # enabled (staging)
-    assert names(on) == names(VOICE_TOOLS)
+    # With every dark flag enabled, the full tool list is exposed.
+    all_on = gated_voice_tools(
+        {"SEMANTIC_SEARCH_AGENTIC": True, "ALCHEMY_V1": True})
+    assert names(all_on) == names(VOICE_TOOLS)
     assert names(gated_voice_tools({})) == names(off)  # unset == dark
     # Identical config -> identical list for both call sites (the invariant).
     cfg = {"SEMANTIC_SEARCH_AGENTIC": False}

--- a/backend/utils/alchemy_sources.py
+++ b/backend/utils/alchemy_sources.py
@@ -1,0 +1,169 @@
+"""Alchemy source material: chunking, embedding, and retrieval.
+
+Sources are published texts (not user data), stored as plaintext chunks
+with packed-float32 embeddings (same convention as NodeEmbedding). The
+alchemy guide retrieves passages per turn via search_source_chunks.
+"""
+import re
+
+from backend.extensions import db
+from backend.models import AlchemySource, AlchemySourceChunk
+from backend.utils.embeddings import (
+    embed_texts, pack_vector, top_k_similar,
+)
+
+# Chunk size targets, in characters. Split on headings first; oversized
+# sections split on paragraph boundaries.
+CHUNK_TARGET_CHARS = 2400
+CHUNK_MIN_CHARS = 200
+
+
+def html_to_text(html):
+    """Best-effort HTML → readable text without external deps.
+
+    Good enough for long-form book pages (meditationbook.page); not a
+    general-purpose parser. Keeps heading markers so chunking can split
+    on section boundaries.
+    """
+    # Drop script/style/head wholesale.
+    html = re.sub(r"(?is)<(script|style|head)[^>]*>.*?</\1>", " ", html)
+    # Mark headings before stripping tags.
+    html = re.sub(r"(?is)<h([1-6])[^>]*>(.*?)</h\1>",
+                  lambda m: "\n\n## " + re.sub(
+                      r"(?s)<[^>]+>", "", m.group(2)).strip() + "\n\n",
+                  html)
+    # Block-level closers become paragraph breaks.
+    html = re.sub(r"(?i)</(p|div|li|blockquote|section|article|tr)>",
+                  "\n\n", html)
+    html = re.sub(r"(?i)<(br|hr)\s*/?>", "\n", html)
+    # Strip remaining tags.
+    text = re.sub(r"(?s)<[^>]+>", " ", html)
+    # Entities (minimal set).
+    for ent, ch in (("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"),
+                    ("&quot;", '"'), ("&#39;", "'"), ("&nbsp;", " "),
+                    ("&mdash;", "—"), ("&ndash;", "–"), ("&hellip;", "…"),
+                    ("&rsquo;", "'"), ("&lsquo;", "'"),
+                    ("&rdquo;", '"'), ("&ldquo;", '"')):
+        text = text.replace(ent, ch)
+    # Collapse whitespace but keep paragraph breaks.
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def chunk_text(text):
+    """Split source text into (heading, content) chunks.
+
+    Sections start at '## ' markers (from html_to_text). Oversized
+    sections split further on paragraph boundaries; tiny fragments merge
+    into their predecessor.
+    """
+    sections = []
+    current_heading = None
+    current = []
+    for line in text.split("\n"):
+        if line.startswith("## "):
+            if current:
+                sections.append((current_heading, "\n".join(current).strip()))
+            current_heading = line[3:].strip()[:255] or None
+            current = []
+        else:
+            current.append(line)
+    if current:
+        sections.append((current_heading, "\n".join(current).strip()))
+
+    chunks = []
+    for heading, body in sections:
+        if not body:
+            continue
+        if len(body) <= CHUNK_TARGET_CHARS:
+            pieces = [body]
+        else:
+            pieces = []
+            buf = ""
+            for para in body.split("\n\n"):
+                if buf and len(buf) + len(para) + 2 > CHUNK_TARGET_CHARS:
+                    pieces.append(buf)
+                    buf = para
+                else:
+                    buf = f"{buf}\n\n{para}" if buf else para
+            if buf:
+                pieces.append(buf)
+        for piece in pieces:
+            piece = piece.strip()
+            if not piece:
+                continue
+            if (len(piece) < CHUNK_MIN_CHARS and chunks
+                    and chunks[-1][0] == heading):
+                prev_h, prev_c = chunks[-1]
+                chunks[-1] = (prev_h, f"{prev_c}\n\n{piece}")
+            else:
+                chunks.append((heading, piece))
+    return chunks
+
+
+def import_source(slug, title, text, description=None, origin_url=None,
+                  api_key=None, embed_user_id=None, replace=True,
+                  batch_size=64):
+    """Create/replace an AlchemySource from raw text: chunk, embed, store.
+
+    Returns (source, chunk_count). Embedding cost is logged against
+    *embed_user_id* (the admin running the import) when given.
+    """
+    source = AlchemySource.query.filter_by(slug=slug).first()
+    if source is None:
+        source = AlchemySource(slug=slug, title=title,
+                               description=description,
+                               origin_url=origin_url)
+        db.session.add(source)
+        db.session.flush()
+    else:
+        source.title = title
+        if description:
+            source.description = description
+        if origin_url:
+            source.origin_url = origin_url
+        if replace:
+            AlchemySourceChunk.query.filter_by(
+                source_id=source.id).delete()
+            db.session.flush()
+
+    chunks = chunk_text(text)
+    for start in range(0, len(chunks), batch_size):
+        batch = chunks[start:start + batch_size]
+        vectors = None
+        if api_key:
+            vectors = embed_texts(
+                [c for _h, c in batch], api_key,
+                user_id=embed_user_id,
+                request_type="alchemy_source_embedding",
+            )
+        for offset, (heading, content) in enumerate(batch):
+            db.session.add(AlchemySourceChunk(
+                source_id=source.id,
+                idx=start + offset,
+                heading=heading,
+                content=content,
+                vector=pack_vector(vectors[offset]) if vectors else None,
+            ))
+        db.session.flush()
+    db.session.commit()
+    return source, len(chunks)
+
+
+def search_source_chunks(source_id, query_text, api_key, user_id=None, k=3):
+    """Top-k chunks of one source for *query_text*. Returns
+    [(chunk_id, score)]."""
+    rows = db.session.query(
+        AlchemySourceChunk.id, AlchemySourceChunk.vector
+    ).filter(
+        AlchemySourceChunk.source_id == source_id,
+        AlchemySourceChunk.vector.isnot(None),
+    ).all()
+    if not rows:
+        return []
+    query_vector = embed_texts(
+        [query_text], api_key, user_id=user_id,
+        request_type="embedding_query",
+    )[0]
+    return top_k_similar(query_vector, rows, k=k, min_score=0.0)

--- a/backend/utils/prompts.py
+++ b/backend/utils/prompts.py
@@ -32,6 +32,14 @@ PROMPT_DEFAULTS = {
         'title': 'Text Mode',
         'file': 'agentic.txt',
     },
+    # Alchemical Mode guide prompt. `hidden` keeps it off the Prompts page:
+    # the user meets the source through the guide (that's the mode's whole
+    # design), and the readiness gate shouldn't be self-editable.
+    'alchemy': {
+        'title': 'Alchemy',
+        'file': 'alchemy.txt',
+        'hidden': True,
+    },
 }
 
 PROMPTS_DIR = os.path.join(

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -27,6 +27,8 @@ services:
     environment:
       - FLASK_ENV=staging
       - FRONTEND_URL=${FRONTEND_URL:-https://staging.loore.org}
+      # Dark features live on staging by design.
+      - ALCHEMY_V1=true
     volumes:
       # Mount migrations from repo root (not in Docker build context)
       - ./migrations:/app/migrations
@@ -37,6 +39,9 @@ services:
 
   celery:
     command: celery -A backend.celery_app.celery worker --loglevel=debug --concurrency=2
+    environment:
+      # Dark features live on staging by design (match the backend service).
+      - ALCHEMY_V1=true
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - PROFILE_USE_BATCH=${PROFILE_USE_BATCH:-false}
       - PROFILE_BATCH_USER_IDS=${PROFILE_BATCH_USER_IDS:-}
       - PROFILE_UPDATES_PAUSED=${PROFILE_UPDATES_PAUSED:-false}
+      - ALCHEMY_V1=${ALCHEMY_V1:-false}
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
       - LLM_NAME=${LLM_NAME:-claude-opus-4.6}
       - FLASK_ENV=${FLASK_ENV:-production}
@@ -94,6 +95,7 @@ services:
       - PROFILE_USE_BATCH=${PROFILE_USE_BATCH:-false}
       - PROFILE_BATCH_USER_IDS=${PROFILE_BATCH_USER_IDS:-}
       - PROFILE_UPDATES_PAUSED=${PROFILE_UPDATES_PAUSED:-false}
+      - ALCHEMY_V1=${ALCHEMY_V1:-false}
       - LLM_NAME=${LLM_NAME:-claude-opus-4.6}
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       - GITHUB_REPO=${GITHUB_REPO}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import HomePage from "./pages/HomePage";
 import VoicePage from "./pages/VoicePage";
 import ConversePage from "./pages/ConversePage";
 import WritePage from "./pages/WritePage";
+import AlchemyPage from "./pages/AlchemyPage";
 import ProfilePage from "./pages/ProfilePage";
 import TodoPage from "./pages/TodoPage";
 import ImportPage from "./pages/ImportPage";
@@ -131,6 +132,7 @@ function App() {
           <Route path="/voice" element={<ProtectedRoute><VoicePage /></ProtectedRoute>} />
           <Route path="/converse" element={<ProtectedRoute><ConversePage /></ProtectedRoute>} />
           <Route path="/textmode" element={<ProtectedRoute><WritePage /></ProtectedRoute>} />
+          <Route path="/alchemy" element={<ProtectedRoute><AlchemyPage /></ProtectedRoute>} />
           {/* Profile and Todo */}
           <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
           <Route path="/todo" element={<ProtectedRoute><TodoPage /></ProtectedRoute>} />

--- a/frontend/src/components/AlchemyOfferModal.js
+++ b/frontend/src/components/AlchemyOfferModal.js
@@ -1,0 +1,298 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+import { useUser } from '../contexts/UserContext';
+
+/**
+ * Opt-in modal for Alchemical Mode (gated depth work).
+ *
+ * Shown from the Home "Alchemy" card while alchemy_status === 'offered'.
+ * The user picks a source, explicitly accepts the risks, and opts in via
+ * POST /api/alchemy/opt-in. On success the user context flips to 'active'
+ * and we navigate straight to /alchemy.
+ */
+function AlchemyOfferModal({ onClose }) {
+  const { setUser } = useUser();
+  const navigate = useNavigate();
+
+  const [sources, setSources] = useState([]);
+  const [loadingSources, setLoadingSources] = useState(true);
+  const [selectedSlug, setSelectedSlug] = useState(null);
+  const [consented, setConsented] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api.get('/alchemy/sources')
+      .then((res) => {
+        setSources(res.data?.sources || []);
+        setLoadingSources(false);
+      })
+      .catch(() => {
+        setError("Couldn't load the source list. Please try again later.");
+        setLoadingSources(false);
+      });
+  }, []);
+
+  const selected = sources.find((s) => s.slug === selectedSlug);
+  const canBegin = consented && !!selected && selected.available && !submitting;
+
+  const handleBegin = () => {
+    if (!canBegin) return;
+    setSubmitting(true);
+    setError('');
+    api.post('/alchemy/opt-in', { source_slug: selectedSlug, accept_risks: true })
+      .then((res) => {
+        const sourceSlug = res.data?.source_slug || selectedSlug;
+        setUser((prev) =>
+          prev ? { ...prev, alchemy_status: 'active', alchemy_source: sourceSlug } : prev
+        );
+        onClose();
+        navigate('/alchemy');
+      })
+      .catch((err) => {
+        setSubmitting(false);
+        setError(
+          err.response?.data?.error ||
+          err.response?.data?.message ||
+          'Something went wrong. Please try again.'
+        );
+      });
+  };
+
+  const backdropStyle = {
+    position: 'fixed',
+    top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    backdropFilter: 'blur(8px)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10000,
+    padding: '24px',
+  };
+
+  const contentStyle = {
+    background: 'var(--bg-card)',
+    border: '1px solid var(--border)',
+    padding: '2rem',
+    borderRadius: '12px',
+    width: '100%',
+    maxWidth: '560px',
+    color: 'var(--text-primary)',
+    maxHeight: '85vh',
+    overflowY: 'auto',
+    fontFamily: 'var(--sans)',
+    fontWeight: 300,
+  };
+
+  const text = {
+    color: 'var(--text-secondary)',
+    lineHeight: 1.65,
+    fontSize: '0.92rem',
+  };
+
+  return (
+    <div style={backdropStyle} onClick={onClose}>
+      <div style={contentStyle} onClick={(e) => e.stopPropagation()}>
+        <h2 style={{
+          fontFamily: 'var(--serif)',
+          fontWeight: 300,
+          fontSize: '1.6rem',
+          margin: '0 0 1rem 0',
+        }}>
+          Alchemical Mode
+        </h2>
+
+        <p style={text}>
+          Based on the depth of your writing here, Loore can guide you through
+          a serious body of transformative source material &mdash; translated
+          into your own language, surfaced when it's relevant to where you
+          are, and paced by your own sharing.
+        </p>
+
+        {/* Risk disclaimer — deliberately strong; do not soften. */}
+        <div style={{
+          border: '1px solid var(--warning)',
+          background: 'color-mix(in srgb, var(--warning) 7%, transparent)',
+          borderRadius: '8px',
+          padding: '14px 16px',
+          margin: '1.3rem 0',
+        }}>
+          <p style={{
+            ...text,
+            color: 'var(--warning)',
+            fontWeight: 400,
+            margin: '0 0 0.5rem 0',
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            fontSize: '0.75rem',
+          }}>
+            Please read before proceeding
+          </p>
+          <p style={{ ...text, margin: 0 }}>
+            This mode is <strong style={{ color: 'var(--text-primary)' }}>experimental</strong>.
+            It engages material that can be
+            {' '}<strong style={{ color: 'var(--text-primary)' }}>destabilizing</strong> &mdash;
+            it may surface difficult experiences and unsettle how things feel for a while.
+            Proceed only if you are currently
+            {' '}<strong style={{ color: 'var(--text-primary)' }}>stable and resourced</strong>.
+            You do so <strong style={{ color: 'var(--text-primary)' }}>at your own risk</strong>.
+            You can stop at any time. Nothing here replaces professional support.
+          </p>
+        </div>
+
+        {/* Source selection */}
+        <p style={{ ...text, fontWeight: 400, color: 'var(--text-primary)', margin: '0 0 0.6rem 0' }}>
+          Choose a source
+        </p>
+        {loadingSources ? (
+          <p style={{ ...text, color: 'var(--text-muted)' }}>Loading sources&hellip;</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {sources.map((source) => {
+              const isSelected = source.slug === selectedSlug;
+              const disabled = !source.available;
+              return (
+                <div
+                  key={source.slug}
+                  role="radio"
+                  aria-checked={isSelected}
+                  aria-disabled={disabled}
+                  onClick={() => !disabled && setSelectedSlug(source.slug)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '12px',
+                    padding: '12px 14px',
+                    borderRadius: '8px',
+                    border: `1px solid ${isSelected ? 'var(--accent)' : 'var(--border)'}`,
+                    background: isSelected ? 'var(--accent-subtle)' : 'var(--bg-deep)',
+                    cursor: disabled ? 'default' : 'pointer',
+                    opacity: disabled ? 0.45 : 1,
+                    transition: 'border-color 0.2s ease, background 0.2s ease',
+                  }}
+                >
+                  {/* radio dot */}
+                  <span style={{
+                    flexShrink: 0,
+                    marginTop: '3px',
+                    width: '14px',
+                    height: '14px',
+                    borderRadius: '50%',
+                    border: `1px solid ${isSelected ? 'var(--accent)' : 'var(--border-hover)'}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}>
+                    {isSelected && (
+                      <span style={{
+                        width: '7px',
+                        height: '7px',
+                        borderRadius: '50%',
+                        background: 'var(--accent)',
+                      }} />
+                    )}
+                  </span>
+                  <div>
+                    <p style={{
+                      margin: 0,
+                      color: 'var(--text-primary)',
+                      fontWeight: 400,
+                      fontSize: '0.92rem',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.6rem',
+                    }}>
+                      {source.title}
+                      {disabled && (
+                        <span style={{
+                          fontSize: '0.65rem',
+                          fontWeight: 400,
+                          color: 'var(--text-muted)',
+                          letterSpacing: '0.05em',
+                          textTransform: 'uppercase',
+                        }}>
+                          Coming soon
+                        </span>
+                      )}
+                    </p>
+                    {source.description && (
+                      <p style={{ ...text, fontSize: '0.84rem', margin: '4px 0 0 0', color: 'var(--text-muted)' }}>
+                        {source.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            {sources.length === 0 && !error && (
+              <p style={{ ...text, color: 'var(--text-muted)' }}>No sources available yet.</p>
+            )}
+          </div>
+        )}
+
+        {/* Explicit consent */}
+        <label style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '10px',
+          margin: '1.3rem 0 0 0',
+          cursor: 'pointer',
+        }}>
+          <input
+            type="checkbox"
+            checked={consented}
+            onChange={(e) => setConsented(e.target.checked)}
+            style={{ marginTop: '3px', accentColor: 'var(--accent)', cursor: 'pointer' }}
+          />
+          <span style={{ ...text, color: 'var(--text-primary)' }}>
+            I understand this is experimental and I proceed at my own risk.
+          </span>
+        </label>
+
+        {error && (
+          <p style={{ ...text, color: 'var(--error)', marginTop: '1rem', marginBottom: 0 }}>
+            {error}
+          </p>
+        )}
+
+        <div style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: '12px',
+          marginTop: '1.6rem',
+        }}>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            style={{
+              padding: '10px 20px',
+              fontSize: '0.92rem',
+              color: 'var(--text-muted)',
+              borderColor: 'var(--border)',
+            }}
+          >
+            Not now
+          </button>
+          <button
+            onClick={handleBegin}
+            disabled={!canBegin}
+            style={{
+              padding: '10px 24px',
+              fontSize: '0.92rem',
+              color: 'var(--accent)',
+              borderColor: 'var(--accent)',
+              opacity: canBegin ? 1 : 0.45,
+              cursor: canBegin ? 'pointer' : 'default',
+            }}
+          >
+            {submitting ? 'Beginning…' : 'Begin'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AlchemyOfferModal;

--- a/frontend/src/pages/AlchemyPage.js
+++ b/frontend/src/pages/AlchemyPage.js
@@ -1,0 +1,183 @@
+import React, { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+import { useUser } from '../contexts/UserContext';
+import useSubmitShortcut, { submitShortcutHint } from '../hooks/useSubmitShortcut';
+
+/**
+ * Alchemical Mode landing (/alchemy) — gated depth-work entry point.
+ *
+ * Only renders for users with alchemy_status === 'active' (readiness
+ * pre-filter + explicit opt-in, both server-side). Mirrors the textmode
+ * landing: one prompt, one textarea, then straight into the conversation.
+ */
+export default function AlchemyPage() {
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const textareaRef = useRef(null);
+
+  const canSubmit = content.trim().length > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await api.post('/alchemy/start', { content });
+      const data = res.data;
+      const llmNodeId = data?.llm_node_id;
+      if (llmNodeId) {
+        // Mirrors WritePage's navigation after /textmode/start: land
+        // directly on the pending LLM node so NodeDetail anchors the
+        // inline input below it and flips to the response in place.
+        navigate(`/node/${llmNodeId}?awaitLlm=${llmNodeId}`);
+      } else if (data?.user_node_id) {
+        navigate(`/node/${data.user_node_id}`);
+      } else {
+        setSubmitting(false);
+        setError('Unexpected response. Please try again.');
+      }
+    } catch (err) {
+      setSubmitting(false);
+      setError(
+        err.response?.data?.error ||
+        err.response?.data?.message ||
+        'Something went wrong. Please try again.'
+      );
+    }
+  };
+
+  useSubmitShortcut(textareaRef, handleSubmit, canSubmit);
+
+  if (user?.alchemy_status !== 'active') {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 'calc(100vh - 120px)',
+        padding: '40px 24px',
+      }}>
+        <p style={{
+          fontFamily: 'var(--sans)',
+          fontWeight: 300,
+          color: 'var(--text-muted)',
+          margin: 0,
+        }}>
+          Not available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      minHeight: 'calc(100vh - 120px)',
+      padding: '60px 24px 40px',
+      background: 'radial-gradient(ellipse at 50% 30%, rgba(196,149,106,0.05) 0%, transparent 70%)',
+    }}>
+      <h1 style={{
+        fontFamily: 'var(--serif)',
+        fontSize: 'clamp(1.6rem, 3.5vw, 2.2rem)',
+        fontWeight: 300,
+        color: 'var(--text-primary)',
+        margin: '0 0 10px 0',
+        textAlign: 'center',
+      }}>
+        Alchemy
+      </h1>
+      <p style={{
+        fontFamily: 'var(--sans)',
+        fontSize: '0.95rem',
+        fontWeight: 300,
+        color: 'var(--text-muted)',
+        margin: '0 0 32px 0',
+        textAlign: 'center',
+      }}>
+        What's alive for you right now?
+      </p>
+
+      <div style={{ width: '720px', maxWidth: '90vw', display: 'flex', flexDirection: 'column' }}>
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Begin where you are…"
+          rows={8}
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            padding: '16px',
+            fontFamily: 'var(--sans)',
+            fontWeight: 300,
+            fontSize: '1rem',
+            lineHeight: 1.65,
+            borderRadius: '10px',
+            resize: 'vertical',
+          }}
+        />
+
+        {error && (
+          <p style={{
+            fontFamily: 'var(--sans)',
+            fontSize: '0.88rem',
+            fontWeight: 300,
+            color: 'var(--error)',
+            margin: '10px 0 0 0',
+          }}>
+            {error}
+          </p>
+        )}
+
+        <div style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: '12px',
+          marginTop: '14px',
+        }}>
+          <span style={{
+            fontFamily: 'var(--sans)',
+            fontSize: '0.75rem',
+            fontWeight: 300,
+            color: 'var(--text-muted)',
+          }}>
+            {submitShortcutHint()}
+          </span>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            style={{
+              padding: '10px 26px',
+              fontSize: '0.95rem',
+              color: 'var(--accent)',
+              borderColor: 'var(--accent)',
+              opacity: canSubmit ? 1 : 0.45,
+              cursor: canSubmit ? 'pointer' : 'default',
+            }}
+          >
+            {submitting ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+
+      <p style={{
+        fontFamily: 'var(--sans)',
+        fontSize: '0.78rem',
+        fontWeight: 300,
+        color: 'var(--text-muted)',
+        marginTop: 'auto',
+        paddingTop: '40px',
+      }}>
+        Experimental — you can stop any time.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useUser } from '../contexts/UserContext';
+import AlchemyOfferModal from '../components/AlchemyOfferModal';
 
 function useOnScreen(ref, threshold = 0.1) {
   const [isVisible, setIsVisible] = useState(false);
@@ -53,6 +55,20 @@ const cards = [
   },
 ];
 
+// Alembic / vessel icon for the gated Alchemy card — same 42px stroke
+// style as the Text card.
+const alchemyIcon = (
+  <svg width="42" height="42" viewBox="0 0 42 42" fill="none">
+    <path
+      d="M17 7 L25 7 M19 7 L19 16 C13.5 18.5 10 23.5 10 28 C10 32.5 14.5 35 21 35 C27.5 35 32 32.5 32 28 C32 23.5 28.5 18.5 23 16 L23 7"
+      stroke="var(--accent)" strokeWidth="1.4" fill="none"
+      strokeLinecap="round" strokeLinejoin="round"
+    />
+    <line x1="13.5" y1="27" x2="28.5" y2="27"
+          stroke="var(--accent)" strokeWidth="1.4" strokeLinecap="round" />
+  </svg>
+);
+
 function WorkflowCard({ card, delay }) {
   const ref = useRef(null);
   const isVisible = useOnScreen(ref);
@@ -72,7 +88,11 @@ function WorkflowCard({ card, delay }) {
   return (
     <div
       ref={ref}
-      onClick={() => !disabled && navigate(card.path)}
+      onClick={() => {
+        if (disabled) return;
+        if (card.onClick) card.onClick();
+        else navigate(card.path);
+      }}
       onMouseEnter={() => !disabled && setHovered(true)}
       onMouseLeave={() => !disabled && setHovered(false)}
       style={{
@@ -102,7 +122,9 @@ function WorkflowCard({ card, delay }) {
         right: 0,
         height: "1px",
         background: "linear-gradient(90deg, transparent, var(--accent), transparent)",
-        opacity: hovered ? 0.5 : 0,
+        // Cards flagged `offered` (Alchemy invitation) keep a faint
+        // permanent accent line as a subtle distinguishing touch.
+        opacity: hovered ? 0.5 : (card.offered ? 0.22 : 0),
         transition: "opacity 0.4s ease",
       }} />
 
@@ -152,6 +174,27 @@ export default function HomePage() {
   const questionRef = useRef(null);
   const greetingVisible = useOnScreen(greetingRef);
   const questionVisible = useOnScreen(questionRef);
+  const { user } = useUser();
+  const [showAlchemyOffer, setShowAlchemyOffer] = useState(false);
+
+  // Alchemical Mode card — only rendered once the readiness pre-filter has
+  // fired ('offered') or the user has opted in ('active'). Null → nothing.
+  const alchemyStatus = user?.alchemy_status;
+  const allCards = [...cards];
+  if (alchemyStatus === 'offered' || alchemyStatus === 'active') {
+    const offered = alchemyStatus === 'offered';
+    allCards.push({
+      key: 'alchemy',
+      path: '/alchemy',
+      title: 'Alchemy',
+      description: offered ? 'An invitation awaits.' : 'Continue the work.',
+      icon: alchemyIcon,
+      offered,
+      // While only offered, the card opens the opt-in modal instead of
+      // navigating.
+      onClick: offered ? () => setShowAlchemyOffer(true) : undefined,
+    });
+  }
 
   return (
     <div style={{
@@ -200,13 +243,17 @@ export default function HomePage() {
         gap: "1.5rem",
         flexWrap: "wrap",
         justifyContent: "center",
-        maxWidth: "580px",
+        maxWidth: allCards.length > 2 ? "880px" : "580px",
         width: "100%",
       }}>
-        {cards.map((card, i) => (
+        {allCards.map((card, i) => (
           <WorkflowCard key={card.key} card={card} delay={400 + i * 120} />
         ))}
       </div>
+
+      {showAlchemyOffer && (
+        <AlchemyOfferModal onClose={() => setShowAlchemyOffer(false)} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

**Alchemical Mode v1** per the spec added to FOUR-FEATURE-ECOSYSTEM.md (2026-07-01), shipped **dark behind `ALCHEMY_V1`** (off in prod, on in the staging overlay).

## The double gate, structural

1. **Our side — readiness check**: `tasks/alchemy_readiness.py` (celery, manually dispatched via admin endpoint — deliberately not scheduled until rollout policy is decided) reads the last ~60 days of the user's writing (ai_usage-filtered) and judges it against `prompts/alchemy_readiness.txt`. Verdict parsing **fails closed** — unparseable output, insufficient data, or any crisis indication → not ready. ⚠️ **The checklist is a v0 draft and says so in its own text — the safety criteria are yours to rewrite.**
2. **User side — opt-in**: only `ready` users ever see the offer (Home card, "An invitation awaits."). The modal carries unsoftened disclaimers (experimental, potentially destabilizing, at own risk, stop any time, not therapy) + source selection + an explicit consent checkbox; the backend requires `accept_risks: true` literally. **Opt-out is one call** — stopping is easier than starting.

## The mode

- Opted-in users get the **Alchemy home card** → `/alchemy` → sessions start with a **hidden guide prompt** (`prompts/alchemy.txt`): registered as `hidden` in PROMPT_DEFAULTS, off the Prompts page, blocked from read/edit — the user meets the material through the guide, and gates must not be self-editable. Threads are forced `privacy_level=private`.
- **`read_source` retrieval tool** rides the existing within-turn loop (same machinery as read_artifact): the guide queries the user's selected source per turn; passages re-resolved at injection time, only chunk ids in tool meta. Tool is dropped from the list when the flag is off (`gated_voice_tools`, cache-prefix safe).
- **Sources are pluggable**: `AlchemySource` + `AlchemySourceChunk` (chunked on headings, embedded, packed-float32 like NodeEmbedding) + `scripts/import_alchemy_source.py` (dry-run by default) to scrape/chunk/embed a page. Meditationbook.page is the PoC source; Chapman corpus and Petr's book land later by running the same script.

## Open decisions (unchanged from the doc)

Checklist contents; third-party licensing; adverse-effect handling (the guide prompt instructs setting the source aside on turbulence, but no automated self-suspend yet); rollout policy for who gets checked when.

## Verification

flake8 E9 clean · 675 backend tests (14 new) · frontend builds clean. Staging pass pending (needs the source imported + a readiness check run — steps in the PR thread after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWZdt4A772UrP9sJP74deJ
