### PR TITLE
feat: dev-update channel — changelog, notifications, polls (#207)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -47,6 +47,11 @@ data/
 # Documentation
 docs/
 *.md
+# The user-facing changelog is APPLICATION DATA, not documentation — the
+# backend serves it (#207). Excluding it turns the updates surface into a
+# silent no-op in Docker (staging), while local dev volume-mounts hide the
+# gap. Keep this exception.
+!user_changelog.md
 !requirements.txt
 
 # Build artifacts

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -188,6 +188,10 @@ def create_app():
     from backend.routes.commons import commons_bp
     app.register_blueprint(commons_bp, url_prefix="/api/commons")
 
+    # Dev-update channel: changelog + notifications + polls (#207).
+    from backend.routes.updates import updates_bp
+    app.register_blueprint(updates_bp, url_prefix="/api/updates")
+
     # AI preferences folded into the artifact model (#158 Slice 5): managed via
     # the generic /api/artifacts CRUD (kind="ai_preferences"); the dedicated
     # /api/ai-preferences blueprint was removed.

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -85,3 +85,4 @@ from backend.tasks import node_cleanup  # noqa: F401
 from backend.tasks import profile_batch  # noqa: F401
 from backend.tasks import spend_monitor  # noqa: F401
 from backend.tasks import embeddings  # noqa: F401
+from backend.tasks import poll_draft  # noqa: F401

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -61,6 +61,11 @@ celery.conf.update(
             'task': 'backend.tasks.spend_monitor.check_api_spend',
             'schedule': 3600.0,  # hourly
         },
+        # Poll drafts ride the Batch API (#207); no-op when none pending.
+        'collect-poll-draft-batches': {
+            'task': 'backend.tasks.poll_draft.collect_poll_draft_batches',
+            'schedule': 60.0,  # batches typically finish in 1-5 min
+        },
     },
 )
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -88,6 +88,14 @@ class Config:
     SHARE_V1 = os.environ.get(
         "SHARE_V1", "true").lower() in ("1", "true", "yes")
 
+    # --- Dev-update channel: changelog + notifications + polls (#207) ---
+    # Intrinsically quiet (nothing shows unless something is unread), so it
+    # deploys on. This env var is the emergency KILL SWITCH only: set
+    # DEV_UPDATES_V1=false to make /api/updates serve nothing (the modal
+    # never appears) without a deploy.
+    DEV_UPDATES_V1 = os.environ.get(
+        "DEV_UPDATES_V1", "true").lower() in ("1", "true", "yes")
+
     # Safety factor for prompt-too-long retries (0.99 = aim for 99% of the limit)
     RETRY_SAFETY_FACTOR = 0.99
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -868,6 +868,9 @@ class APICostLog(db.Model):
     # non-cached calls; lets us query cache hit-rate over time from the DB.
     cache_read_tokens = db.Column(db.Integer, nullable=True, default=0)
     cache_write_tokens = db.Column(db.Integer, nullable=True, default=0)
+    # What specifically caused this cost, when request_type alone is too
+    # coarse — e.g. "poll:3" for a poll-draft (#207). Null for legacy rows.
+    request_ref = db.Column(db.String(64), nullable=True)
     audio_duration_seconds = db.Column(db.Float, nullable=True)
     cost_microdollars = db.Column(db.Integer, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
@@ -1012,16 +1015,32 @@ class UserNotification(db.Model):
 class Poll(db.Model):
     """A question the admin poses to users through the dev-update channel
     (#207 polling extension). Answering is entirely opt-in and two-phase —
-    see PollResponse."""
+    see PollResponse.
+
+    The admin picks per poll which model drafts answers and what data it
+    may read; both are shown to the user BEFORE opt-in 1 (informed
+    consent). Draft costs are attributed to the polls system account, not
+    the answering user — see backend/utils/system_accounts.py.
+    """
     __tablename__ = "poll"
     id = db.Column(db.Integer, primary_key=True)
     question = db.Column(db.Text, nullable=False)
+    # Model that drafts answers (chosen at creation; frozen per poll so
+    # consent shown to early responders can't drift).
+    model_id = db.Column(db.String(64), nullable=True)
+    # What the draft may read: 'derived' = profile + recent summary +
+    # intentions; 'recent_window' = the most recent raw writing that fits
+    # the model's context window.
+    data_source = db.Column(db.String(16), nullable=False,
+                            default="derived", server_default="derived")
     created_by = db.Column(db.Integer, db.ForeignKey("user.id"),
                            nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
     closed_at = db.Column(db.DateTime, nullable=True)
 
     creator = db.relationship("User", foreign_keys=[created_by])
+
+    DATA_SOURCES = ("derived", "recent_window")
 
     @property
     def active(self):
@@ -1076,3 +1095,25 @@ class PollResponse(db.Model):
 
     def get_content(self):
         return decrypt_content(self.content) if self.content else ""
+
+
+class PollDraftBatchJob(db.Model):
+    """A submitted provider batch carrying poll-draft requests (#207).
+    Drafts are async by construction, so they ride the Batch API (~50%
+    cheaper). Mirrors ProfileBatchJob: per-item routing metadata lives in
+    `items` (keyed by custom_id); the beat collector retrieves results and
+    saves each draft to its PollResponse.
+    """
+    __tablename__ = "poll_draft_batch_job"
+
+    id = db.Column(db.Integer, primary_key=True)
+    # "anthropic" | "openai:<api_model>"
+    provider_key = db.Column(db.String(64), nullable=False)
+    batch_id = db.Column(db.String(255), nullable=False, index=True)
+    # "pending" | "collected" | "failed"
+    status = db.Column(db.String(16), nullable=False, default="pending")
+    # List of per-item dicts: {custom_id, response_id, poll_id, model_id}
+    items = db.Column(db.JSON, nullable=False, default=list)
+    submitted_at = db.Column(
+        db.DateTime, nullable=False, default=datetime.utcnow)
+    collected_at = db.Column(db.DateTime, nullable=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -957,3 +957,122 @@ class TTSChunk(db.Model):
         db.UniqueConstraint('node_id', 'chunk_index', name='uq_node_tts_chunk_index'),
         db.UniqueConstraint('profile_id', 'chunk_index', name='uq_profile_tts_chunk_index'),
     )
+
+
+class ChangelogReadState(db.Model):
+    """Per-user read/skip state for a section of the user-facing changelog
+    (#207). Sections live in backend/user_changelog.md (parsed by
+    backend/utils/changelog.py); this table only stores state, keyed by the
+    section's stable id. 'skipped' sections are still served as unread on
+    the next open — skip means "show again later", read means "done".
+    """
+    __tablename__ = "changelog_read_state"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    section_id = db.Column(db.String(128), nullable=False)
+    status = db.Column(db.String(16), nullable=False, default="read")
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow,
+                           onupdate=datetime.utcnow)
+
+    user = db.relationship("User", backref="changelog_read_states")
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "section_id",
+                            name="uq_changelog_read_user_section"),
+    )
+
+
+class UserNotification(db.Model):
+    """Targeted (single-user) in-app notification (#207): profile ready,
+    briefing ready, fix-ready. The broadcast sibling is the changelog file —
+    both are served through /api/updates with the same read/skip semantics.
+    Bodies are system-generated template text, never user content.
+    """
+    __tablename__ = "user_notification"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    # e.g. "profile_ready", "briefing_ready", "fix_ready"
+    type = db.Column(db.String(32), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    body = db.Column(db.Text, nullable=True)
+    # Optional in-app link target (e.g. "/profile")
+    link = db.Column(db.String(255), nullable=True)
+    status = db.Column(db.String(16), nullable=False, default="unread",
+                       index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+    read_at = db.Column(db.DateTime, nullable=True)
+    # Last time the user hit "skip for now" (stays unread)
+    skipped_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship("User", backref="notifications")
+
+
+class Poll(db.Model):
+    """A question the admin poses to users through the dev-update channel
+    (#207 polling extension). Answering is entirely opt-in and two-phase —
+    see PollResponse."""
+    __tablename__ = "poll"
+    id = db.Column(db.Integer, primary_key=True)
+    question = db.Column(db.Text, nullable=False)
+    created_by = db.Column(db.Integer, db.ForeignKey("user.id"),
+                           nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+    closed_at = db.Column(db.DateTime, nullable=True)
+
+    creator = db.relationship("User", foreign_keys=[created_by])
+
+    @property
+    def active(self):
+        return self.closed_at is None
+
+
+class PollResponse(db.Model):
+    """A user's answer to a Poll, with two-phase consent structurally
+    enforced (#207):
+
+    * Opt-in 1 (optional): the user asks the LLM to draft an answer from
+      their archive (profile / recent context / intentions) —
+      draft_requested_at is the consent timestamp; the draft is PRIVATE.
+    * Opt-in 2 (required to share anything): the user explicitly sends the
+      (reviewed/edited or hand-written) answer — sent_at is the consent
+      timestamp. The admin endpoint serves ONLY status='sent' rows; drafts
+      and declined rows are never visible to anyone but the user.
+
+    status: drafting -> draft -> sent | declined ('draft_failed' when the
+    LLM draft task errored; the user can retry or write manually).
+    Content is encrypted at rest like all user content.
+    """
+    __tablename__ = "poll_response"
+    id = db.Column(db.Integer, primary_key=True)
+    poll_id = db.Column(db.Integer, db.ForeignKey("poll.id"),
+                        nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"),
+                        nullable=False, index=True)
+    content = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(16), nullable=False, default="draft",
+                       index=True)
+    # Model id when the current content came from an LLM draft; null for
+    # hand-written answers (cleared when the user edits).
+    generated_by = db.Column(db.String(64), nullable=True)
+    draft_task_id = db.Column(db.String(255), nullable=True)
+    draft_requested_at = db.Column(db.DateTime, nullable=True)
+    sent_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow,
+                           onupdate=datetime.utcnow)
+
+    poll = db.relationship("Poll", backref="responses")
+    user = db.relationship("User", backref="poll_responses")
+
+    __table_args__ = (
+        db.UniqueConstraint("poll_id", "user_id",
+                            name="uq_poll_response_poll_user"),
+    )
+
+    def set_content(self, plaintext):
+        self.content = encrypt_content(plaintext)
+
+    def get_content(self):
+        return decrypt_content(self.content) if self.content else ""

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -409,7 +409,11 @@ def list_polls():
     for poll_id, status, n in rows:
         counts.setdefault(poll_id, {})[status] = n
 
-    return jsonify({"polls": [
+    return jsonify({
+        # The app-wide default, so the create-poll selector can preselect
+        # a CONCRETE model instead of an ambiguous "default" option.
+        "default_model_id": current_app.config.get("DEFAULT_LLM_MODEL"),
+        "polls": [
         {
             "id": p.id,
             "question": p.question,

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -354,3 +354,90 @@ def update_feedback_status(feedback_id):
     feedback.status = status
     db.session.commit()
     return jsonify({"id": feedback.id, "status": feedback.status}), 200
+
+
+# ---------------------------------------------------------------------------
+# Polls — the admin side of the dev-update channel (#207). The admin sees
+# ONLY responses the user explicitly sent (opt-in 2); drafts, failures and
+# declines stay private to the user (declined/pending appear as counts only).
+# ---------------------------------------------------------------------------
+
+@admin_bp.route("/polls", methods=["POST"])
+@login_required
+@admin_required
+def create_poll():
+    from backend.models import Poll
+
+    question = ((request.get_json() or {}).get("question") or "").strip()
+    if not question:
+        return jsonify({"error": "Question is required."}), 400
+    poll = Poll(question=question, created_by=current_user.id)
+    db.session.add(poll)
+    db.session.commit()
+    return jsonify({"id": poll.id, "question": poll.question,
+                    "created_at": iso_utc(poll.created_at)}), 201
+
+
+@admin_bp.route("/polls", methods=["GET"])
+@login_required
+@admin_required
+def list_polls():
+    from backend.models import Poll, PollResponse
+
+    counts = {}
+    rows = db.session.query(
+        PollResponse.poll_id, PollResponse.status,
+        func.count(PollResponse.id)
+    ).group_by(PollResponse.poll_id, PollResponse.status).all()
+    for poll_id, status, n in rows:
+        counts.setdefault(poll_id, {})[status] = n
+
+    return jsonify({"polls": [
+        {
+            "id": p.id,
+            "question": p.question,
+            "created_at": iso_utc(p.created_at),
+            "closed_at": iso_utc(p.closed_at),
+            "sent_count": counts.get(p.id, {}).get("sent", 0),
+            "declined_count": counts.get(p.id, {}).get("declined", 0),
+        }
+        for p in Poll.query.order_by(Poll.created_at.desc()).all()
+    ]}), 200
+
+
+@admin_bp.route("/polls/<int:poll_id>/responses", methods=["GET"])
+@login_required
+@admin_required
+def list_poll_responses(poll_id):
+    from backend.models import Poll, PollResponse
+
+    poll = Poll.query.get_or_404(poll_id)
+    responses = PollResponse.query.filter_by(
+        poll_id=poll.id, status="sent").order_by(
+        PollResponse.sent_at.asc()).all()
+    return jsonify({
+        "poll": {"id": poll.id, "question": poll.question},
+        "responses": [
+            {
+                "id": r.id,
+                "username": r.user.username if r.user else None,
+                "content": r.get_content(),
+                "llm_drafted": r.generated_by is not None,
+                "sent_at": iso_utc(r.sent_at),
+            }
+            for r in responses
+        ],
+    }), 200
+
+
+@admin_bp.route("/polls/<int:poll_id>/close", methods=["POST"])
+@login_required
+@admin_required
+def close_poll(poll_id):
+    from backend.models import Poll
+
+    poll = Poll.query.get_or_404(poll_id)
+    if poll.closed_at is None:
+        poll.closed_at = datetime.utcnow()
+        db.session.commit()
+    return jsonify({"id": poll.id, "closed_at": iso_utc(poll.closed_at)}), 200

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -368,13 +368,30 @@ def update_feedback_status(feedback_id):
 def create_poll():
     from backend.models import Poll
 
-    question = ((request.get_json() or {}).get("question") or "").strip()
+    data = request.get_json() or {}
+    question = (data.get("question") or "").strip()
     if not question:
         return jsonify({"error": "Question is required."}), 400
-    poll = Poll(question=question, created_by=current_user.id)
+
+    # Which model drafts answers, and what data it may read (#207). Both
+    # are frozen at creation and shown to users before opt-in 1.
+    model_id = data.get("model_id") or current_app.config.get(
+        "DEFAULT_LLM_MODEL")
+    supported = current_app.config.get("SUPPORTED_MODELS", {})
+    if model_id not in supported:
+        return jsonify({"error": f"Unsupported model: {model_id}"}), 400
+    data_source = data.get("data_source") or "derived"
+    if data_source not in Poll.DATA_SOURCES:
+        return jsonify({"error": f"Invalid data_source. Allowed: "
+                                 f"{list(Poll.DATA_SOURCES)}"}), 400
+
+    poll = Poll(question=question, created_by=current_user.id,
+                model_id=model_id, data_source=data_source)
     db.session.add(poll)
     db.session.commit()
     return jsonify({"id": poll.id, "question": poll.question,
+                    "model_id": poll.model_id,
+                    "data_source": poll.data_source,
                     "created_at": iso_utc(poll.created_at)}), 201
 
 
@@ -396,6 +413,8 @@ def list_polls():
         {
             "id": p.id,
             "question": p.question,
+            "model_id": p.model_id,
+            "data_source": p.data_source,
             "created_at": iso_utc(p.created_at),
             "closed_at": iso_utc(p.closed_at),
             "sent_count": counts.get(p.id, {}).get("sent", 0),

--- a/backend/routes/updates.py
+++ b/backend/routes/updates.py
@@ -42,6 +42,18 @@ def _serialize_response(resp):
     }
 
 
+def _poll_draft_terms(poll):
+    """What the user is consenting to in opt-in 1 — shown BEFORE they
+    ask for a draft."""
+    model_id = (poll.model_id
+                or current_app.config.get("DEFAULT_LLM_MODEL"))
+    model_cfg = current_app.config["SUPPORTED_MODELS"].get(model_id, {})
+    return {
+        "model": model_cfg.get("display_name", model_id),
+        "data_source": poll.data_source,
+    }
+
+
 def _pending_polls_for(user):
     """Active polls the user hasn't resolved (sent or declined)."""
     responses = {
@@ -58,6 +70,7 @@ def _pending_polls_for(user):
             "id": poll.id,
             "question": poll.question,
             "created_at": iso_utc(poll.created_at),
+            "draft_terms": _poll_draft_terms(poll),
             "response": _serialize_response(resp),
         })
     return pending
@@ -181,6 +194,7 @@ def get_poll(poll_id):
         "id": poll.id,
         "question": poll.question,
         "active": poll.active,
+        "draft_terms": _poll_draft_terms(poll),
         "response": _serialize_response(resp),
     }), 200
 
@@ -189,9 +203,10 @@ def get_poll(poll_id):
 @login_required
 def request_draft(poll_id):
     """Opt-in 1: the user asks the LLM to draft an answer from their
-    archive. Refused when their global AI-usage setting opts out."""
+    archive. Refused when their global AI-usage setting opts out. No
+    spend-cap check: draft costs land on the polls system account, not
+    the user (they're answering OUR question)."""
     from backend.utils.privacy import AI_ALLOWED
-    from backend.utils.spend import user_is_capped
 
     poll = _get_active_poll(poll_id)
     if poll is None:
@@ -200,10 +215,6 @@ def request_draft(poll_id):
         return jsonify({
             "error": "Your AI-usage setting doesn't allow this. You can "
                      "still write an answer yourself."}), 403
-    if user_is_capped(current_user):
-        return jsonify({
-            "error": "monthly_spend_limit_reached",
-            "message": "You've reached your monthly usage limit."}), 402
 
     resp = _get_or_create_response(poll)
     if resp.status == "sent":
@@ -215,10 +226,8 @@ def request_draft(poll_id):
     resp.draft_requested_at = datetime.utcnow()
     db.session.commit()
 
-    from backend.tasks.poll_draft import draft_poll_response
-    task = draft_poll_response.delay(resp.id)
-    resp.draft_task_id = task.id
-    db.session.commit()
+    from backend.tasks.poll_draft import submit_poll_draft
+    submit_poll_draft.delay(resp.id)
     return jsonify({"response": _serialize_response(resp)}), 202
 
 

--- a/backend/routes/updates.py
+++ b/backend/routes/updates.py
@@ -1,0 +1,279 @@
+"""The dev-update channel (#207): user-facing changelog, targeted
+notifications, and admin polls, served through one surface with shared
+read/skip semantics. Skip = show again on next open; read = gone for good.
+
+Everything here is per-user private state. Poll answers cross the privacy
+boundary ONLY through the explicit /send endpoint (opt-in 2) — see
+PollResponse in models.py.
+"""
+import logging
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request, current_app
+from flask_login import login_required, current_user
+
+from backend.extensions import db
+from backend.models import (
+    ChangelogReadState, UserNotification, Poll, PollResponse,
+)
+from backend.utils.changelog import parse_changelog, unread_sections_for
+from backend.utils.timefmt import iso_utc
+
+logger = logging.getLogger(__name__)
+
+updates_bp = Blueprint("updates_bp", __name__)
+
+
+def _updates_enabled():
+    return current_app.config.get("DEV_UPDATES_V1", True)
+
+
+def _serialize_response(resp):
+    """The user's own view of their poll response (drafts included —
+    they're private to the user)."""
+    if resp is None:
+        return None
+    return {
+        "status": resp.status,
+        "content": resp.get_content(),
+        "generated_by": resp.generated_by,
+        "draft_requested_at": iso_utc(resp.draft_requested_at),
+        "sent_at": iso_utc(resp.sent_at),
+    }
+
+
+def _pending_polls_for(user):
+    """Active polls the user hasn't resolved (sent or declined)."""
+    responses = {
+        r.poll_id: r
+        for r in PollResponse.query.filter_by(user_id=user.id).all()
+    }
+    pending = []
+    for poll in Poll.query.filter_by(closed_at=None).order_by(
+            Poll.created_at.asc()).all():
+        resp = responses.get(poll.id)
+        if resp is not None and resp.status in ("sent", "declined"):
+            continue
+        pending.append({
+            "id": poll.id,
+            "question": poll.question,
+            "created_at": iso_utc(poll.created_at),
+            "response": _serialize_response(resp),
+        })
+    return pending
+
+
+@updates_bp.route("", methods=["GET"])
+@login_required
+def get_updates():
+    """Everything unread for the current user. All lists empty -> the
+    frontend shows nothing."""
+    if not _updates_enabled():
+        return jsonify(
+            {"changelog": [], "notifications": [], "polls": []}), 200
+
+    read_states = ChangelogReadState.query.filter_by(
+        user_id=current_user.id).all()
+    changelog = [
+        {
+            "id": s["id"],
+            "title": s["title"],
+            "date": s["date"].isoformat() if s["date"] else None,
+            "body": s["body"],
+        }
+        for s in unread_sections_for(current_user, read_states)
+    ]
+
+    notifications = [
+        {
+            "id": n.id,
+            "type": n.type,
+            "title": n.title,
+            "body": n.body,
+            "link": n.link,
+            "created_at": iso_utc(n.created_at),
+        }
+        for n in UserNotification.query.filter_by(
+            user_id=current_user.id, status="unread"
+        ).order_by(UserNotification.created_at.desc()).limit(20).all()
+    ]
+
+    return jsonify({
+        "changelog": changelog,
+        "notifications": notifications,
+        "polls": _pending_polls_for(current_user),
+    }), 200
+
+
+# ---------------------------------------------------------------------------
+# Changelog read/skip
+# ---------------------------------------------------------------------------
+
+@updates_bp.route("/changelog/<section_id>/<action>", methods=["POST"])
+@login_required
+def mark_changelog(section_id, action):
+    if action not in ("read", "skip"):
+        return jsonify({"error": "Unknown action"}), 404
+    if not any(s["id"] == section_id for s in parse_changelog()):
+        return jsonify({"error": "Unknown section"}), 404
+
+    state = ChangelogReadState.query.filter_by(
+        user_id=current_user.id, section_id=section_id).first()
+    if state is None:
+        state = ChangelogReadState(
+            user_id=current_user.id, section_id=section_id)
+        db.session.add(state)
+    state.status = "read" if action == "read" else "skipped"
+    db.session.commit()
+    return jsonify({"section_id": section_id, "status": state.status}), 200
+
+
+# ---------------------------------------------------------------------------
+# Notifications read/skip
+# ---------------------------------------------------------------------------
+
+@updates_bp.route("/notifications/<int:notification_id>/<action>",
+                  methods=["POST"])
+@login_required
+def mark_notification(notification_id, action):
+    if action not in ("read", "skip"):
+        return jsonify({"error": "Unknown action"}), 404
+    notification = UserNotification.query.filter_by(
+        id=notification_id, user_id=current_user.id).first_or_404()
+    if action == "read":
+        notification.status = "read"
+        notification.read_at = datetime.utcnow()
+    else:
+        notification.skipped_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({"id": notification.id, "status": notification.status}), 200
+
+
+# ---------------------------------------------------------------------------
+# Polls — the user side (two-phase opt-in)
+# ---------------------------------------------------------------------------
+
+def _get_active_poll(poll_id):
+    poll = Poll.query.get_or_404(poll_id)
+    if poll.closed_at is not None:
+        return None
+    return poll
+
+
+def _get_or_create_response(poll):
+    resp = PollResponse.query.filter_by(
+        poll_id=poll.id, user_id=current_user.id).first()
+    if resp is None:
+        resp = PollResponse(poll_id=poll.id, user_id=current_user.id)
+        db.session.add(resp)
+    return resp
+
+
+@updates_bp.route("/polls/<int:poll_id>", methods=["GET"])
+@login_required
+def get_poll(poll_id):
+    """Poll + the user's own response state (polled while a draft is being
+    generated)."""
+    poll = Poll.query.get_or_404(poll_id)
+    resp = PollResponse.query.filter_by(
+        poll_id=poll.id, user_id=current_user.id).first()
+    return jsonify({
+        "id": poll.id,
+        "question": poll.question,
+        "active": poll.active,
+        "response": _serialize_response(resp),
+    }), 200
+
+
+@updates_bp.route("/polls/<int:poll_id>/draft", methods=["POST"])
+@login_required
+def request_draft(poll_id):
+    """Opt-in 1: the user asks the LLM to draft an answer from their
+    archive. Refused when their global AI-usage setting opts out."""
+    from backend.utils.privacy import AI_ALLOWED
+    from backend.utils.spend import user_is_capped
+
+    poll = _get_active_poll(poll_id)
+    if poll is None:
+        return jsonify({"error": "This poll is closed."}), 409
+    if current_user.default_ai_usage not in AI_ALLOWED:
+        return jsonify({
+            "error": "Your AI-usage setting doesn't allow this. You can "
+                     "still write an answer yourself."}), 403
+    if user_is_capped(current_user):
+        return jsonify({
+            "error": "monthly_spend_limit_reached",
+            "message": "You've reached your monthly usage limit."}), 402
+
+    resp = _get_or_create_response(poll)
+    if resp.status == "sent":
+        return jsonify({"error": "Already sent."}), 409
+    if resp.status == "drafting":
+        return jsonify({"response": _serialize_response(resp)}), 200
+
+    resp.status = "drafting"
+    resp.draft_requested_at = datetime.utcnow()
+    db.session.commit()
+
+    from backend.tasks.poll_draft import draft_poll_response
+    task = draft_poll_response.delay(resp.id)
+    resp.draft_task_id = task.id
+    db.session.commit()
+    return jsonify({"response": _serialize_response(resp)}), 202
+
+
+@updates_bp.route("/polls/<int:poll_id>/response", methods=["PUT"])
+@login_required
+def save_response(poll_id):
+    """Save a hand-written or edited answer (still private)."""
+    poll = _get_active_poll(poll_id)
+    if poll is None:
+        return jsonify({"error": "This poll is closed."}), 409
+    content = (request.get_json() or {}).get("content", "")
+    if not content.strip():
+        return jsonify({"error": "Answer is empty."}), 400
+
+    resp = _get_or_create_response(poll)
+    if resp.status == "sent":
+        return jsonify({"error": "Already sent."}), 409
+    resp.set_content(content)
+    resp.status = "draft"
+    resp.generated_by = None  # user-authored/edited now
+    db.session.commit()
+    return jsonify({"response": _serialize_response(resp)}), 200
+
+
+@updates_bp.route("/polls/<int:poll_id>/send", methods=["POST"])
+@login_required
+def send_response(poll_id):
+    """Opt-in 2: explicitly share the answer with the admin. The ONLY
+    transition that makes a response visible to anyone but the user."""
+    poll = _get_active_poll(poll_id)
+    if poll is None:
+        return jsonify({"error": "This poll is closed."}), 409
+    resp = PollResponse.query.filter_by(
+        poll_id=poll.id, user_id=current_user.id).first()
+    if resp is None or not (resp.content and resp.get_content().strip()):
+        return jsonify({"error": "Nothing to send yet."}), 400
+    if resp.status == "drafting":
+        return jsonify({"error": "Draft still generating."}), 409
+    if resp.status == "sent":
+        return jsonify({"response": _serialize_response(resp)}), 200
+
+    resp.status = "sent"
+    resp.sent_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify({"response": _serialize_response(resp)}), 200
+
+
+@updates_bp.route("/polls/<int:poll_id>/decline", methods=["POST"])
+@login_required
+def decline_poll(poll_id):
+    """'No thanks' — permanently dismisses the poll for this user."""
+    poll = Poll.query.get_or_404(poll_id)
+    resp = _get_or_create_response(poll)
+    if resp.status == "sent":
+        return jsonify({"error": "Already sent."}), 409
+    resp.status = "declined"
+    db.session.commit()
+    return jsonify({"response": _serialize_response(resp)}), 200

--- a/backend/routes/updates.py
+++ b/backend/routes/updates.py
@@ -236,9 +236,13 @@ def save_response(poll_id):
     resp = _get_or_create_response(poll)
     if resp.status == "sent":
         return jsonify({"error": "Already sent."}), 409
+    # Keep AI provenance only when the text is the LLM draft verbatim —
+    # the send flow always PUTs before /send, so an unconditional clear
+    # here would strip the (AI-drafted) marker off every sent draft.
+    if not (resp.content and resp.get_content() == content):
+        resp.generated_by = None  # user-authored/edited now
     resp.set_content(content)
     resp.status = "draft"
-    resp.generated_by = None  # user-authored/edited now
     db.session.commit()
     return jsonify({"response": _serialize_response(resp)}), 200
 

--- a/backend/tasks/exports.py
+++ b/backend/tasks/exports.py
@@ -240,6 +240,9 @@ def generate_user_profile(self, user_id: int, model_id: str):
 
             logger.info(f"Profile generation successful for user {user_id}, profile ID: {new_profile.id}")
 
+            from backend.utils.notifications import notify_profile_ready
+            notify_profile_ready(user_id)
+
             return {
                 'user_id': user_id,
                 'profile_id': new_profile.id,
@@ -471,6 +474,9 @@ def update_user_profile(self, user_id: int, model_id: str,
                 )
 
             success = True
+            if result and result.get('profile_id'):
+                from backend.utils.notifications import notify_profile_ready
+                notify_profile_ready(user_id)
             return result
 
         except Exception as e:

--- a/backend/tasks/poll_draft.py
+++ b/backend/tasks/poll_draft.py
@@ -1,0 +1,119 @@
+"""LLM-drafted poll answers (#207 polling extension).
+
+Runs only after the user's explicit opt-in 1 (draft_requested_at is their
+consent timestamp). The draft is written from the user's AI-readable
+derived context — profile, recent context, intentions — never raw nodes,
+and stays PRIVATE until the user separately opts in to send it.
+"""
+import logging
+
+from backend.celery_app import celery, flask_app
+from backend.extensions import db
+from backend.models import (
+    PollResponse, UserProfile, UserRecentContext, UserArtifact, APICostLog,
+)
+from backend.llm_providers import LLMProvider
+from backend.utils.api_keys import get_api_keys_for_usage
+from backend.utils.cost import calculate_llm_cost_microdollars
+
+logger = logging.getLogger(__name__)
+
+DRAFT_SYSTEM_PROMPT = """\
+You are drafting an answer ON BEHALF OF a Loore user to a question the \
+developer asked the community. You have access to the user's profile and \
+recent context below.
+
+Rules:
+- Write in first person, in the user's voice, grounded ONLY in what the \
+context shows about their actual experience with Loore.
+- Be honest and specific; concrete observations beat pleasantries.
+- Keep it short: a few sentences to two short paragraphs.
+- If the context doesn't contain enough to answer meaningfully, say so \
+plainly (e.g. "I haven't used that part much yet") rather than inventing.
+- The user will review and edit this draft before deciding whether to \
+send it. Output ONLY the draft answer — no preamble, no headings.
+"""
+
+
+def _build_user_context(user):
+    parts = []
+    profile = UserProfile.query.filter_by(user_id=user.id).order_by(
+        UserProfile.created_at.desc()).first()
+    if profile:
+        parts.append("## User profile\n\n" + profile.get_content())
+    recent = UserRecentContext.query.filter_by(user_id=user.id).order_by(
+        UserRecentContext.created_at.desc()).first()
+    if recent:
+        parts.append("## Recent context\n\n" + recent.get_content())
+    intentions = UserArtifact.latest_for(user.id, "intentions")
+    if intentions:
+        parts.append("## Intentions\n\n" + intentions.get_content())
+    return "\n\n".join(parts)
+
+
+@celery.task(bind=True)
+def draft_poll_response(self, response_id: int):
+    with flask_app.app_context():
+        resp = PollResponse.query.get(response_id)
+        if resp is None:
+            logger.warning("PollResponse %s vanished", response_id)
+            return
+        if resp.status != "drafting":
+            logger.info(
+                "PollResponse %s no longer drafting (%s) — skipping",
+                response_id, resp.status)
+            return
+
+        user = resp.user
+        try:
+            model_id = (
+                user.preferred_model
+                or flask_app.config.get("DEFAULT_LLM_MODEL")
+            )
+            if model_id not in flask_app.config["SUPPORTED_MODELS"]:
+                raise ValueError(f"Unsupported model: {model_id}")
+
+            context = _build_user_context(user)
+            if not context:
+                # Nothing to draft from — fail soft so the UI offers manual.
+                resp.status = "draft_failed"
+                db.session.commit()
+                return
+
+            messages = [
+                {"role": "system", "content": DRAFT_SYSTEM_PROMPT},
+                {"role": "user", "content": (
+                    f"{context}\n\n---\n\n"
+                    f"The developer asks:\n\n{resp.poll.question}\n\n"
+                    f"Draft the user's answer."
+                )},
+            ]
+            api_keys = get_api_keys_for_usage(flask_app.config, "chat")
+            response = LLMProvider.get_completion(
+                model_id, messages, api_keys, max_tokens=1000)
+
+            input_tokens = response.get("input_tokens", 0)
+            output_tokens = response.get("output_tokens", 0)
+            db.session.add(APICostLog(
+                user_id=user.id, model_id=model_id,
+                request_type="poll_draft",
+                input_tokens=input_tokens, output_tokens=output_tokens,
+                cost_microdollars=calculate_llm_cost_microdollars(
+                    model_id, input_tokens, output_tokens),
+            ))
+
+            resp.set_content(response["content"].strip())
+            resp.generated_by = model_id
+            resp.status = "draft"
+            db.session.commit()
+            logger.info(
+                "Drafted poll response %s for user %s (%s)",
+                response_id, user.id, model_id)
+        except Exception:
+            db.session.rollback()
+            resp = PollResponse.query.get(response_id)
+            if resp is not None and resp.status == "drafting":
+                resp.status = "draft_failed"
+                db.session.commit()
+            logger.exception(
+                "Poll draft failed for response %s", response_id)

--- a/backend/tasks/poll_draft.py
+++ b/backend/tasks/poll_draft.py
@@ -1,27 +1,47 @@
 """LLM-drafted poll answers (#207 polling extension).
 
 Runs only after the user's explicit opt-in 1 (draft_requested_at is their
-consent timestamp). The draft is written from the user's AI-readable
-derived context — profile, recent context, intentions — never raw nodes,
-and stays PRIVATE until the user separately opts in to send it.
+consent timestamp). What the model may read is chosen by the admin PER
+POLL and shown to the user before they opt in:
+
+  * data_source='derived'       — profile + recent summary + intentions
+  * data_source='recent_window' — the most recent raw writing that fits
+                                  the model's context window (AI-readable
+                                  nodes only)
+
+Drafts ride the provider Batch API (~50% cheaper; they're async anyway):
+`submit_poll_draft` fires on opt-in, `collect_poll_draft_batches` (beat,
+every minute) saves finished drafts. Costs are attributed to the polls
+SYSTEM account with request_ref="poll:<id>" — never to the answering
+user. Drafts stay PRIVATE until the user separately opts in to send.
 """
 import logging
+from datetime import datetime
 
 from backend.celery_app import celery, flask_app
 from backend.extensions import db
 from backend.models import (
-    PollResponse, UserProfile, UserRecentContext, UserArtifact, APICostLog,
+    PollResponse, PollDraftBatchJob, UserProfile, UserRecentContext,
+    UserArtifact, APICostLog,
 )
-from backend.llm_providers import LLMProvider
 from backend.utils.api_keys import get_api_keys_for_usage
 from backend.utils.cost import calculate_llm_cost_microdollars
+from backend.utils.llm_batch import (
+    batch_submit, batch_check_and_collect, apply_batch_key_override,
+)
+from backend.utils.tokens import approximate_token_count
 
 logger = logging.getLogger(__name__)
 
+MAX_DRAFT_TOKENS = 1000
+# Headroom for the system prompt, question and formatting when filling
+# the context window with user data.
+WINDOW_OVERHEAD_TOKENS = 2000
+
 DRAFT_SYSTEM_PROMPT = """\
 You are drafting an answer ON BEHALF OF a Loore user to a question the \
-developer asked the community. You have access to the user's profile and \
-recent context below.
+developer asked the community. You have access to the user's context \
+below.
 
 Rules:
 - Write in first person, in the user's voice, grounded ONLY in what the \
@@ -35,7 +55,7 @@ send it. Output ONLY the draft answer — no preamble, no headings.
 """
 
 
-def _build_user_context(user):
+def _derived_context(user):
     parts = []
     profile = UserProfile.query.filter_by(user_id=user.id).order_by(
         UserProfile.created_at.desc()).first()
@@ -51,69 +71,191 @@ def _build_user_context(user):
     return "\n\n".join(parts)
 
 
-@celery.task(bind=True)
-def draft_poll_response(self, response_id: int):
-    with flask_app.app_context():
-        resp = PollResponse.query.get(response_id)
-        if resp is None:
-            logger.warning("PollResponse %s vanished", response_id)
+def _recent_window_context(user, model_cfg):
+    """Most recent AI-readable writing that fits the model's context
+    window (minus draft output + prompt overhead)."""
+    from backend.tasks.exports import build_user_export_content
+    budget = (model_cfg.get("context_window", 200000)
+              - MAX_DRAFT_TOKENS - WINDOW_OVERHEAD_TOKENS)
+    export = build_user_export_content(
+        user, max_tokens=budget, filter_ai_usage=True,
+        include_strategy="engaged_threads")
+    if not export:
+        return ""
+    return "## The user's recent writing\n\n" + export
+
+
+def _build_request(resp):
+    """Build the batch request dict for one PollResponse, or None when
+    there's no context to draft from."""
+    poll = resp.poll
+    user = resp.user
+    model_id = poll.model_id or flask_app.config.get("DEFAULT_LLM_MODEL")
+    model_cfg = flask_app.config["SUPPORTED_MODELS"].get(model_id)
+    if model_cfg is None:
+        raise ValueError(f"Unsupported model: {model_id}")
+
+    if poll.data_source == "recent_window":
+        context = _recent_window_context(user, model_cfg)
+    else:
+        context = _derived_context(user)
+    if not context.strip():
+        return None
+
+    messages = [
+        {"role": "system", "content": DRAFT_SYSTEM_PROMPT},
+        {"role": "user", "content": (
+            f"{context}\n\n---\n\n"
+            f"The developer asks:\n\n{poll.question}\n\n"
+            f"Draft the user's answer."
+        )},
+    ]
+    logger.info(
+        "Poll draft request for response %s: poll %s, model %s, "
+        "source %s, ~%s ctx tokens", resp.id, poll.id, model_id,
+        poll.data_source, approximate_token_count(context))
+    return {
+        "custom_id": f"poll-draft-{resp.id}",
+        "model_id": model_id,
+        "api_model": model_cfg["api_model"],
+        "messages": messages,
+        "max_tokens": MAX_DRAFT_TOKENS,
+        "provider": model_cfg["provider"],
+    }
+
+
+def _fail_response(resp):
+    if resp is not None and resp.status == "drafting":
+        resp.status = "draft_failed"
+        db.session.commit()
+
+
+def _submit_poll_draft(response_id, task_id=None):
+    """Core of submit (plain function so tests can call it without the
+    Celery machinery)."""
+    resp = PollResponse.query.get(response_id)
+    if resp is None or resp.status != "drafting":
+        logger.info("Poll draft %s skipped (gone or not drafting)",
+                    response_id)
+        return
+    try:
+        request = _build_request(resp)
+        if request is None:
+            # Nothing to draft from — fail soft so the UI offers manual.
+            _fail_response(resp)
             return
-        if resp.status != "drafting":
-            logger.info(
-                "PollResponse %s no longer drafting (%s) — skipping",
-                response_id, resp.status)
-            return
 
-        user = resp.user
-        try:
-            model_id = (
-                user.preferred_model
-                or flask_app.config.get("DEFAULT_LLM_MODEL")
-            )
-            if model_id not in flask_app.config["SUPPORTED_MODELS"]:
-                raise ValueError(f"Unsupported model: {model_id}")
+        keys = apply_batch_key_override(
+            get_api_keys_for_usage(flask_app.config, "chat"),
+            flask_app.config)
+        provider = request.pop("provider")
+        batch_ids = batch_submit({provider: [request]}, keys, "poll")
+        if not batch_ids:
+            raise RuntimeError("batch_submit returned no batch ids")
 
-            context = _build_user_context(user)
-            if not context:
-                # Nothing to draft from — fail soft so the UI offers manual.
-                resp.status = "draft_failed"
-                db.session.commit()
-                return
-
-            messages = [
-                {"role": "system", "content": DRAFT_SYSTEM_PROMPT},
-                {"role": "user", "content": (
-                    f"{context}\n\n---\n\n"
-                    f"The developer asks:\n\n{resp.poll.question}\n\n"
-                    f"Draft the user's answer."
-                )},
-            ]
-            api_keys = get_api_keys_for_usage(flask_app.config, "chat")
-            response = LLMProvider.get_completion(
-                model_id, messages, api_keys, max_tokens=1000)
-
-            input_tokens = response.get("input_tokens", 0)
-            output_tokens = response.get("output_tokens", 0)
-            db.session.add(APICostLog(
-                user_id=user.id, model_id=model_id,
-                request_type="poll_draft",
-                input_tokens=input_tokens, output_tokens=output_tokens,
-                cost_microdollars=calculate_llm_cost_microdollars(
-                    model_id, input_tokens, output_tokens),
+        for provider_key, batch_id in batch_ids.items():
+            db.session.add(PollDraftBatchJob(
+                provider_key=provider_key, batch_id=batch_id,
+                items=[{
+                    "custom_id": request["custom_id"],
+                    "response_id": resp.id,
+                    "poll_id": resp.poll_id,
+                    "model_id": request["model_id"],
+                }],
             ))
+        resp.draft_task_id = task_id
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        _fail_response(PollResponse.query.get(response_id))
+        logger.exception(
+            "Poll draft submit failed for response %s", response_id)
 
-            resp.set_content(response["content"].strip())
-            resp.generated_by = model_id
-            resp.status = "draft"
-            db.session.commit()
-            logger.info(
-                "Drafted poll response %s for user %s (%s)",
-                response_id, user.id, model_id)
+
+@celery.task(bind=True)
+def submit_poll_draft(self, response_id: int):
+    """Opt-in 1 fired: submit a single-item provider batch for this
+    response. (Single-item batches still get the 50% batch discount.)"""
+    with flask_app.app_context():
+        _submit_poll_draft(response_id, task_id=self.request.id)
+
+
+def _save_draft_result(item, result):
+    """Save one collected batch result to its PollResponse and log the
+    cost to the polls system account."""
+    from backend.utils.system_accounts import get_poll_system_user
+
+    resp = PollResponse.query.get(item["response_id"])
+    if resp is None or resp.status != "drafting":
+        logger.info("Draft result for response %s dropped (status %s)",
+                    item["response_id"],
+                    resp.status if resp else "gone")
+        return
+
+    system_user = get_poll_system_user()
+    db.session.add(APICostLog(
+        user_id=system_user.id, model_id=item["model_id"],
+        request_type="poll_draft",
+        request_ref=f"poll:{item['poll_id']}",
+        input_tokens=result["input_tokens"],
+        output_tokens=result["output_tokens"],
+        cost_microdollars=calculate_llm_cost_microdollars(
+            item["model_id"], result["input_tokens"],
+            result["output_tokens"], batch=True),
+    ))
+    resp.set_content(result["content"].strip())
+    resp.generated_by = item["model_id"]
+    resp.status = "draft"
+    logger.info("Saved poll draft for response %s (poll %s)",
+                resp.id, item["poll_id"])
+
+
+def _collect_poll_draft_batches():
+    """Core of collect (plain function so tests can call it without the
+    Celery machinery)."""
+    jobs = PollDraftBatchJob.query.filter_by(status="pending").all()
+    if not jobs:
+        return
+
+    keys = apply_batch_key_override(
+        get_api_keys_for_usage(flask_app.config, "chat"),
+        flask_app.config)
+
+    for job in jobs:
+        try:
+            results, still_pending, _ = batch_check_and_collect(
+                {job.provider_key: job.batch_id}, keys)
         except Exception:
-            db.session.rollback()
-            resp = PollResponse.query.get(response_id)
-            if resp is not None and resp.status == "drafting":
-                resp.status = "draft_failed"
-                db.session.commit()
-            logger.exception(
-                "Poll draft failed for response %s", response_id)
+            logger.exception("Collect failed for poll batch %s",
+                             job.batch_id)
+            continue
+        if still_pending:
+            continue
+
+        # Batch ended: every item either has a result or failed.
+        for item in job.items:
+            result = results.get(item["custom_id"])
+            if result:
+                _save_draft_result(item, result)
+            else:
+                logger.warning(
+                    "Poll draft item %s missing from batch %s",
+                    item["custom_id"], job.batch_id)
+                _fail_response(
+                    PollResponse.query.get(item["response_id"]))
+        job.status = "collected"
+        job.collected_at = datetime.utcnow()
+        db.session.commit()
+
+
+@celery.task
+def collect_poll_draft_batches():
+    """Beat task: retrieve finished poll-draft batches and save drafts.
+    No-op when nothing is pending."""
+    with flask_app.app_context():
+        _collect_poll_draft_batches()
+
+
+# Referenced by Poll model docs; kept here so route code has one import
+# point for both entry points.
+__all__ = ["submit_poll_draft", "collect_poll_draft_batches"]

--- a/backend/tasks/profile_batch.py
+++ b/backend/tasks/profile_batch.py
@@ -293,6 +293,9 @@ def _apply_result(user, item, result, submitted_at):
             source_data_cutoff=cutoff, generation_type="integration",
             parent_profile_id=item["prev_profile_id"], batch=True)
         logger.info(f"User {user.id}: saved batch integration profile")
+        # Integration = the batch rebuild finished for this user (#207).
+        from backend.utils.notifications import notify_profile_ready
+        notify_profile_ready(user.id)
     user.profile_batch_attempts = 0
     return None
 

--- a/backend/tests/test_updates.py
+++ b/backend/tests/test_updates.py
@@ -364,6 +364,24 @@ class TestPolls:
         _db.session.refresh(resp)
         assert resp.generated_by is None
 
+    def test_sending_unedited_draft_keeps_provenance(self, app, client):
+        # The send flow PUTs the current text before /send; a verbatim
+        # AI draft must keep its (AI-drafted) marker for the admin.
+        poll = self._poll()
+        resp = PollResponse(poll_id=poll.id, status="draft",
+                            generated_by="claude-opus-4.6",
+                            user_id=User.query.filter_by(
+                                username="tester").first().id)
+        resp.set_content("AI draft")
+        _db.session.add(resp)
+        _db.session.commit()
+        client.put(f"/api/updates/polls/{poll.id}/response",
+                   json={"content": "AI draft"})
+        client.post(f"/api/updates/polls/{poll.id}/send")
+        _db.session.refresh(resp)
+        assert resp.status == "sent"
+        assert resp.generated_by == "claude-opus-4.6"
+
 
 class TestAdminPolls:
     def test_admin_required(self, client):

--- a/backend/tests/test_updates.py
+++ b/backend/tests/test_updates.py
@@ -19,6 +19,7 @@ os.environ.setdefault("ENCRYPTION_DISABLED", "true")
 from backend.extensions import db as _db  # noqa: E402
 from backend.models import (  # noqa: E402
     User, UserNotification, Poll, PollResponse, ChangelogReadState,
+    PollDraftBatchJob, APICostLog, UserProfile,
 )
 import backend.utils.changelog as changelog_mod  # noqa: E402
 from backend.utils.changelog import (  # noqa: E402
@@ -27,6 +28,25 @@ from backend.utils.changelog import (  # noqa: E402
 from backend.utils.notifications import (  # noqa: E402
     notify_user, notify_profile_ready,
 )
+from backend.utils.system_accounts import (  # noqa: E402
+    get_poll_system_user, POLL_SYSTEM_USERNAME,
+)
+
+# ── Import the real poll_draft module against stub glue (same pattern as
+# test_share.py): backend.celery_app would boot the full app. ──
+_GLUE = ("backend.celery_app",)
+_saved_glue = {k: sys.modules.get(k) for k in _GLUE}
+sys.modules["backend.celery_app"] = MagicMock()
+sys.modules.pop("backend.tasks.poll_draft", None)
+import backend.tasks.poll_draft as poll_draft_mod  # noqa: E402
+for _k, _v in _saved_glue.items():
+    if _v is None:
+        sys.modules.pop(_k, None)
+    else:
+        sys.modules[_k] = _v
+# Route tests stub sys.modules["backend.tasks.poll_draft"]; keep the real
+# module reachable for the pipeline tests regardless of ordering.
+sys.modules["backend.tasks.poll_draft"] = poll_draft_mod
 
 
 SAMPLE = textwrap.dedent("""\
@@ -145,6 +165,13 @@ def _make_app(dev_updates=True):
     app.config["SECRET_KEY"] = "test-secret"
     app.config["TESTING"] = True
     app.config["DEV_UPDATES_V1"] = dev_updates
+    app.config["DEFAULT_LLM_MODEL"] = "test-model"
+    app.config["SUPPORTED_MODELS"] = {
+        "test-model": {
+            "provider": "anthropic", "api_model": "test-model-api",
+            "display_name": "Test Model", "context_window": 200000,
+        },
+    }
 
     _db.init_app(app)
     login_manager = LoginManager(app)
@@ -278,7 +305,7 @@ def _stub_poll_draft_task(monkeypatch):
     """The route imports the celery task lazily; give it a stub module so
     tests never touch backend.celery_app."""
     stub = MagicMock()
-    stub.draft_poll_response.delay.return_value = MagicMock(id="task-123")
+    stub.submit_poll_draft.delay.return_value = MagicMock(id="task-123")
     monkeypatch.setitem(sys.modules, "backend.tasks.poll_draft", stub)
     return stub
 
@@ -302,7 +329,7 @@ class TestPolls:
         res = client.post(f"/api/updates/polls/{poll.id}/draft")
         assert res.status_code == 202
         assert res.get_json()["response"]["status"] == "drafting"
-        stub.draft_poll_response.delay.assert_called_once()
+        stub.submit_poll_draft.delay.assert_called_once()
         resp = PollResponse.query.filter_by(poll_id=poll.id).first()
         assert resp.draft_requested_at is not None
 
@@ -315,8 +342,17 @@ class TestPolls:
         poll = self._poll()
         res = client.post(f"/api/updates/polls/{poll.id}/draft")
         assert res.status_code == 403
-        stub.draft_poll_response.delay.assert_not_called()
+        stub.submit_poll_draft.delay.assert_not_called()
         assert PollResponse.query.count() == 0
+
+    def test_draft_terms_shown_before_optin(self, app, client):
+        poll = Poll(question="?", model_id="test-model",
+                    data_source="recent_window")
+        _db.session.add(poll)
+        _db.session.commit()
+        polls = client.get("/api/updates").get_json()["polls"]
+        assert polls[0]["draft_terms"] == {
+            "model": "Test Model", "data_source": "recent_window"}
 
     def test_send_requires_content(self, app, client):
         poll = self._poll()
@@ -393,13 +429,30 @@ class TestAdminPolls:
         res = admin_client.post("/api/admin/polls",
                                 json={"question": "How is voice mode?"})
         assert res.status_code == 201
-        poll_id = res.get_json()["id"]
+        created = res.get_json()
+        # Defaults: server default model, derived context
+        assert created["model_id"] == "test-model"
+        assert created["data_source"] == "derived"
+        poll_id = created["id"]
         polls = admin_client.get("/api/admin/polls").get_json()["polls"]
         assert polls[0]["id"] == poll_id
         assert polls[0]["sent_count"] == 0
+        assert polls[0]["model_id"] == "test-model"
         res = admin_client.post(f"/api/admin/polls/{poll_id}/close")
         assert res.status_code == 200
         assert res.get_json()["closed_at"] is not None
+
+    def test_create_validates_model_and_source(self, admin_client):
+        assert admin_client.post("/api/admin/polls", json={
+            "question": "?", "model_id": "nope"}).status_code == 400
+        assert admin_client.post("/api/admin/polls", json={
+            "question": "?", "data_source": "everything"
+        }).status_code == 400
+        res = admin_client.post("/api/admin/polls", json={
+            "question": "?", "model_id": "test-model",
+            "data_source": "recent_window"})
+        assert res.status_code == 201
+        assert res.get_json()["data_source"] == "recent_window"
 
     def test_admin_sees_only_sent_responses(self, app, admin_client):
         user = User.query.filter_by(username="tester").first()
@@ -423,3 +476,190 @@ class TestAdminPolls:
         assert data["responses"][0]["content"] == "shared on purpose"
         counts = admin_client.get("/api/admin/polls").get_json()["polls"][0]
         assert counts["sent_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Batch draft pipeline (submit → collect), cost attribution
+# ---------------------------------------------------------------------------
+
+TEST_MODELS_CONFIG = {
+    "SUPPORTED_MODELS": {
+        "test-model": {
+            "provider": "anthropic", "api_model": "test-model-api",
+            "display_name": "Test Model", "context_window": 200000,
+        },
+    },
+    "DEFAULT_LLM_MODEL": "test-model",
+}
+
+
+@pytest.fixture
+def pipeline(app, monkeypatch):
+    """Wire poll_draft's glue (stub flask_app config, no-op app_context,
+    captured batch calls) inside the real test app context."""
+    prev_config = poll_draft_mod.flask_app.config
+    poll_draft_mod.flask_app.config = dict(TEST_MODELS_CONFIG)
+    monkeypatch.setattr(poll_draft_mod, "get_api_keys_for_usage",
+                        lambda *a, **k: {"anthropic": "k", "openai": "k"})
+    monkeypatch.setattr(poll_draft_mod, "apply_batch_key_override",
+                        lambda keys, cfg: keys)
+    yield poll_draft_mod
+    poll_draft_mod.flask_app.config = prev_config
+
+
+def _make_drafting_response(model_id="test-model", data_source="derived",
+                            with_profile=True):
+    user = User.query.filter_by(username="tester").first()
+    if with_profile:
+        profile = UserProfile(user_id=user.id, generated_by="user",
+                              tokens_used=0)
+        profile.set_content("PROFILE: daily journaler, voice mode.")
+        _db.session.add(profile)
+    poll = Poll(question="What's missing?", model_id=model_id,
+                data_source=data_source)
+    _db.session.add(poll)
+    _db.session.commit()
+    resp = PollResponse(poll_id=poll.id, user_id=user.id,
+                        status="drafting",
+                        draft_requested_at=datetime.utcnow())
+    _db.session.add(resp)
+    _db.session.commit()
+    return poll, resp
+
+
+class TestDraftBatchPipeline:
+    def test_submit_creates_job(self, pipeline, monkeypatch):
+        captured = {}
+
+        def fake_submit(requests_by_provider, keys, phase=None):
+            captured.update(requests_by_provider)
+            return {"anthropic": "batch-abc"}
+
+        monkeypatch.setattr(pipeline, "batch_submit", fake_submit)
+        poll, resp = _make_drafting_response()
+        pipeline._submit_poll_draft(resp.id, task_id="t-1")
+
+        job = PollDraftBatchJob.query.one()
+        assert job.provider_key == "anthropic"
+        assert job.batch_id == "batch-abc"
+        assert job.status == "pending"
+        assert job.items == [{
+            "custom_id": f"poll-draft-{resp.id}",
+            "response_id": resp.id, "poll_id": poll.id,
+            "model_id": "test-model",
+        }]
+        request = captured["anthropic"][0]
+        body = request["messages"][1]["content"]
+        assert "PROFILE: daily journaler" in body
+        assert "What's missing?" in body
+        assert request["max_tokens"] == pipeline.MAX_DRAFT_TOKENS
+        assert resp.status == "drafting"
+
+    def test_submit_recent_window_uses_export(self, pipeline, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            pipeline, "batch_submit",
+            lambda reqs, keys, phase=None: (
+                captured.update(reqs) or {"anthropic": "batch-w"}))
+        exports_stub = MagicMock()
+        exports_stub.build_user_export_content.return_value = (
+            "RECENT RAW WRITING")
+        monkeypatch.setitem(sys.modules, "backend.tasks.exports",
+                            exports_stub)
+
+        poll, resp = _make_drafting_response(
+            data_source="recent_window", with_profile=False)
+        pipeline._submit_poll_draft(resp.id)
+
+        kwargs = exports_stub.build_user_export_content.call_args.kwargs
+        assert kwargs["max_tokens"] == (
+            200000 - pipeline.MAX_DRAFT_TOKENS
+            - pipeline.WINDOW_OVERHEAD_TOKENS)
+        assert kwargs["filter_ai_usage"] is True
+        assert "RECENT RAW WRITING" in (
+            captured["anthropic"][0]["messages"][1]["content"])
+
+    def test_submit_without_context_fails_soft(self, pipeline,
+                                               monkeypatch):
+        submit = MagicMock()
+        monkeypatch.setattr(pipeline, "batch_submit", submit)
+        poll, resp = _make_drafting_response(with_profile=False)
+        pipeline._submit_poll_draft(resp.id)
+        assert resp.status == "draft_failed"
+        submit.assert_not_called()
+        assert PollDraftBatchJob.query.count() == 0
+
+    def _pending_job(self, poll, resp):
+        job = PollDraftBatchJob(
+            provider_key="anthropic", batch_id="batch-abc",
+            items=[{"custom_id": f"poll-draft-{resp.id}",
+                    "response_id": resp.id, "poll_id": poll.id,
+                    "model_id": "test-model"}])
+        _db.session.add(job)
+        _db.session.commit()
+        return job
+
+    def test_collect_saves_draft_and_attributes_cost(self, pipeline,
+                                                     monkeypatch):
+        poll, resp = _make_drafting_response()
+        job = self._pending_job(poll, resp)
+        monkeypatch.setattr(
+            pipeline, "batch_check_and_collect",
+            lambda ids, keys: ({f"poll-draft-{resp.id}": {
+                "content": " A drafted answer. ",
+                "input_tokens": 100, "output_tokens": 50,
+            }}, {}, {}))
+        cost_calls = {}
+
+        def fake_cost(model_id, inp, out, batch=False):
+            cost_calls.update(model=model_id, batch=batch)
+            return 4242
+
+        monkeypatch.setattr(
+            pipeline, "calculate_llm_cost_microdollars", fake_cost)
+
+        pipeline._collect_poll_draft_batches()
+
+        assert resp.status == "draft"
+        assert resp.get_content() == "A drafted answer."
+        assert resp.generated_by == "test-model"
+        assert job.status == "collected"
+
+        log = APICostLog.query.one()
+        system_user = User.query.filter_by(
+            username=POLL_SYSTEM_USERNAME).one()
+        assert log.user_id == system_user.id          # NOT the tester
+        assert log.request_type == "poll_draft"
+        assert log.request_ref == f"poll:{poll.id}"   # traceable to poll
+        assert log.cost_microdollars == 4242
+        assert cost_calls == {"model": "test-model", "batch": True}
+        # System account can't log in / never gets profile-generated
+        assert system_user.approved is False
+        assert system_user.plan == "free"
+
+    def test_collect_still_pending_leaves_job(self, pipeline, monkeypatch):
+        poll, resp = _make_drafting_response()
+        job = self._pending_job(poll, resp)
+        monkeypatch.setattr(
+            pipeline, "batch_check_and_collect",
+            lambda ids, keys: ({}, {"anthropic": "batch-abc"}, {}))
+        pipeline._collect_poll_draft_batches()
+        assert job.status == "pending"
+        assert resp.status == "drafting"
+
+    def test_collect_missing_item_fails_response(self, pipeline,
+                                                 monkeypatch):
+        poll, resp = _make_drafting_response()
+        job = self._pending_job(poll, resp)
+        monkeypatch.setattr(
+            pipeline, "batch_check_and_collect",
+            lambda ids, keys: ({}, {}, {}))  # ended, no result
+        pipeline._collect_poll_draft_batches()
+        assert job.status == "collected"
+        assert resp.status == "draft_failed"
+
+    def test_system_account_is_idempotent(self, app):
+        first = get_poll_system_user()
+        second = get_poll_system_user()
+        assert first.id == second.id
+        assert first.username == POLL_SYSTEM_USERNAME

--- a/backend/tests/test_updates.py
+++ b/backend/tests/test_updates.py
@@ -1,0 +1,407 @@
+"""Tests for the dev-update channel (#207): changelog parsing + per-user
+read state, targeted notifications, and the two-phase-consent poll flow.
+
+Same minimal-app pattern as test_share.py: sqlite in-memory, only the
+blueprints under test, session login via _user_id.
+"""
+import os
+import sys
+import textwrap
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("ENCRYPTION_DISABLED", "true")
+
+from backend.extensions import db as _db  # noqa: E402
+from backend.models import (  # noqa: E402
+    User, UserNotification, Poll, PollResponse, ChangelogReadState,
+)
+import backend.utils.changelog as changelog_mod  # noqa: E402
+from backend.utils.changelog import (  # noqa: E402
+    parse_changelog, unread_sections_for,
+)
+from backend.utils.notifications import (  # noqa: E402
+    notify_user, notify_profile_ready,
+)
+
+
+SAMPLE = textwrap.dedent("""\
+    # Loore — what's new
+
+    <!--
+    Authoring notes that must never leak into a section body.
+    -->
+
+    <!-- id: second-feature -->
+    ## 2026-07-02 — The second feature
+
+    Newest section body.
+
+    ## 2026-06-01 — First feature
+
+    Older body with **markdown**.
+
+    ## Undated announcement
+
+    No date on this one.
+    """)
+
+
+@pytest.fixture
+def changelog_file(tmp_path):
+    path = tmp_path / "user_changelog.md"
+    path.write_text(SAMPLE, encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+class TestParser:
+    def test_sections_ids_dates_order(self, changelog_file):
+        sections = parse_changelog(changelog_file)
+        assert [s["id"] for s in sections] == [
+            "second-feature", "first-feature", "undated-announcement"]
+        assert sections[0]["date"].isoformat() == "2026-07-02"
+        assert sections[2]["date"] is None
+        assert sections[0]["title"] == "The second feature"
+
+    def test_bodies_and_comment_stripping(self, changelog_file):
+        sections = parse_changelog(changelog_file)
+        assert sections[0]["body"] == "Newest section body."
+        assert "Authoring notes" not in sections[0]["body"]
+        for s in sections:
+            assert "<!--" not in s["body"]
+
+    def test_missing_file_is_empty(self, tmp_path):
+        assert parse_changelog(str(tmp_path / "nope.md")) == []
+
+    def test_duplicate_ids_keep_first(self, tmp_path):
+        path = tmp_path / "dup.md"
+        path.write_text(
+            "<!-- id: x -->\n## 2026-01-01 — A\n\nfirst\n\n"
+            "<!-- id: x -->\n## 2026-01-02 — B\n\nsecond\n",
+            encoding="utf-8")
+        sections = parse_changelog(str(path))
+        assert len(sections) == 1
+        assert sections[0]["title"] == "A"
+
+    def test_cache_invalidated_on_change(self, tmp_path):
+        path = tmp_path / "c.md"
+        path.write_text("## 2026-01-01 — One\n\nbody\n", encoding="utf-8")
+        assert len(parse_changelog(str(path))) == 1
+        path.write_text(
+            "## 2026-01-01 — One\n\nbody\n\n"
+            "## 2026-01-02 — Two\n\nmore body\n", encoding="utf-8")
+        assert len(parse_changelog(str(path))) == 2
+
+
+class TestUnread:
+    def _user(self, created_at):
+        user = MagicMock()
+        user.created_at = created_at
+        return user
+
+    def test_all_unread_without_state(self, changelog_file):
+        user = self._user(datetime(2026, 1, 1))
+        assert len(unread_sections_for(user, [], changelog_file)) == 3
+
+    def test_read_hides_skip_keeps(self, changelog_file):
+        user = self._user(datetime(2026, 1, 1))
+        read = MagicMock(section_id="second-feature", status="read")
+        skipped = MagicMock(section_id="first-feature", status="skipped")
+        ids = [s["id"] for s in
+               unread_sections_for(user, [read, skipped], changelog_file)]
+        assert "second-feature" not in ids
+        assert "first-feature" in ids
+
+    def test_no_backlog_for_new_users(self, changelog_file):
+        # Signed up 2026-06-15: the 06-01 section is pre-signup (hidden),
+        # the 07-02 one and the undated one still show.
+        user = self._user(datetime(2026, 6, 15))
+        ids = [s["id"] for s in unread_sections_for(user, [], changelog_file)]
+        assert ids == ["second-feature", "undated-announcement"]
+
+    def test_same_day_signup_still_shows(self, changelog_file):
+        user = self._user(datetime(2026, 7, 2, 23, 59))
+        ids = [s["id"] for s in unread_sections_for(user, [], changelog_file)]
+        assert "second-feature" in ids
+
+
+# ---------------------------------------------------------------------------
+# App / API
+# ---------------------------------------------------------------------------
+
+def _make_app(dev_updates=True):
+    from flask_login import LoginManager
+
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SECRET_KEY"] = "test-secret"
+    app.config["TESTING"] = True
+    app.config["DEV_UPDATES_V1"] = dev_updates
+
+    _db.init_app(app)
+    login_manager = LoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    from backend.routes.updates import updates_bp
+    app.register_blueprint(updates_bp, url_prefix="/api/updates")
+    from backend.routes.admin import admin_bp
+    app.register_blueprint(admin_bp, url_prefix="/api/admin")
+    return app
+
+
+@pytest.fixture
+def app(changelog_file, monkeypatch):
+    monkeypatch.setattr(changelog_mod, "CHANGELOG_PATH", changelog_file)
+    app = _make_app()
+    with app.app_context():
+        _db.create_all()
+        user = User(username="tester", approved=True,
+                    created_at=datetime(2026, 1, 1),
+                    default_ai_usage="chat")
+        admin = User(username="boss", approved=True, is_admin=True,
+                     created_at=datetime(2026, 1, 1))
+        _db.session.add_all([user, admin])
+        _db.session.commit()
+        yield app
+        _db.session.rollback()
+        _db.drop_all()
+
+
+def _login(app, username):
+    client = app.test_client()
+    user = User.query.filter_by(username=username).first()
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+    return client
+
+
+@pytest.fixture
+def client(app):
+    return _login(app, "tester")
+
+
+@pytest.fixture
+def admin_client(app):
+    return _login(app, "boss")
+
+
+class TestUpdatesAPI:
+    def test_requires_login(self, app):
+        res = app.test_client().get("/api/updates")
+        assert res.status_code in (302, 401)
+
+    def test_get_updates_full_payload(self, client):
+        res = client.get("/api/updates")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert [s["id"] for s in data["changelog"]] == [
+            "second-feature", "first-feature", "undated-announcement"]
+        assert data["notifications"] == []
+        assert data["polls"] == []
+
+    def test_read_and_skip_semantics(self, client):
+        assert client.post(
+            "/api/updates/changelog/second-feature/read").status_code == 200
+        assert client.post(
+            "/api/updates/changelog/first-feature/skip").status_code == 200
+        ids = [s["id"] for s in client.get(
+            "/api/updates").get_json()["changelog"]]
+        assert "second-feature" not in ids     # read → gone
+        assert "first-feature" in ids          # skipped → back next open
+
+    def test_unknown_section_404(self, client):
+        res = client.post("/api/updates/changelog/nope/read")
+        assert res.status_code == 404
+        assert ChangelogReadState.query.count() == 0
+
+    def test_killswitch_serves_nothing(self, changelog_file, monkeypatch):
+        monkeypatch.setattr(changelog_mod, "CHANGELOG_PATH", changelog_file)
+        app = _make_app(dev_updates=False)
+        with app.app_context():
+            _db.create_all()
+            user = User(username="u", approved=True)
+            _db.session.add(user)
+            _db.session.commit()
+            client = _login(app, "u")
+            data = client.get("/api/updates").get_json()
+            assert data == {
+                "changelog": [], "notifications": [], "polls": []}
+            _db.drop_all()
+
+
+class TestNotifications:
+    def test_notify_dedupes_unread(self, app):
+        user = User.query.filter_by(username="tester").first()
+        notify_profile_ready(user.id)
+        notify_profile_ready(user.id)
+        assert UserNotification.query.filter_by(
+            user_id=user.id, type="profile_ready").count() == 1
+
+    def test_read_then_new_one_stacks(self, app, client):
+        user = User.query.filter_by(username="tester").first()
+        first = notify_profile_ready(user.id)
+        res = client.post(f"/api/updates/notifications/{first.id}/read")
+        assert res.status_code == 200
+        notify_profile_ready(user.id)
+        assert UserNotification.query.filter_by(
+            user_id=user.id, type="profile_ready").count() == 2
+        unread = client.get("/api/updates").get_json()["notifications"]
+        assert len(unread) == 1
+
+    def test_skip_keeps_unread(self, app, client):
+        user = User.query.filter_by(username="tester").first()
+        n = notify_user(user.id, "fix_ready", "A fix you reported is live")
+        client.post(f"/api/updates/notifications/{n.id}/skip")
+        unread = client.get("/api/updates").get_json()["notifications"]
+        assert [x["id"] for x in unread] == [n.id]
+
+    def test_cannot_touch_others_notification(self, app, admin_client):
+        user = User.query.filter_by(username="tester").first()
+        n = notify_profile_ready(user.id)
+        res = admin_client.post(f"/api/updates/notifications/{n.id}/read")
+        assert res.status_code == 404
+
+
+def _stub_poll_draft_task(monkeypatch):
+    """The route imports the celery task lazily; give it a stub module so
+    tests never touch backend.celery_app."""
+    stub = MagicMock()
+    stub.draft_poll_response.delay.return_value = MagicMock(id="task-123")
+    monkeypatch.setitem(sys.modules, "backend.tasks.poll_draft", stub)
+    return stub
+
+
+class TestPolls:
+    def _poll(self):
+        poll = Poll(question="What's missing in Loore?")
+        _db.session.add(poll)
+        _db.session.commit()
+        return poll
+
+    def test_pending_poll_appears_in_updates(self, app, client):
+        poll = self._poll()
+        polls = client.get("/api/updates").get_json()["polls"]
+        assert [p["id"] for p in polls] == [poll.id]
+        assert polls[0]["response"] is None
+
+    def test_optin1_dispatches_draft(self, app, client, monkeypatch):
+        stub = _stub_poll_draft_task(monkeypatch)
+        poll = self._poll()
+        res = client.post(f"/api/updates/polls/{poll.id}/draft")
+        assert res.status_code == 202
+        assert res.get_json()["response"]["status"] == "drafting"
+        stub.draft_poll_response.delay.assert_called_once()
+        resp = PollResponse.query.filter_by(poll_id=poll.id).first()
+        assert resp.draft_requested_at is not None
+
+    def test_optin1_refused_when_ai_opted_out(self, app, client,
+                                              monkeypatch):
+        stub = _stub_poll_draft_task(monkeypatch)
+        user = User.query.filter_by(username="tester").first()
+        user.default_ai_usage = "none"
+        _db.session.commit()
+        poll = self._poll()
+        res = client.post(f"/api/updates/polls/{poll.id}/draft")
+        assert res.status_code == 403
+        stub.draft_poll_response.delay.assert_not_called()
+        assert PollResponse.query.count() == 0
+
+    def test_send_requires_content(self, app, client):
+        poll = self._poll()
+        res = client.post(f"/api/updates/polls/{poll.id}/send")
+        assert res.status_code == 400
+
+    def test_manual_answer_then_send(self, app, client):
+        poll = self._poll()
+        res = client.put(f"/api/updates/polls/{poll.id}/response",
+                         json={"content": "More silence between prompts."})
+        assert res.status_code == 200
+        res = client.post(f"/api/updates/polls/{poll.id}/send")
+        assert res.status_code == 200
+        resp = PollResponse.query.filter_by(poll_id=poll.id).first()
+        assert resp.status == "sent"
+        assert resp.sent_at is not None
+        # resolved → gone from the surface
+        assert client.get("/api/updates").get_json()["polls"] == []
+
+    def test_decline_hides_poll(self, app, client):
+        poll = self._poll()
+        client.post(f"/api/updates/polls/{poll.id}/decline")
+        assert client.get("/api/updates").get_json()["polls"] == []
+
+    def test_closed_poll_rejects_answers(self, app, client):
+        poll = self._poll()
+        poll.closed_at = datetime.utcnow()
+        _db.session.commit()
+        res = client.put(f"/api/updates/polls/{poll.id}/response",
+                         json={"content": "too late"})
+        assert res.status_code == 409
+        assert client.get("/api/updates").get_json()["polls"] == []
+
+    def test_edit_clears_generated_by(self, app, client):
+        poll = self._poll()
+        resp = PollResponse(poll_id=poll.id, status="draft",
+                            generated_by="claude-opus-4.6",
+                            user_id=User.query.filter_by(
+                                username="tester").first().id)
+        resp.set_content("AI draft")
+        _db.session.add(resp)
+        _db.session.commit()
+        client.put(f"/api/updates/polls/{poll.id}/response",
+                   json={"content": "my own words"})
+        _db.session.refresh(resp)
+        assert resp.generated_by is None
+
+
+class TestAdminPolls:
+    def test_admin_required(self, client):
+        assert client.post("/api/admin/polls",
+                           json={"question": "?"}).status_code == 403
+        assert client.get("/api/admin/polls").status_code == 403
+
+    def test_create_list_close(self, admin_client):
+        res = admin_client.post("/api/admin/polls",
+                                json={"question": "How is voice mode?"})
+        assert res.status_code == 201
+        poll_id = res.get_json()["id"]
+        polls = admin_client.get("/api/admin/polls").get_json()["polls"]
+        assert polls[0]["id"] == poll_id
+        assert polls[0]["sent_count"] == 0
+        res = admin_client.post(f"/api/admin/polls/{poll_id}/close")
+        assert res.status_code == 200
+        assert res.get_json()["closed_at"] is not None
+
+    def test_admin_sees_only_sent_responses(self, app, admin_client):
+        user = User.query.filter_by(username="tester").first()
+        poll = Poll(question="?")
+        _db.session.add(poll)
+        _db.session.commit()
+
+        private_draft = PollResponse(
+            poll_id=poll.id, user_id=user.id, status="draft")
+        private_draft.set_content("PRIVATE draft — never visible")
+        sent = PollResponse(
+            poll_id=poll.id, status="sent", sent_at=datetime.utcnow(),
+            user_id=User.query.filter_by(username="boss").first().id)
+        sent.set_content("shared on purpose")
+        _db.session.add_all([private_draft, sent])
+        _db.session.commit()
+
+        data = admin_client.get(
+            f"/api/admin/polls/{poll.id}/responses").get_json()
+        assert len(data["responses"]) == 1
+        assert data["responses"][0]["content"] == "shared on purpose"
+        counts = admin_client.get("/api/admin/polls").get_json()["polls"][0]
+        assert counts["sent_count"] == 1

--- a/backend/user_changelog.md
+++ b/backend/user_changelog.md
@@ -19,16 +19,30 @@ Authoring rules:
 -->
 
 <!-- id: dev-updates-channel -->
-## 2026-07-03 — Loore now tells you what's new
+## 2026-07-03 — A quiet channel between us
 
-You're looking at it: this little window appears when something changed in
-Loore that's worth your attention — a new feature, an important fix, a new
-model worth switching to. It only shows what you haven't seen, and if
-there's nothing new, it stays out of your way.
+Loore is meant to be an intimate space — a place for your thinking, not
+another app fighting for your attention. This window will never become a
+stream of notifications: it appears only when there's something genuinely
+worth knowing, and when there's nothing new, it stays out of your way.
 
-Two buttons, no tricks: **Got it** dismisses a note for good, **Later**
-keeps it for your next visit.
+At the same time, a space like this grows best when the people living in
+it and the people building it can hear each other. So this is a two-way
+channel:
 
-Occasionally we may also ask a question here — what's working, what's
-missing. Answering is always optional, and nothing you write leaves your
-account unless you explicitly press Send.
+**From us to you** — announcements like this one: a new feature, an
+important fix, a new model worth switching to.
+
+**From you to us** — whenever you feel like it:
+
+- **A GitHub issue** for a bug report or an idea for improvement.
+- **Feedback** for anything looser — an impression, a frustration, a wish.
+
+You don't need to leave Loore or fill out any forms for either: just say
+it in Voice or Text mode — "report this as a bug", "send this as
+feedback" — and Loore will take care of everything.
+
+**And sometimes both directions at once** — occasionally we'll ask a
+question here. Answering is always optional; Loore can help you draft an
+answer from your own context, and nothing leaves your account unless you
+explicitly press Send.

--- a/backend/user_changelog.md
+++ b/backend/user_changelog.md
@@ -11,6 +11,8 @@ Authoring rules:
 - Give each section a stable id with an HTML comment on the line above the
   heading: `<!-- id: my-feature -->`. Without one, the slugified title is
   used — renaming the title then re-notifies everyone.
+- Write each paragraph as ONE line of text (no hard wrapping) — the UI
+  breaks lines to fit the screen.
 - Write for users, not developers: what's new, why it matters, how to try
   it. Markdown is fully supported.
 - PRs with user-facing changes add a section as part of the PR. Quick
@@ -21,28 +23,17 @@ Authoring rules:
 <!-- id: dev-updates-channel -->
 ## 2026-07-03 — A quiet channel between us
 
-Loore is meant to be an intimate space — a place for your processing, not
-another app fighting for your attention. This window appears only when
-there's something genuinely worth knowing, and when there's nothing new,
-it stays out of your way.
+Loore is meant to be an intimate space — a place for your processing, not another app fighting for your attention. This window appears only when there's something genuinely worth knowing, and when there's nothing new, it stays out of your way.
 
-At the same time, a space like this grows best when the people inhabiting
-it and the people building it can hear each other. So this is a two-way
-channel:
+At the same time, a space like this grows best when the people inhabiting it and the people building it can hear each other. So this is a two-way channel:
 
-**From us to you** — announcements like this one: a new feature, an
-important fix, a new model worth switching to.
+**From us to you** — announcements like this one: a new feature, an important fix, a new model worth switching to.
 
 **From you to us** — whenever you feel like it:
 
 - **A GitHub issue** for a bug report or an idea for improvement.
 - **Feedback** for anything looser — an impression, a frustration, a wish.
 
-You don't need to leave Loore or fill out any forms for either: just say
-it in Voice or Text mode — "report this as a bug", "send this as
-feedback", or similar — and Loore will take care of everything.
+You don't need to leave Loore or fill out any forms for either: just say it in Voice or Text mode — "report this as a bug", "send this as feedback", or similar — and Loore will take care of everything.
 
-**And sometimes both directions at once** — occasionally we'll ask a
-question here. Answering is always optional; Loore can help you draft an
-answer from your own context, and nothing leaves your account unless you
-explicitly press Send.
+**And sometimes both directions at once** — occasionally we'll ask a question here. Answering is always optional; Loore can help you draft an answer from your own context, and nothing leaves your account unless you explicitly press Send.

--- a/backend/user_changelog.md
+++ b/backend/user_changelog.md
@@ -1,0 +1,34 @@
+# Loore — what's new
+
+<!--
+This file IS the user-facing changelog (#207). Each `## ` section below is
+one announcement, shown in-app to each user until they mark it read.
+
+Authoring rules:
+- Newest section at the TOP, right below this comment.
+- Heading format: `## YYYY-MM-DD — Title` (the date hides the section from
+  users who signed up after it — no backlog for new users).
+- Give each section a stable id with an HTML comment on the line above the
+  heading: `<!-- id: my-feature -->`. Without one, the slugified title is
+  used — renaming the title then re-notifies everyone.
+- Write for users, not developers: what's new, why it matters, how to try
+  it. Markdown is fully supported.
+- PRs with user-facing changes add a section as part of the PR. Quick
+  direct-to-main fixes just don't touch this file. Dark-shipped features
+  get their section in the commit that turns them ON, not at merge.
+-->
+
+<!-- id: dev-updates-channel -->
+## 2026-07-03 — Loore now tells you what's new
+
+You're looking at it: this little window appears when something changed in
+Loore that's worth your attention — a new feature, an important fix, a new
+model worth switching to. It only shows what you haven't seen, and if
+there's nothing new, it stays out of your way.
+
+Two buttons, no tricks: **Got it** dismisses a note for good, **Later**
+keeps it for your next visit.
+
+Occasionally we may also ask a question here — what's working, what's
+missing. Answering is always optional, and nothing you write leaves your
+account unless you explicitly press Send.

--- a/backend/user_changelog.md
+++ b/backend/user_changelog.md
@@ -21,12 +21,12 @@ Authoring rules:
 <!-- id: dev-updates-channel -->
 ## 2026-07-03 — A quiet channel between us
 
-Loore is meant to be an intimate space — a place for your thinking, not
-another app fighting for your attention. This window will never become a
-stream of notifications: it appears only when there's something genuinely
-worth knowing, and when there's nothing new, it stays out of your way.
+Loore is meant to be an intimate space — a place for your processing, not
+another app fighting for your attention. This window appears only when
+there's something genuinely worth knowing, and when there's nothing new,
+it stays out of your way.
 
-At the same time, a space like this grows best when the people living in
+At the same time, a space like this grows best when the people inhabiting
 it and the people building it can hear each other. So this is a two-way
 channel:
 
@@ -40,7 +40,7 @@ important fix, a new model worth switching to.
 
 You don't need to leave Loore or fill out any forms for either: just say
 it in Voice or Text mode — "report this as a bug", "send this as
-feedback" — and Loore will take care of everything.
+feedback", or similar — and Loore will take care of everything.
 
 **And sometimes both directions at once** — occasionally we'll ask a
 question here. Answering is always optional; Loore can help you draft an

--- a/backend/utils/changelog.py
+++ b/backend/utils/changelog.py
@@ -1,0 +1,140 @@
+"""Parser for the user-facing changelog file (#207).
+
+The changelog is a markdown file (backend/user_changelog.md) with one
+``## `` section per announcement, newest at the top. Each section has a
+stable id — an ``<!-- id: ... -->`` comment on the line above the heading,
+falling back to the slugified heading title — and a date parsed from the
+``## YYYY-MM-DD — Title`` heading. Sections dated before a user's signup
+are treated as read (new users get no backlog).
+
+Parsed results are cached on (mtime, size) so the file is only re-read
+when it changes.
+"""
+import os
+import re
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+CHANGELOG_PATH = os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), "user_changelog.md")
+
+_ID_COMMENT_RE = re.compile(r"<!--\s*id:\s*([a-zA-Z0-9_-]+)\s*-->")
+_HEADING_RE = re.compile(
+    r"^##\s+(?:(\d{4}-\d{2}-\d{2})\s*[—–-]\s*)?(.+?)\s*$")
+
+# (mtime, size) -> parsed sections
+_cache = {"key": None, "sections": []}
+
+
+def _slugify(title):
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:128] or "untitled"
+
+
+def _parse_date(date_str, line):
+    if not date_str:
+        return None
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        logger.warning("user_changelog.md: bad date %r in %r",
+                       date_str, line)
+        return None
+
+
+def _scan_sections(text):
+    """One pass over the file: skip HTML comments EXCEPT id comments (the
+    authoring-notes block at the top must not leak into any body), collect
+    heading + body lines per section."""
+    sections = []
+    current = None
+    pending_id = None
+    in_comment = False
+    for line in text.splitlines():
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+        id_match = _ID_COMMENT_RE.match(line.strip())
+        if id_match:
+            pending_id = id_match.group(1)
+            continue
+        if line.lstrip().startswith("<!--"):
+            if "-->" not in line:
+                in_comment = True
+            continue
+        heading = _HEADING_RE.match(line)
+        if heading:
+            date_str, title = heading.group(1), heading.group(2)
+            current = {
+                "id": pending_id or _slugify(title),
+                "title": title,
+                "date": _parse_date(date_str, line),
+                "body_lines": [],
+            }
+            sections.append(current)
+            pending_id = None
+            continue
+        if current is not None:
+            current["body_lines"].append(line)
+    return sections
+
+
+def parse_changelog(path=None):
+    """Return the changelog as a list of section dicts, file order (newest
+    first by convention): {id, title, date (datetime.date|None), body}.
+
+    Missing file -> empty list (the feature simply has nothing to show).
+    """
+    path = path or CHANGELOG_PATH
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return []
+    cache_key = (path, stat.st_mtime, stat.st_size)
+    if _cache["key"] == cache_key:
+        return _cache["sections"]
+
+    with open(path, encoding="utf-8") as f:
+        sections = _scan_sections(f.read())
+
+    seen_ids = set()
+    result = []
+    for s in sections:
+        if s["id"] in seen_ids:
+            logger.warning(
+                "user_changelog.md: duplicate section id %r — skipping "
+                "the later section", s["id"])
+            continue
+        seen_ids.add(s["id"])
+        result.append({
+            "id": s["id"],
+            "title": s["title"],
+            "date": s["date"],
+            "body": "\n".join(s["body_lines"]).strip(),
+        })
+
+    _cache["key"] = cache_key
+    _cache["sections"] = result
+    return result
+
+
+def unread_sections_for(user, read_states, path=None):
+    """Sections the user should see: not marked 'read', and not dated
+    before the user signed up. 'skipped' states stay unread by design.
+
+    read_states: iterable of ChangelogReadState for this user.
+    """
+    read_ids = {rs.section_id for rs in read_states if rs.status == "read"}
+    signup_date = user.created_at.date() if user.created_at else None
+    unread = []
+    for section in parse_changelog(path):
+        if section["id"] in read_ids:
+            continue
+        if (signup_date and section["date"]
+                and section["date"] < signup_date):
+            continue
+        unread.append(section)
+    return unread

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -48,8 +48,7 @@ def notify_profile_ready(user_id):
     return notify_user(
         user_id,
         type="profile_ready",
-        title="Your profile has been updated",
-        body="Loore re-read your recent writing and refreshed your "
-             "profile. Take a look — and correct anything it got wrong.",
+        title="Profile updated",
+        body="Your user profile has been updated based on your new data.",
         link="/profile",
     )

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -1,0 +1,55 @@
+"""Producers for targeted in-app notifications (#207).
+
+One helper, called from wherever background work finishes. Notifications
+are the persistent sibling of the transient completion toasts — they
+survive until the user opens Loore and marks them read. Bodies are
+system-generated template text only; never put user content in them.
+"""
+import logging
+
+from backend.extensions import db
+from backend.models import UserNotification
+
+logger = logging.getLogger(__name__)
+
+
+def notify_user(user_id, type, title, body=None, link=None,
+                replace_unread=True):
+    """Create a targeted notification. With replace_unread (default), an
+    existing UNREAD notification of the same type for this user is updated
+    in place instead of stacking ("your profile was updated" twice is one
+    fact, not two).
+
+    Commits as part of the caller's session — call it right before/with
+    the caller's own commit. Never raises: a failed notification must not
+    break the work it announces.
+    """
+    try:
+        notification = None
+        if replace_unread:
+            notification = UserNotification.query.filter_by(
+                user_id=user_id, type=type, status="unread").first()
+        if notification is None:
+            notification = UserNotification(user_id=user_id, type=type)
+            db.session.add(notification)
+        notification.title = title
+        notification.body = body
+        notification.link = link
+        db.session.commit()
+        return notification
+    except Exception:
+        db.session.rollback()
+        logger.exception(
+            "Failed to create %s notification for user %s", type, user_id)
+        return None
+
+
+def notify_profile_ready(user_id):
+    return notify_user(
+        user_id,
+        type="profile_ready",
+        title="Your profile has been updated",
+        body="Loore re-read your recent writing and refreshed your "
+             "profile. Take a look — and correct anything it got wrong.",
+        link="/profile",
+    )

--- a/backend/utils/system_accounts.py
+++ b/backend/utils/system_accounts.py
@@ -1,0 +1,41 @@
+"""System accounts for cost attribution (#207).
+
+Poll drafts run over a user's context but serve the admin's feedback ask,
+so their cost must not eat the answering user's spend budget. It lands on
+a dedicated, non-loginable system account instead — visible in the admin
+users table like any other account.
+
+The username sits inside the protected brand namespace ("loore" is
+blocked for registration by BRAND_SUBSTRING_RE), so no real user can ever
+claim it; we create it directly, bypassing signup validation on purpose.
+"""
+import logging
+
+from backend.extensions import db
+from backend.models import User
+
+logger = logging.getLogger(__name__)
+
+POLL_SYSTEM_USERNAME = "loore-polls"
+
+
+def get_poll_system_user():
+    """Get or lazily create the poll-costs system account.
+
+    approved=False (cannot log in, blocked by the before_request gate) and
+    plan="free" (excluded from profile generation eligibility). Race-safe:
+    a concurrent create loses on the unique username and re-reads.
+    """
+    user = User.query.filter_by(username=POLL_SYSTEM_USERNAME).first()
+    if user:
+        return user
+    try:
+        user = User(username=POLL_SYSTEM_USERNAME, approved=False,
+                    plan="free", default_ai_usage="none")
+        db.session.add(user)
+        db.session.commit()
+        logger.info("Created poll system account (user %s)", user.id)
+        return user
+    except Exception:
+        db.session.rollback()
+        return User.query.filter_by(username=POLL_SYSTEM_USERNAME).first()

--- a/docs/ACCELERATED-DEVELOPMENT-ROADMAP.md
+++ b/docs/ACCELERATED-DEVELOPMENT-ROADMAP.md
@@ -96,6 +96,7 @@ Feature 1 (Journaling) is production-ready and significantly expanded — see FO
 | A.17 | Unified agentic Voice | AI tool use in voice sessions (todos, GitHub issues), proposal tracking |
 | A.18 | Resilient audio recording | 15s upload intervals, batched transcription, draft recovery |
 | A.19 | Hierarchical context freshness | Context artifacts, recent summaries, profile freshness |
+| A.20 | Dev-update channel (#207) | In-app changelog (markdown file in repo, per-user read/skip), persistent background-task notifications, admin polls with two-phase opt-in LLM-drafted answers |
 
 ### Remaining Items
 

--- a/docs/TECHNICAL-ROADMAP.md
+++ b/docs/TECHNICAL-ROADMAP.md
@@ -46,6 +46,7 @@ These technical capabilities are production-ready and form the foundation:
 - **Dollar-cost tracking** - Per-user API cost tracking via APICostLog model, replacing token-based tracking (#61)
 - **Pin-to-profile** - Pin selected nodes to user profile page (#60)
 - **Cmd+Click navigation** - Open nodes in new tab across all previews
+- **Dev-update channel** (#207) - In-app "what's new" surface: user-facing changelog authored as a markdown file in the repo (`backend/user_changelog.md`, per-section per-user read/skip state, date-gated so new users get no backlog), persistent targeted notifications (profile-generation-complete wired as first producer), and admin polls with two-phase opt-in (LLM drafts an answer from the user's profile only on explicit request; nothing reaches the admin until the user explicitly sends). `DEV_UPDATES_V1` killswitch. This modal is the announcement channel for dark-shipped features (e.g. the public side / Commons).
 
 ### User Plan Tiers
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,6 +29,7 @@ import PublicSharePage from "./pages/PublicSharePage";
 import CommonsPage from "./pages/CommonsPage";
 import PublicThreadPage from "./pages/PublicThreadPage";
 import ProfileGenerationWatcher from "./components/ProfileGenerationWatcher";
+import UpdatesModal from "./components/UpdatesModal";
 import PromptsPage from "./pages/PromptsPage";
 import PromptDetailPage from "./pages/PromptDetailPage";
 import SearchModal from "./components/SearchModal";
@@ -101,6 +102,8 @@ function App() {
   const [showSearch, setShowSearch] = useState(false);
   const nodeFormRef = useRef(null);
   const [showTerms, setShowTerms] = useState(false);
+  const [updates, setUpdates] = useState(null);
+  const updatesFetched = useRef(false);
   const { user, setUser } = useUser();
   const navigate = useNavigate();
 
@@ -114,6 +117,21 @@ function App() {
         setShowTerms(false);
       }
     }
+  }, [user]);
+
+  // Dev-update channel (#207): once per session, after terms are settled,
+  // ask what's unread. Anything there opens the updates modal; nothing
+  // unread means nothing is shown.
+  useEffect(() => {
+    if (!user || !user.approved || !user.terms_up_to_date) return;
+    if (updatesFetched.current) return;
+    updatesFetched.current = true;
+    api.get("/updates").then((res) => {
+      const d = res.data || {};
+      const count = (d.changelog?.length || 0) +
+        (d.notifications?.length || 0) + (d.polls?.length || 0);
+      if (count > 0) setUpdates(d);
+    }).catch(() => {});
   }, [user]);
 
   // Cmd+K / Ctrl+K to open search
@@ -168,6 +186,10 @@ function App() {
             }
           }}
         />
+      )}
+
+      {updates && !showTerms && (
+        <UpdatesModal data={updates} onClose={() => setUpdates(null)} />
       )}
 
         <ProfileGenerationWatcher />

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -249,6 +249,89 @@ function AdminPolls() {
   );
 }
 
+// User feedback (#158): proposed by the AI in conversation, sent only on
+// the user's explicit confirm. The admin API existed without a UI —
+// this lists items and manages their triage status.
+const FEEDBACK_STATUSES = ["new", "reviewed", "done"];
+
+function AdminFeedback() {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("new");
+  const [feedbackError, setFeedbackError] = useState("");
+
+  useEffect(() => {
+    api.get("/admin/feedback")
+      .then((res) => setItems(res.data.feedback || []))
+      .catch(() => setFeedbackError("Failed to fetch feedback."));
+  }, []);
+
+  const updateStatus = async (id, status) => {
+    try {
+      await api.put(`/admin/feedback/${id}`, { status });
+      setItems((prev) =>
+        prev.map((f) => (f.id === id ? { ...f, status } : f)));
+    } catch (err) {
+      setFeedbackError("Failed to update feedback status.");
+    }
+  };
+
+  const visible = filter === "all"
+    ? items
+    : items.filter((f) => f.status === filter);
+  const countFor = (s) => items.filter((f) => f.status === s).length;
+
+  return (
+    <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: "12px" }}>
+        <h2>Feedback</h2>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          style={{ ...adminSelectStyle, padding: "6px 10px", fontSize: "0.85rem" }}
+        >
+          <option value="all">All ({items.length})</option>
+          {FEEDBACK_STATUSES.map((s) => (
+            <option key={s} value={s}>{s} ({countFor(s)})</option>
+          ))}
+        </select>
+      </div>
+      {feedbackError && (
+        <div style={{ color: "var(--error)" }}>{feedbackError}</div>
+      )}
+      {visible.length === 0 ? (
+        <div style={{ color: "var(--text-muted)", padding: "8px 0" }}>
+          Nothing here.
+        </div>
+      ) : (
+        visible.map((f) => (
+          <div key={f.id} style={{ borderTop: "1px solid var(--border)", padding: "10px 0" }}>
+            <div style={{ display: "flex", gap: "10px", alignItems: "baseline" }}>
+              <strong>{f.username || `user ${f.user_id}`}</strong>
+              <span style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}>
+                {f.category} · {f.source} ·{" "}
+                {f.created_at ? new Date(f.created_at).toLocaleDateString() : ""}
+              </span>
+              <span style={{ flex: 1 }} />
+              <select
+                value={f.status}
+                onChange={(e) => updateStatus(f.id, e.target.value)}
+                style={{ ...adminSelectStyle, padding: "6px 10px", fontSize: "0.85rem" }}
+              >
+                {FEEDBACK_STATUSES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <div style={{ whiteSpace: "pre-wrap", color: "var(--text-secondary)", marginTop: "4px" }}>
+              {f.content}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
 function AdminPanel() {
   const [users, setUsers] = useState([]);
   const [allowedPlans, setAllowedPlans] = useState([]);
@@ -425,6 +508,8 @@ function AdminPanel() {
       </div>
 
       <AdminPolls />
+
+      <AdminFeedback />
 
       {error && <div style={{ color: "var(--error)" }}>{error}</div>}
       <table style={{ width: "100%", borderCollapse: "collapse", color: "var(--text-primary)" }}>

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -60,6 +60,120 @@ function SortToggle({ dir, onToggle, label }) {
   );
 }
 
+// Polls — the admin side of the dev-update channel (#207). Ask the
+// community a question; read only the answers users explicitly sent.
+function AdminPolls() {
+  const [polls, setPolls] = useState([]);
+  const [question, setQuestion] = useState("");
+  const [responses, setResponses] = useState({}); // poll_id -> array
+  const [pollsError, setPollsError] = useState("");
+
+  const fetchPolls = async () => {
+    try {
+      const res = await api.get("/admin/polls");
+      setPolls(res.data.polls);
+    } catch (err) {
+      setPollsError("Failed to fetch polls.");
+    }
+  };
+
+  useEffect(() => { fetchPolls(); }, []);
+
+  const createPoll = async () => {
+    if (!question.trim()) return;
+    try {
+      await api.post("/admin/polls", { question });
+      setQuestion("");
+      fetchPolls();
+    } catch (err) {
+      setPollsError(err.response?.data?.error || "Failed to create poll.");
+    }
+  };
+
+  const toggleResponses = async (pollId) => {
+    if (responses[pollId]) {
+      setResponses((r) => {
+        const next = { ...r };
+        delete next[pollId];
+        return next;
+      });
+      return;
+    }
+    try {
+      const res = await api.get(`/admin/polls/${pollId}/responses`);
+      setResponses((r) => ({ ...r, [pollId]: res.data.responses }));
+    } catch (err) {
+      setPollsError("Failed to fetch responses.");
+    }
+  };
+
+  const closePoll = async (pollId) => {
+    try {
+      await api.post(`/admin/polls/${pollId}/close`);
+      fetchPolls();
+    } catch (err) {
+      setPollsError("Failed to close poll.");
+    }
+  };
+
+  return (
+    <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
+      <h2>Polls</h2>
+      <div style={{ display: "flex", gap: "10px", marginBottom: "12px" }}>
+        <input
+          type="text"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask the community a question…"
+          style={{ padding: "8px", flex: 1 }}
+        />
+        <button onClick={createPoll}>Create poll</button>
+      </div>
+      {pollsError && <div style={{ color: "var(--error)" }}>{pollsError}</div>}
+      {polls.map((p) => (
+        <div key={p.id} style={{ borderTop: "1px solid var(--border)", padding: "8px 0" }}>
+          <div style={{ display: "flex", gap: "10px", alignItems: "baseline" }}>
+            <span style={{ flex: 1 }}>
+              {p.question}
+              {p.closed_at && (
+                <em style={{ color: "var(--text-muted)" }}> (closed)</em>
+              )}
+            </span>
+            <span style={{ color: "var(--text-muted)", fontSize: "0.85rem", whiteSpace: "nowrap" }}>
+              {p.sent_count} sent / {p.declined_count} declined
+            </span>
+            <button onClick={() => toggleResponses(p.id)}>
+              {responses[p.id] ? "Hide" : "Responses"}
+            </button>
+            {!p.closed_at && (
+              <button onClick={() => closePoll(p.id)}>Close</button>
+            )}
+          </div>
+          {responses[p.id] && (
+            responses[p.id].length === 0 ? (
+              <div style={{ color: "var(--text-muted)", padding: "6px 0 0 12px" }}>
+                No responses sent yet.
+              </div>
+            ) : (
+              responses[p.id].map((r) => (
+                <div key={r.id} style={{ padding: "6px 0 0 12px" }}>
+                  <strong>{r.username}</strong>
+                  {r.llm_drafted && (
+                    <span style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}> (AI-drafted)</span>
+                  )}
+                  <div style={{ whiteSpace: "pre-wrap", color: "var(--text-secondary)" }}>
+                    {r.content}
+                  </div>
+                </div>
+              ))
+            )
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function AdminPanel() {
   const [users, setUsers] = useState([]);
   const [allowedPlans, setAllowedPlans] = useState([]);
@@ -234,6 +348,8 @@ function AdminPanel() {
         <button onClick={handleWhitelistUser}>Whitelist User</button>
         {newHandleError && <div style={{ color: "var(--error)" }}>{newHandleError}</div>}
       </div>
+
+      <AdminPolls />
 
       {error && <div style={{ color: "var(--error)" }}>{error}</div>}
       <table style={{ width: "100%", borderCollapse: "collapse", color: "var(--text-primary)" }}>

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -67,6 +67,29 @@ const POLL_DATA_SOURCES = [
   { value: "recent_window", label: "Recent writing (context window)" },
 ];
 
+// Bubble tabs, same treatment as ArtifactsNav (the documents workspace) —
+// the admin dashboard is organized as Users / Feedback / Polls sections.
+const adminBubbleStyle = (active) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  padding: "6px 14px",
+  background: active ? "var(--bg-card)" : "none",
+  border: "1px solid",
+  borderColor: active ? "var(--accent)" : "var(--border)",
+  borderRadius: "16px",
+  color: active ? "var(--text-primary)" : "var(--text-muted)",
+  fontFamily: "var(--sans)",
+  fontSize: "0.8rem",
+  fontWeight: 300,
+  cursor: "pointer",
+});
+
+const ADMIN_TABS = [
+  { key: "users", label: "Users" },
+  { key: "feedback", label: "Feedback" },
+  { key: "polls", label: "Polls" },
+];
+
 // Same select treatment as AccountPage's Settings (inputStyle+selectStyle
 // there) so admin controls don't render as bare browser widgets.
 const adminSelectStyle = {
@@ -166,8 +189,7 @@ function AdminPolls() {
   };
 
   return (
-    <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
-      <h2>Polls</h2>
+    <div>
       <div style={{ display: "flex", gap: "10px", marginBottom: "12px" }}>
         <input
           type="text"
@@ -281,9 +303,8 @@ function AdminFeedback() {
   const countFor = (s) => items.filter((f) => f.status === s).length;
 
   return (
-    <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
+    <div>
       <div style={{ display: "flex", alignItems: "baseline", gap: "12px" }}>
-        <h2>Feedback</h2>
         <select
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
@@ -333,6 +354,7 @@ function AdminFeedback() {
 }
 
 function AdminPanel() {
+  const [activeTab, setActiveTab] = useState("users");
   const [users, setUsers] = useState([]);
   const [allowedPlans, setAllowedPlans] = useState([]);
   const [error, setError] = useState("");
@@ -491,8 +513,28 @@ function AdminPanel() {
 
   return (
     <div style={{ padding: "20px" }}>
-      <h1>Admin Panel</h1>
+      <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "20px" }}>
+        {ADMIN_TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setActiveTab(t.key)}
+            style={adminBubbleStyle(activeTab === t.key)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <h1 style={{
+        fontFamily: "var(--serif)", fontSize: "2rem", fontWeight: 300,
+        color: "var(--text-primary)", margin: "0 0 20px",
+      }}>
+        {ADMIN_TABS.find((t) => t.key === activeTab).label}
+      </h1>
 
+      {activeTab === "polls" && <AdminPolls />}
+      {activeTab === "feedback" && <AdminFeedback />}
+
+      {activeTab === "users" && (<>
       {/* Whitelist New User Section */}
       <div style={{ marginBottom: "20px", padding: "10px", border: "1px solid var(--border)" }}>
         <h2>Whitelist a New User</h2>
@@ -506,10 +548,6 @@ function AdminPanel() {
         <button onClick={handleWhitelistUser}>Whitelist User</button>
         {newHandleError && <div style={{ color: "var(--error)" }}>{newHandleError}</div>}
       </div>
-
-      <AdminPolls />
-
-      <AdminFeedback />
 
       {error && <div style={{ color: "var(--error)" }}>{error}</div>}
       <table style={{ width: "100%", borderCollapse: "collapse", color: "var(--text-primary)" }}>
@@ -649,6 +687,7 @@ function AdminPanel() {
           ))}
         </tbody>
       </table>
+      </>)}
     </div>
   );
 }

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -62,9 +62,17 @@ function SortToggle({ dir, onToggle, label }) {
 
 // Polls — the admin side of the dev-update channel (#207). Ask the
 // community a question; read only the answers users explicitly sent.
+const POLL_DATA_SOURCES = [
+  { value: "derived", label: "Profile + recent + intentions" },
+  { value: "recent_window", label: "Recent writing (context window)" },
+];
+
 function AdminPolls() {
   const [polls, setPolls] = useState([]);
   const [question, setQuestion] = useState("");
+  const [models, setModels] = useState([]);
+  const [modelId, setModelId] = useState("");
+  const [dataSource, setDataSource] = useState("derived");
   const [responses, setResponses] = useState({}); // poll_id -> array
   const [pollsError, setPollsError] = useState("");
 
@@ -77,12 +85,21 @@ function AdminPolls() {
     }
   };
 
-  useEffect(() => { fetchPolls(); }, []);
+  useEffect(() => {
+    fetchPolls();
+    api.get("/nodes/models")
+      .then((res) => setModels(res.data.models || []))
+      .catch(() => {});
+  }, []);
 
   const createPoll = async () => {
     if (!question.trim()) return;
     try {
-      await api.post("/admin/polls", { question });
+      await api.post("/admin/polls", {
+        question,
+        ...(modelId ? { model_id: modelId } : {}),
+        data_source: dataSource,
+      });
       setQuestion("");
       fetchPolls();
     } catch (err) {
@@ -127,6 +144,27 @@ function AdminPolls() {
           placeholder="Ask the community a question…"
           style={{ padding: "8px", flex: 1 }}
         />
+        <select
+          value={modelId}
+          onChange={(e) => setModelId(e.target.value)}
+          title="Model that drafts answers"
+          style={{ padding: "8px" }}
+        >
+          <option value="">Default model</option>
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <select
+          value={dataSource}
+          onChange={(e) => setDataSource(e.target.value)}
+          title="What the draft may read (shown to users before opt-in)"
+          style={{ padding: "8px" }}
+        >
+          {POLL_DATA_SOURCES.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
         <button onClick={createPoll}>Create poll</button>
       </div>
       {pollsError && <div style={{ color: "var(--error)" }}>{pollsError}</div>}
@@ -135,6 +173,12 @@ function AdminPolls() {
           <div style={{ display: "flex", gap: "10px", alignItems: "baseline" }}>
             <span style={{ flex: 1 }}>
               {p.question}
+              <span style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}>
+                {" "}— {p.model_id || "default model"},{" "}
+                {(POLL_DATA_SOURCES.find(
+                  (s) => s.value === p.data_source) || POLL_DATA_SOURCES[0]
+                ).label.toLowerCase()}
+              </span>
               {p.closed_at && (
                 <em style={{ color: "var(--text-muted)" }}> (closed)</em>
               )}

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -67,6 +67,23 @@ const POLL_DATA_SOURCES = [
   { value: "recent_window", label: "Recent writing (context window)" },
 ];
 
+// Same select treatment as AccountPage's Settings (inputStyle+selectStyle
+// there) so admin controls don't render as bare browser widgets.
+const adminSelectStyle = {
+  padding: "10px 12px",
+  borderRadius: "6px",
+  border: "1px solid var(--border)",
+  backgroundColor: "var(--bg-input)",
+  color: "var(--text-primary)",
+  fontFamily: "var(--sans)",
+  fontWeight: 300,
+  fontSize: "0.95rem",
+  boxSizing: "border-box",
+  cursor: "pointer",
+  WebkitAppearance: "none",
+  appearance: "none",
+};
+
 function AdminPolls() {
   const [polls, setPolls] = useState([]);
   const [question, setQuestion] = useState("");
@@ -148,7 +165,7 @@ function AdminPolls() {
           value={modelId}
           onChange={(e) => setModelId(e.target.value)}
           title="Model that drafts answers"
-          style={{ padding: "8px" }}
+          style={adminSelectStyle}
         >
           <option value="">Default model</option>
           {models.map((m) => (
@@ -159,7 +176,7 @@ function AdminPolls() {
           value={dataSource}
           onChange={(e) => setDataSource(e.target.value)}
           title="What the draft may read (shown to users before opt-in)"
-          style={{ padding: "8px" }}
+          style={adminSelectStyle}
         >
           {POLL_DATA_SOURCES.map((s) => (
             <option key={s.value} value={s.value}>{s.label}</option>
@@ -452,6 +469,8 @@ function AdminPanel() {
                 <select
                   value={u.plan || "free"}
                   onChange={(e) => updatePlan(u.id, e.target.value)}
+                  style={{ ...adminSelectStyle,
+                           padding: "6px 10px", fontSize: "0.85rem" }}
                 >
                   {allowedPlans.map((p) => (
                     <option key={p} value={p}>{p}</option>

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -97,24 +97,39 @@ function AdminPolls() {
     try {
       const res = await api.get("/admin/polls");
       setPolls(res.data.polls);
+      return res.data.default_model_id;
     } catch (err) {
       setPollsError("Failed to fetch polls.");
+      return null;
     }
   };
 
   useEffect(() => {
-    fetchPolls();
-    api.get("/nodes/models")
-      .then((res) => setModels(res.data.models || []))
-      .catch(() => {});
+    // Preselect the app default as a concrete model — no ambiguous
+    // "default" option that resolves invisibly at creation time.
+    Promise.all([
+      fetchPolls(),
+      api.get("/nodes/models")
+        .then((res) => res.data.models || [])
+        .catch(() => []),
+    ]).then(([defaultModelId, fetchedModels]) => {
+      setModels(fetchedModels);
+      setModelId((current) => {
+        if (current) return current;
+        if (fetchedModels.some((m) => m.id === defaultModelId)) {
+          return defaultModelId;
+        }
+        return fetchedModels[0]?.id || "";
+      });
+    });
   }, []);
 
   const createPoll = async () => {
-    if (!question.trim()) return;
+    if (!question.trim() || !modelId) return;
     try {
       await api.post("/admin/polls", {
         question,
-        ...(modelId ? { model_id: modelId } : {}),
+        model_id: modelId,
         data_source: dataSource,
       });
       setQuestion("");
@@ -167,7 +182,6 @@ function AdminPolls() {
           title="Model that drafts answers"
           style={adminSelectStyle}
         >
-          <option value="">Default model</option>
           {models.map((m) => (
             <option key={m.id} value={m.id}>{m.name}</option>
           ))}

--- a/frontend/src/components/MarkdownBody.js
+++ b/frontend/src/components/MarkdownBody.js
@@ -96,7 +96,13 @@ function AddTaskInput({ onSubmit, onCancel }) {
  *   onCheckboxToggle: optional callback(lineText, currentChecked) for clickable checkboxes
  *   onAddTask: optional callback(afterItemText, newText) — enables the per-row hover "+"
  */
-const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckboxToggle, onAddTask }) => {
+// flowText: render paragraphs with standard markdown soft-wrap semantics
+// (single source newlines flow into the line) instead of the default
+// pre-wrap. The default preserves newlines because node content (user
+// writing, LLM replies) depends on it; AUTHORED markdown wrapped at a
+// fixed column (e.g. the user changelog) must opt in to flow, or every
+// source line break renders literally — unreadable on narrow screens.
+const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', flowText = false, onCheckboxToggle, onAddTask }) => {
   const [addingAfter, setAddingAfter] = React.useState(null);
   const components = {
     h1: ({ node, children, ...props }) => (
@@ -118,7 +124,7 @@ const MarkdownBody = ({ children, style, paragraphMargin = '0.5em 0', onCheckbox
       <h6 style={{ fontFamily: 'var(--serif)', fontSize: '0.95em', fontWeight: 600, lineHeight: 1.35, margin: '0.9em 0 0.3em', color: 'var(--text-primary)' }} {...props}>{children}</h6>
     ),
     p: ({ node, ...props }) => (
-      <p style={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word', margin: paragraphMargin }} {...props} />
+      <p style={{ whiteSpace: flowText ? 'normal' : 'pre-wrap', overflowWrap: 'break-word', margin: paragraphMargin }} {...props} />
     ),
     blockquote: ({ node, ...props }) => (
       <blockquote

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -344,6 +344,16 @@ function PollItem({ poll, onDone }) {
 
 function UpdatesModal({ data, onClose }) {
   const isMobile = useIsMobile();
+  // Real visible height: iOS Safari's `vh` pretends the collapsing
+  // toolbars don't exist, so a vh-sized card overflows the screen and
+  // swallows its own buttons. innerHeight tracks the actual viewport.
+  const [viewHeight, setViewHeight] = useState(
+    () => (typeof window !== "undefined" ? window.innerHeight : 800));
+  useEffect(() => {
+    const onResize = () => setViewHeight(window.innerHeight);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
   const [changelog, setChangelog] = useState(data.changelog || []);
   const [notifications, setNotifications] = useState(
     data.notifications || []);
@@ -369,20 +379,26 @@ function UpdatesModal({ data, onClose }) {
     setter((items) => items.filter((item) => item[key] !== id));
 
   // Most users only ever open Loore on a phone: give the card the full
-  // (padded) width there, trim the padding, and let the height breathe.
+  // (padded) width there, trim the padding, and cap the height BELOW the
+  // visible viewport so the dimmed app stays visible above and below —
+  // the card must read as an overlay, not a page.
   const responsiveCard = isMobile
     ? {
         ...cardStyle,
         width: "100%",
         maxWidth: "100%",
         padding: "1.4rem 1.15rem",
-        maxHeight: "88vh",
+        maxHeight: `${Math.max(viewHeight - 72, 320)}px`,
       }
     : cardStyle;
 
   return (
     <div
-      style={{ ...overlayStyle, padding: "12px", boxSizing: "border-box" }}
+      style={{
+        ...overlayStyle,
+        padding: isMobile ? "36px 12px" : "12px",
+        boxSizing: "border-box",
+      }}
       onClick={onClose}
     >
       <div style={responsiveCard} onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api";
 import MarkdownBody from "./MarkdownBody";
+import { useIsMobile } from "../hooks/useIsMobile";
 
 /**
  * The dev-update channel surface (#207): shows unread changelog sections,
@@ -37,7 +38,7 @@ const cardStyle = {
 
 const headerStyle = {
   fontFamily: "var(--serif)",
-  fontSize: "1.5rem",
+  fontSize: "1.65rem",
   fontWeight: 400,
   color: "var(--text-primary)",
   margin: 0,
@@ -50,27 +51,32 @@ const itemStyle = {
   marginTop: "1.25rem",
 };
 
+// The serif title must outweigh the sans body (whose **bolds** render at
+// 700) — Cormorant asserts itself through size, not weight.
 const itemTitleStyle = {
   fontFamily: "var(--serif)",
-  fontSize: "1.15rem",
+  fontSize: "1.4rem",
   fontWeight: 400,
+  lineHeight: 1.3,
   color: "var(--text-primary)",
-  margin: 0,
+  margin: "0.4rem 0 0",
 };
 
 const dateStyle = {
   fontFamily: "var(--sans)",
-  fontSize: "0.75rem",
+  fontSize: "0.72rem",
   fontWeight: 300,
   color: "var(--text-muted)",
-  letterSpacing: "0.04em",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
 };
 
 const buttonRowStyle = {
   display: "flex",
+  flexWrap: "wrap",
   gap: "10px",
   justifyContent: "flex-end",
-  marginTop: "0.75rem",
+  marginTop: "1rem",
 };
 
 const ghostButtonStyle = {
@@ -110,7 +116,11 @@ function ChangelogItem({ section, onDone }) {
     <div style={itemStyle}>
       {section.date && <div style={dateStyle}>{section.date}</div>}
       <h3 style={itemTitleStyle}>{section.title}</h3>
-      <MarkdownBody style={{ fontSize: "0.9rem" }}>
+      <MarkdownBody style={{
+        fontSize: "0.9rem",
+        color: "var(--text-secondary)",
+        marginTop: "0.9rem",
+      }}>
         {section.body}
       </MarkdownBody>
       <div style={buttonRowStyle}>
@@ -139,7 +149,7 @@ function NotificationItem({ notification, onDone }) {
         <p style={{
           fontFamily: "var(--sans)", fontSize: "0.9rem", fontWeight: 300,
           color: "var(--text-secondary)", lineHeight: 1.6,
-          margin: "0.5rem 0 0",
+          margin: "0.9rem 0 0",
         }}>
           {notification.body}
         </p>
@@ -251,7 +261,7 @@ function PollItem({ poll, onDone }) {
     <div style={itemStyle}>
       <div style={dateStyle}>A QUESTION FROM THE DEVELOPER</div>
       <h3 style={itemTitleStyle}>{poll.question}</h3>
-      <p style={{ ...mutedNoteStyle, margin: "0.5rem 0 0" }}>
+      <p style={{ ...mutedNoteStyle, margin: "0.9rem 0 0" }}>
         Answering is optional. If you ask for a draft, {draftModel} will
         read {draftSource} to write one for you to edit — and nothing is
         sent until you press Send.
@@ -333,6 +343,7 @@ function PollItem({ poll, onDone }) {
 }
 
 function UpdatesModal({ data, onClose }) {
+  const isMobile = useIsMobile();
   const [changelog, setChangelog] = useState(data.changelog || []);
   const [notifications, setNotifications] = useState(
     data.notifications || []);
@@ -357,9 +368,24 @@ function UpdatesModal({ data, onClose }) {
   const removeFrom = (setter) => (id, key) =>
     setter((items) => items.filter((item) => item[key] !== id));
 
+  // Most users only ever open Loore on a phone: give the card the full
+  // (padded) width there, trim the padding, and let the height breathe.
+  const responsiveCard = isMobile
+    ? {
+        ...cardStyle,
+        width: "100%",
+        maxWidth: "100%",
+        padding: "1.4rem 1.15rem",
+        maxHeight: "88vh",
+      }
+    : cardStyle;
+
   return (
-    <div style={overlayStyle} onClick={onClose}>
-      <div style={cardStyle} onClick={(e) => e.stopPropagation()}>
+    <div
+      style={{ ...overlayStyle, padding: "12px", boxSizing: "border-box" }}
+      onClick={onClose}
+    >
+      <div style={responsiveCard} onClick={(e) => e.stopPropagation()}>
         <h2 style={headerStyle}>While you were away</h2>
         <p style={{ ...mutedNoteStyle, margin: 0 }}>
           What's new in Loore since your last visit.

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -164,6 +164,13 @@ function NotificationItem({ notification, onDone }) {
   );
 }
 
+// Human wording for what the draft may read — must match the backend
+// Poll.DATA_SOURCES semantics (informed consent, shown before opt-in 1).
+const DATA_SOURCE_LABELS = {
+  derived: "your profile, recent summary and intentions",
+  recent_window: "your recent writing (as much as fits its context window)",
+};
+
 function PollItem({ poll, onDone }) {
   const [response, setResponse] = useState(poll.response);
   const [text, setText] = useState(poll.response?.content || "");
@@ -174,8 +181,13 @@ function PollItem({ poll, onDone }) {
   const pollTimer = useRef(null);
 
   const drafting = response?.status === "drafting";
+  const draftModel = poll.draft_terms?.model || "the AI";
+  const draftSource =
+    DATA_SOURCE_LABELS[poll.draft_terms?.data_source] ||
+    DATA_SOURCE_LABELS.derived;
 
-  // While the LLM draft is generating, poll for its completion.
+  // While the LLM draft is generating (async batch, minutes), poll for
+  // its completion.
   useEffect(() => {
     if (!drafting) return undefined;
     pollTimer.current = setInterval(async () => {
@@ -195,7 +207,7 @@ function PollItem({ poll, onDone }) {
           }
         }
       } catch (e) { /* keep polling */ }
-    }, 2500);
+    }, 5000);
     return () => clearInterval(pollTimer.current);
   }, [drafting, poll.id]);
 
@@ -240,14 +252,16 @@ function PollItem({ poll, onDone }) {
       <div style={dateStyle}>A QUESTION FROM THE DEVELOPER</div>
       <h3 style={itemTitleStyle}>{poll.question}</h3>
       <p style={{ ...mutedNoteStyle, margin: "0.5rem 0 0" }}>
-        Answering is optional. Loore can draft a reply from your profile
-        for you to edit — and nothing is sent until you press Send.
+        Answering is optional. If you ask for a draft, {draftModel} will
+        read {draftSource} to write one for you to edit — and nothing is
+        sent until you press Send.
       </p>
 
       {drafting && (
         <p style={{ ...mutedNoteStyle, margin: "0.75rem 0 0",
           color: "var(--accent)" }}>
-          Loore is drafting an answer from your profile…
+          {draftModel} is drafting an answer in the background — this can
+          take a few minutes. You can close this and come back later.
         </p>
       )}
 
@@ -262,8 +276,8 @@ function PollItem({ poll, onDone }) {
         <div>
           {response?.generated_by && response?.content === text && (
             <p style={{ ...mutedNoteStyle, margin: "0.6rem 0 0" }}>
-              Drafted by AI from your profile — please review and edit
-              before sending.
+              Drafted by {draftModel} from {draftSource} — please review
+              and edit before sending.
             </p>
           )}
           <textarea

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -1,0 +1,382 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api";
+import MarkdownBody from "./MarkdownBody";
+
+/**
+ * The dev-update channel surface (#207): shows unread changelog sections,
+ * targeted notifications, and pending admin polls when the user opens
+ * Loore. Appears only when something is unread; closing it (or "Later")
+ * shows the remaining items again next visit, "Got it" dismisses an item
+ * for good. Poll answers follow the two-phase opt-in: an LLM draft is
+ * requested explicitly, and nothing leaves the account until "Send".
+ */
+
+const overlayStyle = {
+  position: "fixed",
+  top: 0, left: 0, right: 0, bottom: 0,
+  backgroundColor: "rgba(0,0,0,0.7)",
+  backdropFilter: "blur(8px)",
+  WebkitBackdropFilter: "blur(8px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+};
+
+const cardStyle = {
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "12px",
+  padding: "2rem",
+  width: "560px",
+  maxWidth: "92vw",
+  maxHeight: "82vh",
+  overflowY: "auto",
+};
+
+const headerStyle = {
+  fontFamily: "var(--serif)",
+  fontSize: "1.5rem",
+  fontWeight: 400,
+  color: "var(--text-primary)",
+  margin: 0,
+  marginBottom: "0.25rem",
+};
+
+const itemStyle = {
+  borderTop: "1px solid var(--border)",
+  paddingTop: "1.25rem",
+  marginTop: "1.25rem",
+};
+
+const itemTitleStyle = {
+  fontFamily: "var(--serif)",
+  fontSize: "1.15rem",
+  fontWeight: 400,
+  color: "var(--text-primary)",
+  margin: 0,
+};
+
+const dateStyle = {
+  fontFamily: "var(--sans)",
+  fontSize: "0.75rem",
+  fontWeight: 300,
+  color: "var(--text-muted)",
+  letterSpacing: "0.04em",
+};
+
+const buttonRowStyle = {
+  display: "flex",
+  gap: "10px",
+  justifyContent: "flex-end",
+  marginTop: "0.75rem",
+};
+
+const ghostButtonStyle = {
+  fontFamily: "var(--sans)", fontSize: "0.85rem", fontWeight: 300,
+  padding: "8px 16px", borderRadius: "6px", cursor: "pointer",
+  background: "none", border: "1px solid var(--border)",
+  color: "var(--text-secondary)",
+};
+
+const accentButtonStyle = {
+  fontFamily: "var(--sans)", fontSize: "0.85rem", fontWeight: 400,
+  padding: "8px 16px", borderRadius: "6px", cursor: "pointer",
+  background: "var(--accent)", border: "none",
+  color: "var(--bg-deep)",
+};
+
+const mutedNoteStyle = {
+  fontFamily: "var(--sans)", fontSize: "0.78rem", fontWeight: 300,
+  color: "var(--text-muted)", lineHeight: 1.5,
+};
+
+const textareaStyle = {
+  width: "100%", minHeight: "110px", boxSizing: "border-box",
+  fontFamily: "var(--sans)", fontSize: "0.9rem", fontWeight: 300,
+  lineHeight: 1.6, color: "var(--text-primary)",
+  background: "var(--bg-surface)", border: "1px solid var(--border)",
+  borderRadius: "8px", padding: "10px 12px", resize: "vertical",
+  marginTop: "0.6rem",
+};
+
+function ChangelogItem({ section, onDone }) {
+  const mark = (action) => {
+    api.post(`/updates/changelog/${section.id}/${action}`).catch(() => {});
+    onDone();
+  };
+  return (
+    <div style={itemStyle}>
+      {section.date && <div style={dateStyle}>{section.date}</div>}
+      <h3 style={itemTitleStyle}>{section.title}</h3>
+      <MarkdownBody style={{ fontSize: "0.9rem" }}>
+        {section.body}
+      </MarkdownBody>
+      <div style={buttonRowStyle}>
+        <button style={ghostButtonStyle} onClick={() => mark("skip")}>
+          Later
+        </button>
+        <button style={accentButtonStyle} onClick={() => mark("read")}>
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NotificationItem({ notification, onDone }) {
+  const navigate = useNavigate();
+  const mark = (action) => {
+    api.post(`/updates/notifications/${notification.id}/${action}`)
+      .catch(() => {});
+    onDone();
+  };
+  return (
+    <div style={itemStyle}>
+      <h3 style={itemTitleStyle}>{notification.title}</h3>
+      {notification.body && (
+        <p style={{
+          fontFamily: "var(--sans)", fontSize: "0.9rem", fontWeight: 300,
+          color: "var(--text-secondary)", lineHeight: 1.6,
+          margin: "0.5rem 0 0",
+        }}>
+          {notification.body}
+        </p>
+      )}
+      <div style={buttonRowStyle}>
+        <button style={ghostButtonStyle} onClick={() => mark("skip")}>
+          Later
+        </button>
+        {notification.link && (
+          <button
+            style={ghostButtonStyle}
+            onClick={() => { mark("read"); navigate(notification.link); }}
+          >
+            Take a look
+          </button>
+        )}
+        <button style={accentButtonStyle} onClick={() => mark("read")}>
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PollItem({ poll, onDone }) {
+  const [response, setResponse] = useState(poll.response);
+  const [text, setText] = useState(poll.response?.content || "");
+  const [writing, setWriting] = useState(
+    !!(poll.response && poll.response.content));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const pollTimer = useRef(null);
+
+  const drafting = response?.status === "drafting";
+
+  // While the LLM draft is generating, poll for its completion.
+  useEffect(() => {
+    if (!drafting) return undefined;
+    pollTimer.current = setInterval(async () => {
+      try {
+        const res = await api.get(`/updates/polls/${poll.id}`);
+        const r = res.data.response;
+        if (r && r.status !== "drafting") {
+          setResponse(r);
+          if (r.status === "draft") {
+            setText(r.content || "");
+            setWriting(true);
+          } else if (r.status === "draft_failed") {
+            setError(
+              "Drafting didn't work this time — you can still write " +
+              "your own answer.");
+            setWriting(true);
+          }
+        }
+      } catch (e) { /* keep polling */ }
+    }, 2500);
+    return () => clearInterval(pollTimer.current);
+  }, [drafting, poll.id]);
+
+  const requestDraft = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await api.post(`/updates/polls/${poll.id}/draft`);
+      setResponse(res.data.response);
+    } catch (e) {
+      setError(e.response?.data?.error ||
+        "Couldn't start the draft — you can still write your own answer.");
+      setWriting(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const send = async () => {
+    if (!text.trim()) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await api.put(`/updates/polls/${poll.id}/response`,
+        { content: text });
+      await api.post(`/updates/polls/${poll.id}/send`);
+      onDone();
+    } catch (e) {
+      setError(e.response?.data?.error || "Sending failed — try again?");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const decline = () => {
+    api.post(`/updates/polls/${poll.id}/decline`).catch(() => {});
+    onDone();
+  };
+
+  return (
+    <div style={itemStyle}>
+      <div style={dateStyle}>A QUESTION FROM THE DEVELOPER</div>
+      <h3 style={itemTitleStyle}>{poll.question}</h3>
+      <p style={{ ...mutedNoteStyle, margin: "0.5rem 0 0" }}>
+        Answering is optional. Loore can draft a reply from your profile
+        for you to edit — and nothing is sent until you press Send.
+      </p>
+
+      {drafting && (
+        <p style={{ ...mutedNoteStyle, margin: "0.75rem 0 0",
+          color: "var(--accent)" }}>
+          Loore is drafting an answer from your profile…
+        </p>
+      )}
+
+      {error && (
+        <p style={{ ...mutedNoteStyle, margin: "0.75rem 0 0",
+          color: "var(--error)" }}>
+          {error}
+        </p>
+      )}
+
+      {writing && !drafting && (
+        <div>
+          {response?.generated_by && response?.content === text && (
+            <p style={{ ...mutedNoteStyle, margin: "0.6rem 0 0" }}>
+              Drafted by AI from your profile — please review and edit
+              before sending.
+            </p>
+          )}
+          <textarea
+            style={textareaStyle}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Your answer…"
+          />
+        </div>
+      )}
+
+      <div style={buttonRowStyle}>
+        <button style={ghostButtonStyle} onClick={decline} disabled={busy}>
+          No thanks
+        </button>
+        <button style={ghostButtonStyle} onClick={onDone} disabled={busy}>
+          Later
+        </button>
+        {!writing && !drafting && (
+          <>
+            <button
+              style={ghostButtonStyle}
+              onClick={() => setWriting(true)}
+              disabled={busy}
+            >
+              Write my own
+            </button>
+            <button
+              style={accentButtonStyle}
+              onClick={requestDraft}
+              disabled={busy}
+            >
+              Draft with AI
+            </button>
+          </>
+        )}
+        {writing && !drafting && (
+          <button
+            style={{
+              ...accentButtonStyle,
+              opacity: text.trim() && !busy ? 1 : 0.5,
+              cursor: text.trim() && !busy ? "pointer" : "default",
+            }}
+            onClick={send}
+            disabled={!text.trim() || busy}
+          >
+            Send to developer
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UpdatesModal({ data, onClose }) {
+  const [changelog, setChangelog] = useState(data.changelog || []);
+  const [notifications, setNotifications] = useState(
+    data.notifications || []);
+  const [polls, setPolls] = useState(data.polls || []);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const remaining =
+    changelog.length + notifications.length + polls.length;
+  useEffect(() => {
+    if (remaining === 0) onClose();
+  }, [remaining, onClose]);
+
+  if (remaining === 0) return null;
+
+  const removeFrom = (setter) => (id, key) =>
+    setter((items) => items.filter((item) => item[key] !== id));
+
+  return (
+    <div style={overlayStyle} onClick={onClose}>
+      <div style={cardStyle} onClick={(e) => e.stopPropagation()}>
+        <h2 style={headerStyle}>While you were away</h2>
+        <p style={{ ...mutedNoteStyle, margin: 0 }}>
+          What's new in Loore since your last visit.
+        </p>
+
+        {notifications.map((n) => (
+          <NotificationItem
+            key={`n-${n.id}`}
+            notification={n}
+            onDone={() => removeFrom(setNotifications)(n.id, "id")}
+          />
+        ))}
+
+        {polls.map((p) => (
+          <PollItem
+            key={`p-${p.id}`}
+            poll={p}
+            onDone={() => removeFrom(setPolls)(p.id, "id")}
+          />
+        ))}
+
+        {changelog.map((s) => (
+          <ChangelogItem
+            key={`c-${s.id}`}
+            section={s}
+            onDone={() => removeFrom(setChangelog)(s.id, "id")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default UpdatesModal;

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -116,7 +116,7 @@ function ChangelogItem({ section, onDone }) {
     <div style={itemStyle}>
       {section.date && <div style={dateStyle}>{section.date}</div>}
       <h3 style={itemTitleStyle}>{section.title}</h3>
-      <MarkdownBody style={{
+      <MarkdownBody flowText style={{
         fontSize: "0.9rem",
         color: "var(--text-secondary)",
         marginTop: "0.9rem",

--- a/frontend/src/components/UpdatesModal.js
+++ b/frontend/src/components/UpdatesModal.js
@@ -135,12 +135,19 @@ function ChangelogItem({ section, onDone }) {
   );
 }
 
-function NotificationItem({ notification, onDone }) {
+function NotificationItem({ notification, onDone, onCloseModal }) {
   const navigate = useNavigate();
   const mark = (action) => {
     api.post(`/updates/notifications/${notification.id}/${action}`)
       .catch(() => {});
     onDone();
+  };
+  // Following the link must close the WHOLE modal first — navigating
+  // under a still-open overlay looks like the click did nothing.
+  const takeALook = () => {
+    mark("read");
+    onCloseModal();
+    navigate(notification.link);
   };
   return (
     <div style={itemStyle}>
@@ -159,10 +166,7 @@ function NotificationItem({ notification, onDone }) {
           Later
         </button>
         {notification.link && (
-          <button
-            style={ghostButtonStyle}
-            onClick={() => { mark("read"); navigate(notification.link); }}
-          >
+          <button style={ghostButtonStyle} onClick={takeALook}>
             Take a look
           </button>
         )}
@@ -412,6 +416,7 @@ function UpdatesModal({ data, onClose }) {
             key={`n-${n.id}`}
             notification={n}
             onDone={() => removeFrom(setNotifications)(n.id, "id")}
+            onCloseModal={onClose}
           />
         ))}
 


### PR DESCRIPTION
## PR D — the dev-update channel (#207)

The in-app "what's new" surface, plus the automated-feedback/polling extension specified 2026-07-02. This modal is also the designated **announcement channel for the public side** — the way users will learn the Account "Public sharing" toggle exists.

Closes #207 — the notification system itself is complete; the remaining producers named in the issue (briefing-ready, fix-ready) each depend on features that don't exist yet (#151 morning briefing, per-user staging) and will be wired in one line each (`notify_user(...)`) when those land. Shout if you'd rather keep #207 open as the umbrella.

### Changelog (broadcast)

- Entries live in **`backend/user_changelog.md`** — one `## YYYY-MM-DD — Title` section per announcement, newest at top, stable ids via `<!-- id: ... -->` comments (slugified title as fallback). Authoring rules are documented in the file header.
- The file ships with the deploy like code; the backend parses it at request time (cached on mtime/size). No deploy-pipeline machinery, editable after the fact, reviewable in PR diffs.
- **Dark-ship native:** a dark PR doesn't touch the changelog — the commit that flips a feature ON adds its section.
- Per-user, per-section read/skip state (`changelog_read_state`): **Got it** = gone for good, **Later** = back next open. Sections dated before a user's signup are auto-read (no backlog for new users).
- Ships with one meta-section announcing the channel itself (please reword to taste).

### Targeted notifications

- `user_notification` — persistent sibling of the transient toasts, same read/skip semantics, served through the same surface.
- First producer wired: **profile generation complete** (sync task paths + batch-pipeline integration step). Unread notifications of the same type update in place instead of stacking.

### Polls (the automated-feedback extension)

Two-phase opt-in, structurally enforced in the model:

1. **Opt-in 1** (optional): user asks Loore to draft an answer. Refused when their global AI-usage setting opts out.
2. **Opt-in 2** (required): `POST /send` is the *only* transition that makes an answer admin-visible. Drafts, failures, and declines stay private — the admin endpoint serves `status='sent'` rows only, everything else appears as counts.

Draft content is encrypted at rest like all user content. Editing an AI draft clears `generated_by` (the sent answer is marked AI-drafted only if sent verbatim-generated). Admin panel gets a Polls section: create / close / counts / read sent responses.

### Poll drafts v2 (second night's pass, per review discussion)

- **Cost attribution**: draft costs land on a dedicated system account (`loore-polls` — can't log in, never profile-eligible), NOT the answering user; the user-side spend-cap check is gone (they're answering *our* question). Every cost row carries `request_ref="poll:<id>"` so it's traceable to the specific poll.
- **Per-poll draft terms, chosen by the admin at creation** and frozen: the drafting **model** and the **data source** — `derived` (profile + recent summary + intentions) or `recent_window` (the most recent AI-readable writing that fits the model's context window, via the same export builder profile-gen uses). Both are shown to the user **before** opt-in 1 (informed consent) and echoed in the draft-provenance note.
- **Batch API**: drafts are async by construction, so they ride the provider Batch API (~50% cheaper). `submit_poll_draft` submits a single-item batch on opt-in; `collect_poll_draft_batches` (celery-beat, 60s) saves finished drafts; `PollDraftBatchJob` mirrors `ProfileBatchJob`; shared `utils/llm_batch` helpers. Note: staging runs no celery-beat, so drafts only collect there if triggered manually — verified end-to-end locally against the real Anthropic Batch API instead.

### Wiring

- `/api/updates` (GET everything unread; POST read/skip; poll draft/response/send/decline) — new `updates_bp`.
- `UpdatesModal` mounts in App.js after the terms gate, fetches once per session, renders only when something is unread — nothing new, nothing shown.
- `DEV_UPDATES_V1` env killswitch (default on), same pattern as `SHARE_V1`.
- New tables (`changelog_read_state`, `user_notification`, `poll`, `poll_response`) auto-migrate on deploy.

### Testing

- 29 new backend tests (parser edge cases, read/skip semantics, no-backlog gating, consent gating incl. AI-usage opt-out refusal, admin sees only sent). Full suite 741 green; frontend build clean.
- Local Docker E2E: changelog Later/Got-it semantics across reloads, poll Draft-with-AI → drafting → graceful-failure fallback → manual answer → Send → visible in admin with correct counts, profile-ready notification with Take-a-look navigation.
- Staging E2E: see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWZdt4A772UrP9sJP74deJ

